### PR TITLE
CustomizableUI.jsm can't be used for Pale Moon - setting conditions

### DIFF
--- a/devtools/client/framework/devtools-browser.js
+++ b/devtools/client/framework/devtools-browser.js
@@ -29,7 +29,7 @@ loader.lazyRequireGetter(this, "BrowserMenus", "devtools/client/framework/browse
 
 loader.lazyImporter(this, "AppConstants", "resource://gre/modules/AppConstants.jsm");
 #ifdef MC_BASILISK
-  loader.lazyImporter(this, "CustomizableUI", "resource:///modules/CustomizableUI.jsm");
+loader.lazyImporter(this, "CustomizableUI", "resource:///modules/CustomizableUI.jsm");
 #endif
 
 const {LocalizationHelper} = require("devtools/shared/l10n");

--- a/devtools/client/framework/devtools-browser.js
+++ b/devtools/client/framework/devtools-browser.js
@@ -27,8 +27,11 @@ loader.lazyRequireGetter(this, "DebuggerServer", "devtools/server/main", true);
 loader.lazyRequireGetter(this, "DebuggerClient", "devtools/shared/client/main", true);
 loader.lazyRequireGetter(this, "BrowserMenus", "devtools/client/framework/browser-menus");
 
-loader.lazyImporter(this, "CustomizableUI", "resource:///modules/CustomizableUI.jsm");
 loader.lazyImporter(this, "AppConstants", "resource://gre/modules/AppConstants.jsm");
+
+if (AppConstants.MOZ_APP_NAME.toLowerCase() != "palemoon") {
+  loader.lazyImporter(this, "CustomizableUI", "resource:///modules/CustomizableUI.jsm");
+}
 
 const {LocalizationHelper} = require("devtools/shared/l10n");
 const L10N = new LocalizationHelper("devtools/client/locales/toolbox.properties");
@@ -295,6 +298,9 @@ var gDevToolsBrowser = exports.gDevToolsBrowser = {
    * Install Developer widget
    */
   installDeveloperWidget: function () {
+    if (typeof CustomizableUI === "undefined") {
+      return;
+    }
     let id = "developer-button";
     let widget = CustomizableUI.getWidget(id);
     if (widget && widget.provider == CustomizableUI.PROVIDER_API) {
@@ -350,7 +356,7 @@ var gDevToolsBrowser = exports.gDevToolsBrowser = {
    */
   // Used by itself
   installWebIDEWidget: function () {
-    if (this.isWebIDEWidgetInstalled()) {
+    if ((typeof CustomizableUI === "undefined") || this.isWebIDEWidgetInstalled()) {
       return;
     }
 
@@ -374,6 +380,9 @@ var gDevToolsBrowser = exports.gDevToolsBrowser = {
   },
 
   isWebIDEWidgetInstalled: function () {
+    if (typeof CustomizableUI === "undefined") {
+      return false;
+    }
     let widgetWrapper = CustomizableUI.getWidget("webide-button");
     return !!(widgetWrapper && widgetWrapper.provider == CustomizableUI.PROVIDER_API);
   },
@@ -387,6 +396,9 @@ var gDevToolsBrowser = exports.gDevToolsBrowser = {
    * Uninstall WebIDE widget
    */
   uninstallWebIDEWidget: function () {
+    if (typeof CustomizableUI === "undefined") {
+      return;
+    }
     if (this.isWebIDEWidgetInstalled()) {
       CustomizableUI.removeWidgetFromArea("webide-button");
     }
@@ -398,6 +410,9 @@ var gDevToolsBrowser = exports.gDevToolsBrowser = {
    */
    // Used by webide.js
   moveWebIDEWidgetInNavbar: function () {
+    if (typeof CustomizableUI === "undefined") {
+      return;
+    }
     CustomizableUI.addWidgetToArea("webide-button", CustomizableUI.AREA_NAVBAR);
   },
 

--- a/devtools/client/framework/devtools-browser.js
+++ b/devtools/client/framework/devtools-browser.js
@@ -28,10 +28,9 @@ loader.lazyRequireGetter(this, "DebuggerClient", "devtools/shared/client/main", 
 loader.lazyRequireGetter(this, "BrowserMenus", "devtools/client/framework/browser-menus");
 
 loader.lazyImporter(this, "AppConstants", "resource://gre/modules/AppConstants.jsm");
-
-if (AppConstants.MOZ_APP_NAME.toLowerCase() != "palemoon") {
+#ifdef MC_BASILISK
   loader.lazyImporter(this, "CustomizableUI", "resource:///modules/CustomizableUI.jsm");
-}
+#endif
 
 const {LocalizationHelper} = require("devtools/shared/l10n");
 const L10N = new LocalizationHelper("devtools/client/locales/toolbox.properties");
@@ -298,9 +297,7 @@ var gDevToolsBrowser = exports.gDevToolsBrowser = {
    * Install Developer widget
    */
   installDeveloperWidget: function () {
-    if (typeof CustomizableUI === "undefined") {
-      return;
-    }
+#ifdef MC_BASILISK
     let id = "developer-button";
     let widget = CustomizableUI.getWidget(id);
     if (widget && widget.provider == CustomizableUI.PROVIDER_API) {
@@ -349,6 +346,9 @@ var gDevToolsBrowser = exports.gDevToolsBrowser = {
         doc.getElementById("PanelUI-multiView").appendChild(view);
       }
     });
+#else
+    return;
+#endif
   },
 
   /**
@@ -356,7 +356,8 @@ var gDevToolsBrowser = exports.gDevToolsBrowser = {
    */
   // Used by itself
   installWebIDEWidget: function () {
-    if ((typeof CustomizableUI === "undefined") || this.isWebIDEWidgetInstalled()) {
+#ifdef MC_BASILISK
+    if (this.isWebIDEWidgetInstalled()) {
       return;
     }
 
@@ -377,14 +378,18 @@ var gDevToolsBrowser = exports.gDevToolsBrowser = {
         gDevToolsBrowser.openWebIDE();
       }
     });
+#else
+    return;
+#endif
   },
 
   isWebIDEWidgetInstalled: function () {
-    if (typeof CustomizableUI === "undefined") {
-      return false;
-    }
+#ifdef MC_BASILISK
     let widgetWrapper = CustomizableUI.getWidget("webide-button");
     return !!(widgetWrapper && widgetWrapper.provider == CustomizableUI.PROVIDER_API);
+#else
+    return false;
+#endif
   },
 
   /**
@@ -396,13 +401,14 @@ var gDevToolsBrowser = exports.gDevToolsBrowser = {
    * Uninstall WebIDE widget
    */
   uninstallWebIDEWidget: function () {
-    if (typeof CustomizableUI === "undefined") {
-      return;
-    }
+#ifdef MC_BASILISK
     if (this.isWebIDEWidgetInstalled()) {
       CustomizableUI.removeWidgetFromArea("webide-button");
     }
     CustomizableUI.destroyWidget("webide-button");
+#else
+    return;
+#endif
   },
 
   /**
@@ -410,10 +416,11 @@ var gDevToolsBrowser = exports.gDevToolsBrowser = {
    */
    // Used by webide.js
   moveWebIDEWidgetInNavbar: function () {
-    if (typeof CustomizableUI === "undefined") {
-      return;
-    }
+#ifdef MC_BASILISK
     CustomizableUI.addWidgetToArea("webide-button", CustomizableUI.AREA_NAVBAR);
+#else
+    return;
+#endif
   },
 
   /**

--- a/devtools/client/framework/moz.build
+++ b/devtools/client/framework/moz.build
@@ -13,7 +13,6 @@ DevToolsModules(
     'about-devtools-toolbox.js',
     'attach-thread.js',
     'browser-menus.js',
-    'devtools-browser.js',
     'devtools.js',
     'gDevTools.jsm',
     'location-store.js',
@@ -31,3 +30,7 @@ DevToolsModules(
     'toolbox.js',
     'ToolboxProcess.jsm',
 )
+
+FINAL_TARGET_PP_FILES.chrome.devtools.modules.devtools.client.framework += [
+    'devtools-browser.js',
+]


### PR DESCRIPTION
This resolves #97 → You add the label `Component: Devtools`, please

Or is there any better solution for this?

---

I've created the new build (x32, Windows) - `Basilisk`/`Pale Moon UXP` - and tested.
