### PR TITLE
Markup View: show an ellipsis character in collapsed nodes

### DIFF
--- a/devtools/client/inspector/markup/views/markup-container.js
+++ b/devtools/client/inspector/markup/views/markup-container.js
@@ -211,10 +211,12 @@ MarkupContainer.prototype = {
     }
 
     if (this.showExpander) {
+      this.elt.classList.add("expandable");
       this.expander.style.visibility = "visible";
       // Update accessibility expanded state.
       this.tagLine.setAttribute("aria-expanded", this.expanded);
     } else {
+      this.elt.classList.remove("expandable");
       this.expander.style.visibility = "hidden";
       // No need for accessible expanded state indicator when expander is not
       // shown.

--- a/devtools/client/themes/markup.css
+++ b/devtools/client/themes/markup.css
@@ -197,6 +197,22 @@ ul.children + .tag-line::before {
   display: inline;
 }
 
+.expandable.collapsed .close::before {
+  /* Display an ellipsis character in collapsed nodes that can be expanded. */
+  content: "\2026";
+  display: inline-block;
+  width: 12px;
+  height: 8px;
+  margin: 0 2px;
+  line-height: 3px;
+  color: var(--theme-body-color-inactive);
+  border-radius: 3px;
+  border-style: solid;
+  border-width: 1px;
+  text-align: center;
+  vertical-align: middle;
+}
+
 /* Hide HTML void elements (img, hr, br, …) closing tag when the element is not
  * expanded (it can be if it has pseudo-elements attached) */
 .child.collapsed > .tag-line .void-element .close {
@@ -318,7 +334,8 @@ ul.children + .tag-line::before {
 .theme-selected ~ .editor .theme-fg-color4,
 .theme-selected ~ .editor .theme-fg-color5,
 .theme-selected ~ .editor .theme-fg-color6,
-.theme-selected ~ .editor .theme-fg-color7 {
+.theme-selected ~ .editor .theme-fg-color7,
+.theme-selected ~ .editor .close::before {
   color: var(--theme-selection-color);
 }
 


### PR DESCRIPTION
This resolves #2 → You add the label `Devtools`, please

Bug(s):
https://bugzilla.mozilla.org/show_bug.cgi?id=1323193
(native in moebius)

---

I've created the new build (x32, Windows) and tested.
