### PR TITLE
Fix: Developer Toolbar (the command: "cookie"; themes)

### DIFF
--- a/application/palemoon/base/content/browser-devtools-theme.js
+++ b/application/palemoon/base/content/browser-devtools-theme.js
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Listeners for the DevEdition theme.  This adds an extra stylesheet
+ * to browser.xul if a pref is set and no other themes are applied.
+ */
+var DevToolsTheme = {
+  _devtoolsThemePrefName: "devtools.theme",
+  styleSheet: null,
+  initialized: false,
+
+  get isStyleSheetEnabled() {
+    return this.styleSheet && !this.styleSheet.sheet.disabled;
+  },
+
+  init: function () {
+    this.initialized = true;
+    Services.prefs.addObserver(this._devtoolsThemePrefName, this, false);
+    Services.obs.addObserver(this, "lightweight-theme-styling-update", false);
+    Services.obs.addObserver(this, "lightweight-theme-window-updated", false);
+    this._updateDevtoolsThemeAttribute();
+  },
+
+  observe: function (subject, topic, data) {
+    if (topic == "lightweight-theme-styling-update") {
+      let newTheme = JSON.parse(data);
+      this._toggleStyleSheet();
+    }
+
+    if (topic == "nsPref:changed" && data == this._devtoolsThemePrefName) {
+      this._updateDevtoolsThemeAttribute();
+    }
+  },
+
+  _inferBrightness: function() {
+    ToolbarIconColor.inferFromText();
+    // Get an inverted full screen button if the dark theme is applied.
+    if (this.isStyleSheetEnabled &&
+        document.documentElement.getAttribute("devtoolstheme") == "dark") {
+      document.documentElement.setAttribute("brighttitlebarforeground", "true");
+    } else {
+      document.documentElement.removeAttribute("brighttitlebarforeground");
+    }
+  },
+
+  _updateDevtoolsThemeAttribute: function() {
+    // Set an attribute on root element to make it possible
+    // to change colors based on the selected devtools theme.
+    let devtoolsTheme = Services.prefs.getCharPref(this._devtoolsThemePrefName);
+    if (devtoolsTheme != "dark") {
+      devtoolsTheme = "light";
+    }
+    document.documentElement.setAttribute("devtoolstheme", devtoolsTheme);
+    this._inferBrightness();
+  },
+
+  handleEvent: function(e) {
+    if (e.type === "load") {
+      this.styleSheet.removeEventListener("load", this);
+      this.refreshBrowserDisplay();
+    }
+  },
+
+  refreshBrowserDisplay: function() {
+    // Don't touch things on the browser if gBrowserInit.onLoad hasn't
+    // yet fired.
+    if (this.initialized) {
+      gBrowser.tabContainer._positionPinnedTabs();
+      this._inferBrightness();
+    }
+  },
+
+  _toggleStyleSheet: function() {
+    let wasEnabled = this.isStyleSheetEnabled;
+    if (wasEnabled) {
+      this.styleSheet.sheet.disabled = true;
+      this.refreshBrowserDisplay();
+    }
+  },
+
+  uninit: function () {
+    Services.prefs.removeObserver(this._devtoolsThemePrefName, this);
+    Services.obs.removeObserver(this, "lightweight-theme-styling-update", false);
+    Services.obs.removeObserver(this, "lightweight-theme-window-updated", false);
+    if (this.styleSheet) {
+      this.styleSheet.removeEventListener("load", this);
+    }
+    this.styleSheet = null;
+  }
+};

