### PR TITLE
Added support of the appmenu for DevTools menuitems (optional)

### DIFF
--- a/devtools/client/menus.js
+++ b/devtools/client/menus.js
@@ -183,9 +183,9 @@ exports.menuitems = [
     }
   },
   { separator: true,
-    id: "devToolsEndSeparator"
+    id: "menu_devToolsEndSeparator"
   },
-  { id: "getMoreDevtools",
+  { id: "menu_getMoreDevtools",
     l10nKey: "getMoreDevtoolsCmd",
     oncommand(event) {
       let window = event.target.ownerDocument.defaultView;


### PR DESCRIPTION
This resolves #96 → You add the label `Component: Devtools`, please

Reverted:
https://hg.mozilla.org/mozilla-central/rev/836da2d40b19
\+ adding some code

---

I've created the new build (x32, Windows) - `Basilisk`/`Pale Moon UXP` - and tested.
