### PR TITLE
Improve support for GCC 7.x

### DIFF
--- a/dom/canvas/moz.build
+++ b/dom/canvas/moz.build
@@ -162,7 +162,7 @@ SOURCES += [
 ]
 
 # Suppress warnings from third-party code.
-if CONFIG['CLANG_CXX']:
+if CONFIG['CLANG_CXX'] or CONFIG['GNU_CXX']:
     SOURCES['MurmurHash3.cpp'].flags += ['-Wno-implicit-fallthrough']
 
 LOCAL_INCLUDES += [

--- a/js/src/gdb/moz.build
+++ b/js/src/gdb/moz.build
@@ -42,7 +42,7 @@ if CONFIG['ENABLE_INTL_API'] and CONFIG['MOZ_ICU_DATA_ARCHIVE']:
 OS_LIBS += CONFIG['MOZ_ZLIB_LIBS']
 
 if CONFIG['GNU_CXX']:
-    CXXFLAGS += ['-Wno-shadow']
+    CXXFLAGS += ['-Wno-shadow', '-fno-strict-aliasing']
 
 # This is intended as a temporary workaround to enable VS2015.
 if CONFIG['_MSC_VER']:

--- a/js/src/jsapi-tests/moz.build
+++ b/js/src/jsapi-tests/moz.build
@@ -147,7 +147,7 @@ USE_LIBS += [
 OS_LIBS += CONFIG['MOZ_ZLIB_LIBS']
 
 if CONFIG['GNU_CXX']:
-    CXXFLAGS += ['-Wno-shadow', '-Werror=format']
+    CXXFLAGS += ['-Wno-shadow', '-Werror=format', '-fno-strict-aliasing']
 
 # This is intended as a temporary workaround to enable VS2015.
 if CONFIG['_MSC_VER']:

--- a/js/src/moz.build
+++ b/js/src/moz.build
@@ -785,7 +785,9 @@ if CONFIG['JS_HAS_CTYPES']:
         DEFINES['FFI_BUILDING'] = True
 
 if CONFIG['GNU_CXX']:
-    CXXFLAGS += ['-Wno-shadow', '-Werror=format']
+    # Disable strict-aliasing for GCC, which is enabled by default
+    # starting with version 7.1, see Mozilla bug 1363009.
+    CXXFLAGS += ['-Wno-shadow', '-Werror=format', '-fno-strict-aliasing']
 
 # Suppress warnings in third-party code.
 if CONFIG['CLANG_CXX']:

--- a/js/src/moz.build
+++ b/js/src/moz.build
@@ -790,5 +790,5 @@ if CONFIG['GNU_CXX']:
     CXXFLAGS += ['-Wno-shadow', '-Werror=format', '-fno-strict-aliasing']
 
 # Suppress warnings in third-party code.
-if CONFIG['CLANG_CXX']:
+if CONFIG['CLANG_CXX'] or CONFIG['GNU_CXX']:
     SOURCES['jsdtoa.cpp'].flags += ['-Wno-implicit-fallthrough']

--- a/media/webrtc/signaling/test/mediaconduit_unittests.cpp
+++ b/media/webrtc/signaling/test/mediaconduit_unittests.cpp
@@ -550,14 +550,16 @@ class TransportConduitTest : public ::testing::Test
     mozilla::SyncRunnable::DispatchToThread(gMainThread,
                                             WrapRunnableNMRet(&mAudioSession,
                                                 &mozilla::AudioSessionConduit::Create));
-    if( !mAudioSession )
+    if( !mAudioSession ) {
       ASSERT_NE(mAudioSession, (void*)nullptr);
+		}
 
     mozilla::SyncRunnable::DispatchToThread(gMainThread,
                                             WrapRunnableNMRet(&mAudioSession2,
                                                 &mozilla::AudioSessionConduit::Create));
-    if( !mAudioSession2 )
+    if( !mAudioSession2 ) {
       ASSERT_NE(mAudioSession2, (void*)nullptr);
+		}
 
     WebrtcMediaTransport* xport = new WebrtcMediaTransport();
     ASSERT_NE(xport, (void*)nullptr);
@@ -615,15 +617,17 @@ class TransportConduitTest : public ::testing::Test
     mozilla::SyncRunnable::DispatchToThread(gMainThread,
                                             WrapRunnableNMRet(&mVideoSession,
                                                 &mozilla::VideoSessionConduit::Create));
-    if( !mVideoSession )
+    if( !mVideoSession ) {
       ASSERT_NE(mVideoSession, (void*)nullptr);
+		}
 
    // This session is for other one
     mozilla::SyncRunnable::DispatchToThread(gMainThread,
                                             WrapRunnableNMRet(&mVideoSession2,
                                                 &mozilla::VideoSessionConduit::Create));
-    if( !mVideoSession2 )
+    if( !mVideoSession2 ) {
       ASSERT_NE(mVideoSession2,(void*)nullptr);
+		}
 
     if (!send_vp8) {
       SetGmpCodecs();
@@ -716,8 +720,9 @@ class TransportConduitTest : public ::testing::Test
     mozilla::SyncRunnable::DispatchToThread(gMainThread,
                                             WrapRunnableNMRet(&videoSession,
                                                 &mozilla::VideoSessionConduit::Create));
-    if( !videoSession )
+    if( !videoSession ) {
       ASSERT_NE(videoSession, (void*)nullptr);
+		}
 
     //Test Configure Recv Codec APIS
     cerr << "   *************************************************" << endl;
@@ -831,8 +836,9 @@ class TransportConduitTest : public ::testing::Test
     mozilla::SyncRunnable::DispatchToThread(gMainThread,
                                             WrapRunnableNMRet(&mVideoSession,
                                                 &mozilla::VideoSessionConduit::Create));
-    if( !mVideoSession )
+    if( !mVideoSession ) {
       ASSERT_NE(mVideoSession, (void*)nullptr);
+		}
 
     mozilla::EncodingConstraints constraints;
     constraints.maxFs = max_fs;

--- a/media/webrtc/signaling/test/signaling_unittests.cpp
+++ b/media/webrtc/signaling/test/signaling_unittests.cpp
@@ -1475,8 +1475,8 @@ class SignalingAgent {
     pObserver->addIceCandidateState = TestObserver::stateNoResponse;
     pc->AddIceCandidate(candidate.c_str(), mid.c_str(), level);
     ASSERT_TRUE(pObserver->addIceCandidateState ==
-                expectSuccess ? TestObserver::stateSuccess :
-                                TestObserver::stateError
+                (expectSuccess ? TestObserver::stateSuccess :
+                                TestObserver::stateError)
                );
 
     // Verify that adding ICE candidates does not change the signaling state

--- a/memory/mozalloc/mozalloc.h
+++ b/memory/mozalloc/mozalloc.h
@@ -175,6 +175,12 @@ MFBT_API void* moz_xvalloc(size_t size)
  */
 #define MOZALLOC_THROW_IF_HAS_EXCEPTIONS
 #define MOZALLOC_THROW_BAD_ALLOC_IF_HAS_EXCEPTIONS
+#elif __cplusplus >= 201103
+/*
+ * C++11 has deprecated exception-specifications in favour of |noexcept|.
+ */
+#define MOZALLOC_THROW_IF_HAS_EXCEPTIONS noexcept(true)
+#define MOZALLOC_THROW_BAD_ALLOC_IF_HAS_EXCEPTIONS noexcept(false)
 #else
 #define MOZALLOC_THROW_IF_HAS_EXCEPTIONS throw()
 #define MOZALLOC_THROW_BAD_ALLOC_IF_HAS_EXCEPTIONS throw(std::bad_alloc)

--- a/mfbt/Attributes.h
+++ b/mfbt/Attributes.h
@@ -256,6 +256,8 @@
 #  define MOZ_MUST_USE
 #endif
 
+#ifdef __cplusplus
+
 /**
  * MOZ_FALLTHROUGH is an annotation to suppress compiler warnings about switch
  * cases that fall through without a break or return statement. MOZ_FALLTHROUGH
@@ -282,9 +284,14 @@
  *     return 5;
  * }
  */
-#if defined(__clang__) && __cplusplus >= 201103L
-   /* clang's fallthrough annotations are only available starting in C++11. */
+#ifndef __has_cpp_attribute
+#  define __has_cpp_attribute(x) 0
+#endif
+
+#if __has_cpp_attribute(clang::fallthrough)
 #  define MOZ_FALLTHROUGH [[clang::fallthrough]]
+#elif __has_cpp_attribute(gnu::fallthrough)
+#  define MOZ_FALLTHROUGH [[gnu::fallthrough]]
 #elif defined(_MSC_VER)
    /*
     * MSVC's __fallthrough annotations are checked by /analyze (Code Analysis):
@@ -295,8 +302,6 @@
 #else
 #  define MOZ_FALLTHROUGH /* FALLTHROUGH */
 #endif
-
-#ifdef __cplusplus
 
 /*
  * The following macros are attributes that support the static analysis plugin

--- a/parser/html/moz.build
+++ b/parser/html/moz.build
@@ -98,7 +98,6 @@ LOCAL_INCLUDES += [
     '/dom/base',
 ]
 
-if CONFIG['GNU_CXX']:
-    CXXFLAGS += ['-Wno-error=shadow']
-    if CONFIG['CLANG_CXX']:
-        CXXFLAGS += ['-Wno-implicit-fallthrough']
+if CONFIG['GNU_CXX'] or CONFIG['CLANG_CXX']:
+    CXXFLAGS += ['-Wno-error=shadow',
+                 '-Wno-implicit-fallthrough']

--- a/security/sandbox/linux/moz.build
+++ b/security/sandbox/linux/moz.build
@@ -75,8 +75,8 @@ SOURCES += [
 # consistent.  See also the comment in SandboxLogging.h.
 SOURCES['../chromium/base/strings/safe_sprintf.cc'].flags += ['-DNDEBUG']
 
-# Keep clang from warning about intentional 'switch' fallthrough in icu_utf.cc:
-if CONFIG['CLANG_CXX']:
+# Keep clang and GCC from warning about intentional 'switch' fallthrough in icu_utf.cc:
+if CONFIG['CLANG_CXX'] or CONFIG['GNU_CXX']:
     SOURCES['../chromium/base/third_party/icu/icu_utf.cc'].flags += ['-Wno-implicit-fallthrough']
 
 if CONFIG['GNU_CXX']:

--- a/toolkit/components/ctypes/tests/jsctypes-test-finalizer.cpp
+++ b/toolkit/components/ctypes/tests/jsctypes-test-finalizer.cpp
@@ -232,8 +232,8 @@ test_finalizer_acq_string_t(int i)
 {
   gFinalizerTestResources[i] = 1;
   if (!gFinalizerTestNames[i]) {
-    char* buf = new char[10];
-    snprintf(buf, 10, "%d", i);
+    char* buf = new char[12];
+    snprintf(buf, 12, "%d", i);
     gFinalizerTestNames[i] = buf;
     return buf;
   }

--- a/toolkit/crashreporter/jsoncpp/src/lib_json/moz.build
+++ b/toolkit/crashreporter/jsoncpp/src/lib_json/moz.build
@@ -32,3 +32,8 @@ DISABLE_STL_WRAPPING = True
 Library('jsoncpp')
 
 include('/toolkit/crashreporter/crashreporter.mozbuild')
+
+if CONFIG['CLANG_CXX'] or CONFIG['CLANG_CL'] or CONFIG['GNU_CXX']:
+    CXXFLAGS += [
+        '-Wno-implicit-fallthrough',
+    ]


### PR DESCRIPTION
This PR improves our support for using GCC 7. Note that in my limited testing thus far, GCC 7 does not produce stable builds (with or without these commits). I also tested this patch set using GCC 5 with no issues seen. Specific changes:

- Disable strict-aliasing (which is enabled by default starting with GCC 7.1) in js/src, js/src/gdb, and js/src/jsapi-tests. Compiling with strict aliasing has been disabled since the Mozilla 1.x days (http://xref.palemoon.org/uxp-trunk/source/old-configure.in#605).
- Disable implicit-fallthrough in various places in the tree. The -Wno-implicit-fallthrough flag was previously a clang-only option, but GCC has now added support for it. This silences build warning spam.
- Use |noexcept| instead of an exception-specification in mozalloc.h The dynamic exception specifications have been deprecated in C++11, and GCC 7 throws hundreds of build warnings about it. Using |noexcept| fixes this.
- Expands the existing MOZ_FALLTHROUGH macro to suppress more GCC 7 build spam.
- Fixes up a couple tests so that they will compile correctly with GCC 7.

With these patches in, the number of compiler warnings thrown by GCC 7 is reduced by nearly 400.