### PR TITLE
Require at least GCC 4.9

### DIFF
--- a/build/moz.configure/toolchain.configure
+++ b/build/moz.configure/toolchain.configure
@@ -686,9 +686,9 @@ def compiler(language, host_or_target, c_compiler=None, other_compiler=None,
         # Check the compiler version here instead of in `compiler_version` so
         # that the `checking` message doesn't pretend the compiler can be used
         # to then bail out one line later.
-        if info.type == 'gcc' and info.version < '4.8.0':
+        if info.type == 'gcc' and info.version < '4.9.0':
             raise FatalCheckError(
-                'Only GCC 4.8 or newer is supported (found version %s).'
+                'Only GCC 4.9 or newer is supported (found version %s).'
                 % info.version)
 
         # If you want to bump the version check here search for

--- a/layout/style/nsCSSPseudoElements.h
+++ b/layout/style/nsCSSPseudoElements.h
@@ -111,8 +111,7 @@ private:
   // which is a general gcc bug that we seem to have hit only on Android/x86.
 #if defined(ANDROID) && defined(__i386__) && defined(__GNUC__) && \
     !defined(__clang__)
-#if (MOZ_GCC_VERSION_AT_LEAST(4,8,0) && MOZ_GCC_VERSION_AT_MOST(4,8,4)) || \
-    (MOZ_GCC_VERSION_AT_LEAST(4,9,0) && MOZ_GCC_VERSION_AT_MOST(4,9,2))
+#if (MOZ_GCC_VERSION_AT_LEAST(4,9,0) && MOZ_GCC_VERSION_AT_MOST(4,9,2))
    __attribute__((noinline))
 #endif
 #endif

--- a/mfbt/Attributes.h
+++ b/mfbt/Attributes.h
@@ -562,9 +562,7 @@
 #  define MOZ_HAVE_REF_QUALIFIERS
 #elif defined(__GNUC__)
 #  include "mozilla/Compiler.h"
-#  if MOZ_GCC_VERSION_AT_LEAST(4, 8, 1)
-#    define MOZ_HAVE_REF_QUALIFIERS
-#  endif
+#  define MOZ_HAVE_REF_QUALIFIERS
 #endif
 
 #endif /* __cplusplus */

--- a/mfbt/Compiler.h
+++ b/mfbt/Compiler.h
@@ -26,8 +26,8 @@
 #  define MOZ_GCC_VERSION_AT_MOST(major, minor, patchlevel)           \
      ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) \
       <= ((major) * 10000 + (minor) * 100 + (patchlevel)))
-#  if !MOZ_GCC_VERSION_AT_LEAST(4, 8, 0)
-#    error "mfbt (and Gecko) require at least gcc 4.8 to build."
+#  if !MOZ_GCC_VERSION_AT_LEAST(4, 9, 0)
+#    error "mfbt (and Goanna) require at least gcc 4.9 to build."
 #  endif
 
 #elif defined(_MSC_VER)

--- a/python/mozbuild/mozbuild/test/configure/test_toolchain_configure.py
+++ b/python/mozbuild/mozbuild/test/configure/test_toolchain_configure.py
@@ -313,7 +313,7 @@ class LinuxToolchainTest(BaseToolchainTest):
         '/usr/bin/clang-3.3': CLANG_3_3 + CLANG_PLATFORM_X86_64_LINUX,
         '/usr/bin/clang++-3.3': CLANGXX_3_3 + CLANG_PLATFORM_X86_64_LINUX,
     }
-    GCC_4_7_RESULT = ('Only GCC 4.8 or newer is supported '
+    GCC_4_7_RESULT = ('Only GCC 4.9 or newer is supported '
                       '(found version 4.7.3).')
     GXX_4_7_RESULT = GCC_4_7_RESULT
     GCC_4_9_RESULT = CompilerResult(


### PR DESCRIPTION
Just what it says in the tin.

The moebius repo already requires GCC 4.9, and there's no real reason to keep GCC 4.8 support around here. This will also head off potential bustage with versions < 4.9 when porting features from Moz (they dropped GCC 4.8 support immediately after ESR52).