### PR TITLE
 Fix: Findbar broken

### DIFF
--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -65,6 +65,9 @@ XPCOMUtils.defineLazyGetter(window, "gFindBar", function() {
   return findbar;
 });
 
+XPCOMUtils.defineLazyModuleGetter(this, "BrowserUtils",
+  "resource://gre/modules/BrowserUtils.jsm");
+
 XPCOMUtils.defineLazyGetter(this, "gPrefService", function() {
   return Services.prefs;
 });
@@ -3426,26 +3429,6 @@ function updateCharacterEncodingMenuState()
   }
 }
 
-/**
- * Returns true if |aMimeType| is text-based, false otherwise.
- *
- * @param aMimeType
- *        The MIME type to check.
- *
- * If adding types to this function, please also check the similar
- * function in findbar.xml
- */
-function mimeTypeIsTextBased(aMimeType)
-{
-  return aMimeType.startsWith("text/") ||
-         aMimeType.endsWith("+xml") ||
-         aMimeType == "application/x-javascript" ||
-         aMimeType == "application/javascript" ||
-         aMimeType == "application/json" ||
-         aMimeType == "application/xml" ||
-         aMimeType == "mozilla.application/cached-xul";
-}
-
 var XULBrowserWindow = {
   // Stored Status, Link and Loading values
   status: "",
@@ -3669,7 +3652,7 @@ var XULBrowserWindow = {
         this.setDefaultStatus(msg);
 
         // Disable menu entries for images, enable otherwise
-        if (!gMultiProcessBrowser && content.document && mimeTypeIsTextBased(content.document.contentType))
+        if (!gMultiProcessBrowser && content.document && BrowserUtils.mimeTypeIsTextBased(content.document.contentType))
           this.isImage.removeAttribute('disabled');
         else
           this.isImage.setAttribute('disabled', 'true');
@@ -3717,7 +3700,7 @@ var XULBrowserWindow = {
     }
 
     // Disable menu entries for images, enable otherwise
-    if (!gMultiProcessBrowser && content.document && mimeTypeIsTextBased(content.document.contentType))
+    if (!gMultiProcessBrowser && content.document && BrowserUtils.mimeTypeIsTextBased(content.document.contentType))
       this.isImage.removeAttribute('disabled');
     else
       this.isImage.setAttribute('disabled', 'true');

--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -3798,11 +3798,16 @@ var XULBrowserWindow = {
           gFindBar.close();
         }
         
+        // XXX
+        // See: https://github.com/MoonchildProductions/Pale-Moon/issues/364
+        // An actual preference: findbar.highlightAll
+        /*
         if (!(gPrefService.getBoolPref("accessibility.typeaheadfind.highlightallremember") ||
               gPrefService.getBoolPref("accessibility.typeaheadfind.highlightallbydefault"))) {
             // fix bug 253793 - turn off highlight when page changes
             gFindBar.getElement("highlight").checked = false;
         }
+        */
       }
     }
     UpdateBackForwardCommands(gBrowser.webNavigation);

