### PR TITLE
Editable menulist loosing editable attribute gets focus stuck (menulist.xml)

### DIFF
--- a/toolkit/content/widgets/menulist.xml
+++ b/toolkit/content/widgets/menulist.xml
@@ -129,8 +129,22 @@
       <property name="label" readonly="true" onget="return this.getAttribute('label');"/>
       <property name="description" onset="this.setAttribute('description',val); return val;"
                                    onget="return this.getAttribute('description');"/>
-      <property name="editable"  onset="this.setAttribute('editable',val); return val;"
-                                 onget="return this.getAttribute('editable') == 'true';"/>
+
+      <property name="editable" onget="return this.getAttribute('editable') == 'true';">
+        <setter>
+          <![CDATA[
+            if (!val && this.editable) {
+              // If we were focused and transition from editable to not editable,
+              // focus the parent menulist so that the focus does not get stuck.
+              if (this.inputField == document.activeElement)
+                window.setTimeout(() => this.focus(), 0);
+            }
+
+            this.setAttribute("editable", val);
+            return val;
+          ]]>
+        </setter>
+      </property>
 
       <property name="open" onset="this.menuBoxObject.openMenu(val);
                                    return val;"


### PR DESCRIPTION
Ad:
https://github.com/MoonchildProductions/Pale-Moon/pull/1203

__Native in moebius.__

Bug(s):
https://bugzilla.mozilla.org/show_bug.cgi?id=1142224

---

__Steps to reproduce__

Go to: `about:config`
`dom.allow_XUL_XBL_for_file` = `true` (temporary)

1. have a `<menulist>` element that has a oncommand handler function that sets `this.editable=false` inside it.

An example (e.g. `menulist.xul`):
```
<?xml version="1.0"?>
<overlay xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
<!-- dom.allow_XUL_XBL_for_file = true (temporary) -->
<menulist editable="true" oncommand="this.editable=false;"
          style="width: 300px; max-height: 50px;">
  <menupopup>
    <menuitem label="option 1" value="1"/>
    <menuitem label="option 2" value="2"/>
    <menuitem label="option 3" value="3"/>
    <menuitem label="option 4" value="4"/>
  </menupopup>
</menulist>
</overlay>
```

Open this file in the browser.

2. focus the element with keyboard.
3. use arrow keys to select an item so that the oncommand function runs.

__Result__
focus is not visible and stuck inside the element, you can't tab to any other element. If .editable would be true, you could normally tab in and out of the element. If you focus another element with mouse. You can again tab in and out of this menulist properly. It seems to be the transition from editable to not editable freezes the focus for keyboard navigation.

---

I've created the new build (x32, Windows) - `Basilisk` - and tested.
