### PR TITLE
Make JS callers of ios.newChannel call ios.newChannel2 in browser/

### DIFF
--- a/application/palemoon/base/content/nsContextMenu.js
+++ b/application/palemoon/base/content/nsContextMenu.js
@@ -1116,10 +1116,17 @@ nsContextMenu.prototype = {
       }
     }
 
-    // set up a channel to do the saving
-    var ioService = Cc["@mozilla.org/network/io-service;1"].
-                    getService(Ci.nsIIOService);
-    var channel = ioService.newChannelFromURI(makeURI(linkURL));
+    // setting up a new channel for 'right click - save link as ...'
+    // ideally we should use:
+    // * doc            - as the loadingNode, and/or
+    // * this.principal - as the loadingPrincipal
+    // for now lets use systemPrincipal to bypass mixedContentBlocker
+    // checks after redirects, see bug: 1136055
+    var channel = NetUtil.newChannel({
+                    uri: makeURI(linkURL),
+                    loadUsingSystemPrincipal: true
+                  });
+
     if (linkDownload)
       channel.contentDispositionFilename = linkDownload;
     if (channel instanceof Ci.nsIPrivateBrowsingChannel) {
@@ -1152,7 +1159,7 @@ nsContextMenu.prototype = {
                            timer.TYPE_ONE_SHOT);
 
     // kick off the channel with our proxy object as the listener
-    channel.asyncOpen(new saveAsListener(), null);
+    channel.asyncOpen2(new saveAsListener());
   },
 
   // Save URL of clicked-on link.


### PR DESCRIPTION
This addresses "`nsIOService::NewChannelFromURI()` deprecated, please use `nsIOService::NewChannelFromURI2() WindowsPreviewPerTab.jsm:77:16`" warning in #121.

Based on:
- https://bugzilla.mozilla.org/show_bug.cgi?id=1087726

Follow-ups:
- https://bugzilla.mozilla.org/show_bug.cgi?id=1130816
- https://bugzilla.mozilla.org/show_bug.cgi?id=1136055
- https://bugzilla.mozilla.org/show_bug.cgi?id=1095798
- https://bugzilla.mozilla.org/show_bug.cgi?id=1125618
- https://bugzilla.mozilla.org/show_bug.cgi?id=1167053
- https://bugzilla.mozilla.org/show_bug.cgi?id=1048048
- https://bugzilla.mozilla.org/show_bug.cgi?id=1255499
- https://bugzilla.mozilla.org/show_bug.cgi?id=1223225
- https://bugzilla.mozilla.org/show_bug.cgi?id=1225641