### PR TITLE
Round down to the nearest 2ms (instead of 1ms)

### DIFF
--- a/dom/performance/PerformanceTiming.cpp
+++ b/dom/performance/PerformanceTiming.cpp
@@ -307,12 +307,8 @@ PerformanceTiming::SecureConnectionStartHighRes()
   if (!nsContentUtils::IsPerformanceTimingEnabled() || !IsInitialized()) {
     return mZeroTime;
   }
-
-  // Round down to the nearest 1ms
-  const double maxResolutionMs = 1;
-  return mSecureConnectionStart.IsNull()
-         ? mZeroTime
-         : floor(TimeStampToDOMHighRes(mSecureConnectionStart) / maxResolutionMs) * maxResolutionMs;
+  return mSecureConnectionStart.IsNull() ? mZeroTime
+                                         : TimerClamping::ReduceMsTimeValue(TimeStampToDOMHighRes(mSecureConnectionStart));
 }
 
 DOMTimeMilliSec

--- a/dom/tests/browser/browser_performanceAPI.js
+++ b/dom/tests/browser/browser_performanceAPI.js
@@ -17,6 +17,7 @@ const PERFORMANCE_TIMINGS = [
   "domainLookupEnd",
   "connectStart",
   "connectEnd",
+  "secureConnectionStart",
   "requestStart",
   "responseStart",
   "responseEnd",

--- a/dom/tests/browser/browser_performanceAPI.js
+++ b/dom/tests/browser/browser_performanceAPI.js
@@ -17,7 +17,6 @@ const PERFORMANCE_TIMINGS = [
   "domainLookupEnd",
   "connectStart",
   "connectEnd",
-  "secureConnectionStart",
   "requestStart",
   "responseStart",
   "responseEnd",


### PR DESCRIPTION
This addresses a comment made in #67

Split out to #69.