--- a/application/palemoon/base/content/nsContextMenu.js
+++ b/application/palemoon/base/content/nsContextMenu.js
@@ -265,7 +265,7 @@ nsContextMenu.prototype = {
 
     // Hide menu entries for images, show otherwise
     if (this.inFrame) {
-      if (mimeTypeIsTextBased(this.target.ownerDocument.contentType))
+      if (BrowserUtils.mimeTypeIsTextBased(this.target.ownerDocument.contentType))
         this.isFrameImage.removeAttribute('hidden');
       else
         this.isFrameImage.setAttribute('hidden', 'true');

--- a/application/palemoon/base/content/tabbrowser.xml
+++ b/application/palemoon/base/content/tabbrowser.xml
@@ -2860,7 +2860,7 @@
 
       <property name="contentWindowAsCPOW"
                 readonly="true"
-                onget="return this.contentWindow;"/>
+                onget="return this.mCurrentBrowser.contentWindow;"/>
 
       <property name="sessionHistory"
                 onget="return this.mCurrentBrowser.sessionHistory;"

--- a/application/palemoon/base/content/tabbrowser.xml
+++ b/application/palemoon/base/content/tabbrowser.xml
@@ -2730,6 +2730,9 @@
           get finder() {
             return this.mTabBrowser.mCurrentBrowser.finder;
           },
+          destroy: function() {
+            this.finder.destroy();
+          },
           addResultListener: function(aListener) {
             this.mListeners.add(aListener);
             this.finder.addResultListener(aListener);
@@ -2750,20 +2753,32 @@
           set caseSensitive(val) {
             return this.finder.caseSensitive = val;
           },
-          fastFind: function(aSearchString, aLinksOnly, aDrawOutline) {
-            this.finder.fastFind(aSearchString, aLinksOnly, aDrawOutline);
+          set entireWord(val) {
+            return this.finder.entireWord = val;
           },
-          findAgain: function(aFindBackwards, aLinksOnly, aDrawOutline) {
-            this.finder.findAgain(aFindBackwards, aLinksOnly, aDrawOutline);
+          get highlighter() {
+            return this.finder.highlighter;
+          },
+          get matchesCountLimit() {
+            return this.finder.matchesCountLimit;
+          },
+          fastFind: function(...args) {
+            this.finder.fastFind(...args);
+          },
+          findAgain: function(...args) {
+            this.finder.findAgain(...args);
           },
           setSearchStringToSelection: function() {
             return this.finder.setSearchStringToSelection();
           },
-          highlight: function(aHighlight, aWord) {
-            this.finder.highlight(aHighlight, aWord);
+          highlight: function(...args) {
+            this.finder.highlight(...args);
           },
           getInitialSelection: function() {
             this.finder.getInitialSelection();
+          },
+          getActiveSelectionText: function() {
+            return this.finder.getActiveSelectionText();
           },
           enableSelection: function() {
             this.finder.enableSelection();
@@ -2774,11 +2789,38 @@
           focusContent: function() {
             this.finder.focusContent();
           },
+          onFindbarClose: function() {
+            this.finder.onFindbarClose();
+          },
+          onFindbarOpen: function() {
+            this.finder.onFindbarOpen();
+          },
+          onModalHighlightChange: function(...args) {
+            return this.finder.onModalHighlightChange(...args);
+          },
+          onHighlightAllChange: function(...args) {
+            return this.finder.onHighlightAllChange(...args);
+          },
           keyPress: function(aEvent) {
             this.finder.keyPress(aEvent);
           },
-          requestMatchesCount: function(aWord, aMatchLimit, aLinksOnly) {
-            this.finder.requestMatchesCount(aWord, aMatchLimit, aLinksOnly);
+          requestMatchesCount: function(...args) {
+            this.finder.requestMatchesCount(...args);
+          },
+          onIteratorRangeFound: function(...args) {
+            this.finder.onIteratorRangeFound(...args);
+          },
+          onIteratorReset: function() {
+            this.finder.onIteratorReset();
+          },
+          onIteratorRestart: function(...args) {
+            this.finder.onIteratorRestart(...args);
+          },
+          onIteratorStart: function(...args) {
+            this.finder.onIteratorStart(...args);
+          },
+          onLocationChange: function(...args) {
+            this.finder.onLocationChange(...args);
           }
         })
       ]]></field>
@@ -2786,6 +2828,19 @@
       <property name="docShell"
                 onget="return this.mCurrentBrowser.docShell"
                 readonly="true"/>
+
+      <property name="messageManager"
+                readonly="true">
+        <getter>
+          <![CDATA[
+            let frameLoader = this.mCurrentBrowser.frameLoader;
+            if (!frameLoader) {
+              return null;
+            }
+            return frameLoader.messageManager;
+          ]]>
+        </getter>
+      </property>
 
       <property name="webNavigation"
                 onget="return this.mCurrentBrowser.webNavigation"
@@ -2802,6 +2857,10 @@
       <property name="contentWindow"
                 readonly="true"
                 onget="return this.mCurrentBrowser.contentWindow"/>
+
+      <property name="contentWindowAsCPOW"
+                readonly="true"
+                onget="return this.contentWindow;"/>
 
       <property name="sessionHistory"
                 onget="return this.mCurrentBrowser.sessionHistory;"
@@ -2870,23 +2929,6 @@
                 aEvent.stopPropagation();
                 aEvent.preventDefault();
                 return;
-            }
-          }
-
-          // We need to take care of FAYT-watching as long as the findbar
-          // isn't initialized.  The checks on aEvent are copied from
-          // _shouldFastFind (see findbar.xml).
-          if (!gFindBarInitialized &&
-              !(aEvent.ctrlKey || aEvent.metaKey) &&
-              !aEvent.defaultPrevented) {
-            let charCode = aEvent.charCode;
-            if (charCode) {
-              let char = String.fromCharCode(charCode);
-              if (char == "'" || char == "/" ||
-                  Services.prefs.getBoolPref("accessibility.typeaheadfind")) {
-                gFindBar._onBrowserKeypress(aEvent);
-                return;
-              }
             }
           }
 
@@ -2981,6 +3023,14 @@
               window.focus();
               break;
             }
+            case "Findbar:Keypress":
+              if (!gFindBarInitialized) {
+                // If the find bar for this tab is not yet alive, change that,
+                // and make sure we return the result:
+                return gFindBar.receiveMessage(aMessage);
+              }
+              break;
+
           }
         ]]></body>
       </method>
@@ -3047,6 +3097,7 @@
                                               this.mCurrentBrowser);
           }
           messageManager.addMessageListener("DOMWebNotificationClicked", this);
+          messageManager.addMessageListener("Findbar:Keypress", this);
         ]]>
       </constructor>
 


### PR DESCRIPTION
This resolves #138 (partially)

---

__TODO (I leave for you to correct - I don't know what your preferences are...):__
https://github.com/MoonchildProductions/UXP/pull/141/files#diff-35cdf6e12e681e90421415d441835592R3801

`accessibility.typeaheadfind.highlightallremember`
and
`accessibility.typeaheadfind.highlightallbydefault`
does not exist (now)

Ad https://github.com/MoonchildProductions/Pale-Moon/issues/364
An actual preference: `findbar.highlightAll`

---

Bug(s):
https://bugzilla.mozilla.org/show_bug.cgi?id=1133981
https://bugzilla.mozilla.org/show_bug.cgi?id=1154799
https://bugzilla.mozilla.org/show_bug.cgi?id=1320095

Also:
http://xref.palemoon.org/uxp-trunk/source/toolkit/modules/Finder.jsm#49

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
