### PR TITLE
[PALEMOON] Fix Login Manager (Prompter) - basic

### DIFF
--- a/application/palemoon/base/content/content.js
+++ b/application/palemoon/base/content/content.js
@@ -13,6 +13,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "BrowserUtils",
   "resource://gre/modules/BrowserUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "LoginManagerContent",
   "resource://gre/modules/LoginManagerContent.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "LoginFormFactory",
+  "resource://gre/modules/LoginManagerContent.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "InsecurePasswordUtils",
   "resource://gre/modules/InsecurePasswordUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "FormSubmitObserver",
@@ -47,8 +49,9 @@ addMessageListener("Browser:HideSessionRestoreButton", function (message) {
 });
 
 addEventListener("DOMFormHasPassword", function(event) {
-  InsecurePasswordUtils.checkForInsecurePasswords(event.target);
-  LoginManagerContent.onFormPassword(event);
+  LoginManagerContent.onDOMFormHasPassword(event, content);
+  let formLike = LoginFormFactory.createFromForm(event.target);
+  InsecurePasswordUtils.reportInsecurePasswords(formLike);
 });
 addEventListener("DOMAutoComplete", function(event) {
   LoginManagerContent.onUsernameInput(event);

--- a/application/palemoon/base/content/popup-notifications.inc
+++ b/application/palemoon/base/content/popup-notifications.inc
@@ -89,6 +89,14 @@
       </popupnotificationcontent>
     </popupnotification>
 
+    <popupnotification id="password-notification" hidden="true">
+      <popupnotificationcontent orient="vertical">
+        <textbox id="password-notification-username"/>
+        <textbox id="password-notification-password" type="password" show-content=""/>
+        <checkbox id="password-notification-visibilityToggle" hidden="true"/>
+      </popupnotificationcontent>
+    </popupnotification>
+
     <popupnotification id="mixed-content-blocked-notification" hidden="true">
       <popupnotificationcontent orient="vertical" align="start">
         <separator/>

--- a/application/palemoon/base/content/tabbrowser.xml
+++ b/application/palemoon/base/content/tabbrowser.xml
@@ -302,6 +302,16 @@
         </body>
       </method>
 
+      <method name="getBrowserForContentWindow">
+        <parameter name="aWindow"/>
+        <body>
+          <![CDATA[
+            var tab = this._getTabForContentWindow(aWindow);
+            return tab ? tab.linkedBrowser : null;
+          ]]>
+        </body>
+      </method>
+
       <method name="getBrowserForOuterWindowID">
         <parameter name="aID"/>
         <body>

--- a/application/palemoon/components/preferences/security.js
+++ b/application/palemoon/components/preferences/security.js
@@ -3,6 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+XPCOMUtils.defineLazyModuleGetter(this, "LoginHelper",
+ "resource://gre/modules/LoginHelper.jsm");
+
 Components.utils.import("resource://gre/modules/PrivateBrowsingUtils.jsm");
 
 var gSecurityPane = {
@@ -141,33 +144,13 @@ var gSecurityPane = {
    */
   _initMasterPasswordUI: function ()
   {
-    var noMP = !this._masterPasswordSet();
+    var noMP = !LoginHelper.isMasterPasswordSet();
 
     var button = document.getElementById("changeMasterPassword");
     button.disabled = noMP;
 
     var checkbox = document.getElementById("useMasterPassword");
     checkbox.checked = !noMP;
-  },
-
-  /**
-   * Returns true if the user has a master password set and false otherwise.
-   */
-  _masterPasswordSet: function ()
-  {
-    const Cc = Components.classes, Ci = Components.interfaces;
-    var secmodDB = Cc["@mozilla.org/security/pkcs11moduledb;1"].
-                   getService(Ci.nsIPKCS11ModuleDB);
-    var slot = secmodDB.findSlotByName("");
-    if (slot) {
-      var status = slot.status;
-      var hasMP = status != Ci.nsIPKCS11Slot.SLOT_UNINITIALIZED &&
-                  status != Ci.nsIPKCS11Slot.SLOT_READY;
-      return hasMP;
-    } else {
-      // XXX I have no bloody idea what this means
-      return false;
-    }
   },
 
   /**

--- a/toolkit/components/passwordmgr/nsLoginManagerPrompter.js
+++ b/toolkit/components/passwordmgr/nsLoginManagerPrompter.js
@@ -1408,11 +1408,9 @@ LoginManagerPrompter.prototype = {
     let windows = Services.wm.getEnumerator(null);
     while (windows.hasMoreElements()) {
       let win = windows.getNext();
-      if (win.gBrowser) {
-        let browser = win.gBrowser.getBrowserForContentWindow(aWindow);
-        if (browser) {
-          return { win, browser };
-        }
+      let browser = win.gBrowser.getBrowserForContentWindow(aWindow);
+      if (browser) {
+        return { win, browser };
       }
     }
     return null;

--- a/toolkit/components/passwordmgr/nsLoginManagerPrompter.js
+++ b/toolkit/components/passwordmgr/nsLoginManagerPrompter.js
@@ -1408,9 +1408,11 @@ LoginManagerPrompter.prototype = {
     let windows = Services.wm.getEnumerator(null);
     while (windows.hasMoreElements()) {
       let win = windows.getNext();
-      let browser = win.gBrowser.getBrowserForContentWindow(aWindow);
-      if (browser) {
-        return { win, browser };
+      if (win.gBrowser) {
+        let browser = win.gBrowser.getBrowserForContentWindow(aWindow);
+        if (browser) {
+          return { win, browser };
+        }
       }
     }
     return null;

--- a/toolkit/components/passwordmgr/nsLoginManagerPrompter.js
+++ b/toolkit/components/passwordmgr/nsLoginManagerPrompter.js
@@ -808,6 +808,9 @@ LoginManagerPrompter.prototype = {
    */
   _showLoginCaptureDoorhanger(login, type) {
     let { browser } = this._getNotifyWindow();
+    if (!browser) {
+      return;
+    }
 
     let saveMsgNames = {
       prompt: login.username === "" ? "rememberLoginMsgNoUser"
@@ -1405,10 +1408,34 @@ LoginManagerPrompter.prototype = {
    * Given a content DOM window, returns the chrome window and browser it's in.
    */
   _getChromeWindow: function (aWindow) {
+    // Handle non-e10s toolkit consumers.
+    if (!Cu.isCrossProcessWrapper(aWindow)) {
+      let chromeWin = aWindow.QueryInterface(Ci.nsIInterfaceRequestor)
+                             .getInterface(Ci.nsIWebNavigation)
+                             .QueryInterface(Ci.nsIDocShell)
+                             .chromeEventHandler.ownerGlobal;
+      if (!chromeWin) {
+        return null;
+     }
+
+      // gBrowser only exists on some apps, like Firefox.
+      let tabbrowser = chromeWin.gBrowser ||
+        (typeof chromeWin.getBrowser == "function" ? chromeWin.getBrowser() : null);
+      // At least serve the chrome window if getBrowser()
+      // or getBrowserForContentWindow() are not supported.
+      if (!tabbrowser || typeof tabbrowser.getBrowserForContentWindow != "function") {
+        return { win: chromeWin };
+      }
+
+      let browser = tabbrowser.getBrowserForContentWindow(aWindow);
+      return { win: chromeWin, browser };
+    }
+
     let windows = Services.wm.getEnumerator(null);
     while (windows.hasMoreElements()) {
       let win = windows.getNext();
-      let browser = win.gBrowser.getBrowserForContentWindow(aWindow);
+      let tabbrowser = win.gBrowser || win.getBrowser();
+      let browser = tabbrowser.getBrowserForContentWindow(aWindow);
       if (browser) {
         return { win, browser };
       }


### PR DESCRIPTION
- [Frontend vs Backend]
Implemented `getBrowserForContentWindow` method in `tabbrowser.xml`
  - [Bug 1045987](https://bugzilla.mozilla.org/show_bug.cgi?id=1045987)
(it is used in: [toolkit/components/passwordmgr/nsLoginManagerPrompter.js#1411](http://xref.palemoon.org/uxp-trunk/source/toolkit/components/passwordmgr/nsLoginManagerPrompter.js#1411))
- [Frontend vs Backend] `Preferences` - `Security` - `Password Manager`
Use `LoginHelper.isMasterPasswordSet` instead of `_masterPasswordSet`
  - [Bug 1174900](https://bugzilla.mozilla.org/show_bug.cgi?id=1174900)
    - Capture doorhanger password field toggle should stay hidden for master password users

- [Frontend vs Backend]
Implemented Popup Notifications

- [Frontend vs Backend]
`InsecurePasswordUtils.checkForInsecurePasswords` is not a function
  - [Bug 1149975](https://bugzilla.mozilla.org/show_bug.cgi?id=1149975)
    - Handle visibility of the login fill doorhanger anchor
  - [Bug 1310049](https://bugzilla.mozilla.org/show_bug.cgi?id=1310049)
    - Refactor FormLikeFactory to its own module for use by Form Autofill

- [moebius#117](https://github.com/MoonchildProductions/moebius/pull/117): Login Manager Prompter - auth: Throws an errors

An example:
https://www.httpwatch.com/httpgallery/authentication/

---

I've created the new build (x32, Windows) - `Basilisk` / `Pale Moon UXP` - and tested.
