### PR TITLE
Use modern syntax to call NetUtil.newChannel() in _SessionFile.jsm

### DIFF
--- a/application/palemoon/components/sessionstore/_SessionFile.jsm
+++ b/application/palemoon/components/sessionstore/_SessionFile.jsm
@@ -156,7 +156,10 @@ let SessionFileInternal = {
     let text;
     try {
       let file = new FileUtils.File(aPath);
-      let chan = NetUtil.newChannel(file);
+      let chan = NetUtil.newChannel({
+        uri: NetUtil.newURI(file),
+        loadUsingSystemPrincipal: true
+      });
       let stream = chan.open();
       text = NetUtil.readInputStreamToString(stream, stream.available(),
         {charset: "utf-8"});


### PR DESCRIPTION
This addresses "Warning: `NetUtil.newChannel(uri)` deprecated, please provide argument 'aWhatToLoad'".

Tag #121.