### PR TITLE
about:plugins - fix "addMessageListener is not a function" (e10s off - revert bug 1068087 - partially)

### DIFF
--- a/toolkit/content/plugins.html
+++ b/toolkit/content/plugins.html
@@ -10,6 +10,7 @@
   "use strict";
 
   Components.utils.import("resource://gre/modules/Services.jsm");
+  Components.utils.import("resource://gre/modules/AddonManager.jsm");
 
   var Ci = Components.interfaces;
   var strBundleService = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
@@ -57,7 +58,7 @@
    */
   navigator.plugins.refresh(false);
 
-  addMessageListener("PluginList", function({ data: aPlugins }) {
+  AddonManager.getAddonsByTypes(["plugin"], function (aPlugins) {
     var fragment = document.createDocumentFragment();
 
     // "Installed plugins"
@@ -209,8 +210,6 @@
 
     document.getElementById("outside").appendChild(fragment);
   });
-
-  sendAsyncMessage("RequestPlugins");
 </script>
 </div>
 </body>


### PR DESCRIPTION
Tag: #57 

__Steps to reproduce__
Go to: `about:plugins`
Throws an error: `addMessageListener is not a function`

e10s off - revert [bug 1068087](https://bugzilla.mozilla.org/show_bug.cgi?id=1068087) - partially (frontend only).


---

I've created the new build (x32, Windows) - `Basilisk` / `Pale Moon UXP` - and tested.
