### PR TITLE
[PALEMOON] "Page Info" - "Permissions" - use uri.spec instead of uri in a new Error

### DIFF
--- a/application/palemoon/base/content/pageinfo/permissions.js
+++ b/application/palemoon/base/content/pageinfo/permissions.js
@@ -264,7 +264,7 @@ function onIndexedDBUsageCallback(request)
 {
   let uri = request.principal.URI;
   if (!uri.equals(gPermURI)) {
-    throw new Error("Callback received for bad URI: " + uri);
+    throw new Error("Callback received for bad URI: " + uri.spec);
   }
 
   let usage = request.result.usage;


### PR DESCRIPTION
Tags: #112 and #57

For display of the URL.
