### PR TITLE
Use document's principal for favicons in browser

### DIFF
--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -2849,7 +2849,7 @@ const DOMLinkHandler = {
               break;
 
             let tab = gBrowser.tabs[browserIndex];
-            gBrowser.setIcon(tab, uri.spec);
+            gBrowser.setIcon(tab, uri.spec, link.ownerDocument.nodePrincipal);
             iconAdded = true;
           }
           break;

--- a/application/palemoon/base/content/tabbrowser.xml
+++ b/application/palemoon/base/content/tabbrowser.xml
@@ -778,19 +778,28 @@
       <method name="setIcon">
         <parameter name="aTab"/>
         <parameter name="aURI"/>
+        <parameter name="aLoadingPrincipal"/>
         <body>
           <![CDATA[
-            var browser = this.getBrowserForTab(aTab);
+            let browser = this.getBrowserForTab(aTab);
             browser.mIconURL = aURI instanceof Ci.nsIURI ? aURI.spec : aURI;
 
             if (aURI && this.mFaviconService) {
-              if (!(aURI instanceof Ci.nsIURI))
+              if (!(aURI instanceof Ci.nsIURI)) {
                 aURI = makeURI(aURI);
-              this.mFaviconService.setAndFetchFaviconForPage(browser.currentURI,
-                                                             aURI, false,
-                                                             PrivateBrowsingUtils.isWindowPrivate(window) ?
-                                                               this.mFaviconService.FAVICON_LOAD_PRIVATE :
-                                                               this.mFaviconService.FAVICON_LOAD_NON_PRIVATE);
+              }
+              // We do not serialize the principal from within SessionStore.jsm,
+              // hence if aLoadingPrincipal is null we default to the
+              // systemPrincipal which will allow the favicon to load.
+              let loadingPrincipal = aLoadingPrincipal
+                ? aLoadingPrincipal
+                : Services.scriptSecurityManager.getSystemPrincipal();
+              let loadType = PrivateBrowsingUtils.isWindowPrivate(window)
+                ? this.mFaviconService.FAVICON_LOAD_PRIVATE
+                : this.mFaviconService.FAVICON_LOAD_NON_PRIVATE;
+
+              this.mFaviconService.setAndFetchFaviconForPage(
+                browser.currentURI, aURI, false, loadType, null, loadingPrincipal);
             }
 
             let sizedIconUrl = browser.mIconURL || "";
@@ -886,7 +895,7 @@
               if (!this.isFailedIcon(url))
                 icon = url;
             }
-            this.setIcon(aTab, icon);
+            this.setIcon(aTab, icon, browser.contentPrincipal);
           ]]>
         </body>
       </method>
@@ -2146,7 +2155,7 @@
               // Workarounds for bug 458697
               // Icon might have been set on DOMLinkAdded, don't override that.
               if (!ourBrowser.mIconURL && otherBrowser.mIconURL)
-                this.setIcon(aOurTab, otherBrowser.mIconURL);
+                this.setIcon(aOurTab, otherBrowser.mIconURL, otherBrowser.contentPrincipal);
               var isBusy = aOtherTab.hasAttribute("busy");
               if (isBusy) {
                 aOurTab.setAttribute("busy", "true");

--- a/application/palemoon/components/feeds/FeedWriter.js
+++ b/application/palemoon/components/feeds/FeedWriter.js
@@ -1395,6 +1395,8 @@ FeedWriter.prototype = {
                                          .QueryInterface(Ci.nsIDocShell)
                                          .QueryInterface(Ci.nsILoadContext)
                                          .usePrivateBrowsing;
+    var nullPrincipal = Cc["@mozilla.org/nullprincipal;1"]
+                          .createInstance(Ci.nsIPrincipal);
     this._faviconService.setAndFetchFaviconForPage(readerURI, faviconURI, false,
       usePrivateBrowsing ? this._faviconService.FAVICON_LOAD_PRIVATE
                          : this._faviconService.FAVICON_LOAD_NON_PRIVATE,
@@ -1409,7 +1411,7 @@ FeedWriter.prototype = {
           self._contentSandbox.menuItem = null;
           self._contentSandbox.dataURL = null;
         }
-      });
+      }, nullPrincipal);
   },
 
   classID: FEEDWRITER_CID,

--- a/application/palemoon/components/sessionstore/SessionStore.jsm
+++ b/application/palemoon/components/sessionstore/SessionStore.jsm
@@ -3131,7 +3131,11 @@ let SessionStoreInternal = {
 
     // Restore the tab icon.
     if ("image" in tabData) {
-      aWindow.gBrowser.setIcon(tab, tabData.image);
+      // Using null as the loadingPrincipal because serializing
+      // the principal would be overkill. Within SetIcon we
+      // default to the systemPrincipal if aLoadingPrincipal is
+      // null which will allow the favicon to load.
+      aWindow.gBrowser.setIcon(tab, tabData.image, null);
     }
 
     if (tabData.storage && browser.docShell instanceof Ci.nsIDocShell)


### PR DESCRIPTION
This addresses "`nsFaviconService::setAndFetchFaviconForPage()` deprecated, please use `nsFaviconService::setAndFetchFaviconForPage(..., [optional aLoadingPrincipal])` tabbrowser.xml:776:14" warning in #121.

Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1119386