--- a/application/palemoon/base/content/browser-devtools-theme.js
+++ b/application/palemoon/base/content/browser-devtools-theme.js
@@ -3,8 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /**
- * Listeners for the DevEdition theme.  This adds an extra stylesheet
- * to browser.xul if a pref is set and no other themes are applied.
+ * Listeners for the DevTools theme.
  */
 var DevToolsTheme = {
   _devtoolsThemePrefName: "devtools.theme",

--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -722,6 +722,14 @@ var gBrowserInit = {
 
     window.addEventListener("AppCommand", HandleAppCommandEvent, true);
 
+    // These routines add message listeners. They must run before
+    // loading the frame script to ensure that we don't miss any
+    // message sent between when the frame script is loaded and when
+    // the listener is registered.
+#ifdef MOZ_DEVTOOLS
+    DevToolsTheme.init();
+#endif
+
     messageManager.loadFrameScript("chrome://browser/content/content.js", true);
     messageManager.loadFrameScript("chrome://browser/content/content-sessionStore.js", true);
 
@@ -1280,6 +1288,10 @@ var gBrowserInit = {
     TabsInTitlebar.uninit();
     
     ToolbarIconColor.uninit();
+
+#ifdef MOZ_DEVTOOLS
+    DevToolsTheme.uninit();
+#endif
 
     var enumerator = Services.wm.getEnumerator(null);
     enumerator.getNext();

--- a/application/palemoon/base/content/browser.xul
+++ b/application/palemoon/base/content/browser.xul
@@ -65,6 +65,9 @@
 # wishes to include *must* go into the global-scripts.inc file
 # so that they can be shared by macBrowserOverlay.xul.
 #include global-scripts.inc
+#ifdef MOZ_DEVTOOLS
+#include global-devtools-theme-scripts.inc
+#endif
 <script type="application/javascript" src="chrome://browser/content/nsContextMenu.js"/>
 
 <script type="application/javascript" src="chrome://global/content/contentAreaUtils.js"/>

--- a/application/palemoon/base/content/global-devtools-theme-scripts.inc
+++ b/application/palemoon/base/content/global-devtools-theme-scripts.inc
@@ -1,0 +1,6 @@
+# -*- Mode: Java; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+<script type="application/javascript" src="chrome://browser/content/browser-devtools-theme.js"/>

--- a/application/palemoon/base/content/macBrowserOverlay.xul
+++ b/application/palemoon/base/content/macBrowserOverlay.xul
@@ -24,6 +24,9 @@
 # wishes to include *must* go into the global-scripts.inc file
 # so that they can be shared by this overlay.
 #include global-scripts.inc
+#ifdef MOZ_DEVTOOLS
+#include global-devtools-theme-scripts.inc
+#endif
 
 <script type="application/javascript">
   function OpenBrowserWindowFromDockMenu(options) {

--- a/application/palemoon/base/content/tabbrowser.xml
+++ b/application/palemoon/base/content/tabbrowser.xml
@@ -2882,6 +2882,10 @@
                 onget="return this.mCurrentBrowser.contentDocument;"
                 readonly="true"/>
 
+      <property name="contentDocumentAsCPOW"
+                onget="return this.mCurrentBrowser.contentDocument;"
+                readonly="true"/>
+
       <property name="contentTitle"
                 onget="return this.mCurrentBrowser.contentTitle;"
                 readonly="true"/>

--- a/application/palemoon/base/jar.mn
+++ b/application/palemoon/base/jar.mn
@@ -53,6 +53,9 @@ browser.jar:
         content/browser/browser-title.css             (content/browser-title.css)
 *       content/browser/browser.js                    (content/browser.js)
 *       content/browser/browser.xul                   (content/browser.xul)
+#ifdef MOZ_DEVTOOLS
+        content/browser/browser-devtools-theme.js     (content/browser-devtools-theme.js)
+#endif
 *       content/browser/browser-tabPreviews.xml       (content/browser-tabPreviews.xml)
         content/browser/content.js                    (content/content.js)
         content/browser/padlock.xul                   (content/padlock.xul)


### PR DESCRIPTION
Tag #102

## 1) The command `cookie`

Throws an error:
```
contentWindow is undefined
```

This is fixed in:
https://github.com/MoonchildProductions/UXP/pull/141/files#diff-4b6b776a4ce679d0a93355fb630031c3R2861

But - using `contentDocumentAsCPOW` (in `developer-toolbar.js` also):
http://xref.palemoon.org/uxp-trunk/search?string=contentDocumentAsCPOW

## 2) Themes

[Bug 1053434](https://bugzilla.mozilla.org/show_bug.cgi?id=1053434) - Add listeners for devedition prefs in browser.js and stub CSS files

Use `browser-devtools-theme.js` instead of `browser-devedition.js`
based on:
http://xref.palemoon.org/uxp-trunk/source/browser/base/content/browser-devedition.js

Links on DevEdition themes etc. in this file are deleted.

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
