### PR TITLE
Fix: TypeError: "this._richlistbox.selectedItems.slice is not a function" in allDownloadsViewOverlay.js

### DIFF
--- a/application/palemoon/components/downloads/content/allDownloadsViewOverlay.js
+++ b/application/palemoon/components/downloads/content/allDownloadsViewOverlay.js
@@ -1476,11 +1476,11 @@ DownloadsPlacesView.prototype = {
         goUpdateCommand("downloadsCmd_clearDownloads");
         break;
       default: {
-        // Slicing the array to get a freezed list of selected items. Otherwise,
-        // the selectedItems array is live and doCommand may alter the selection
-        // while we are trying to do one particular action, like removing items
-        // from history.
-        let selectedElements = this._richlistbox.selectedItems.slice();
+        // Cloning the nodelist into an array to get a frozen list of selected items.
+        // Otherwise, the selectedItems nodelist is live and doCommand may alter the
+        // selection while we are trying to do one particular action, like removing
+        // items from history.
+        let selectedElements = [...this._richlistbox.selectedItems];
         for (let element of selectedElements) {
           element._shell.doCommand(aCommand);
         }


### PR DESCRIPTION
Tag #121

__Steps to reproduce:__

Go to the main menu: `Tools` - `Downloads`
Select a downloaded file
The context menu: `Remove From History`


Throws an error:
```
Error: TypeError: this._richlistbox.selectedItems.slice is not a function

Source File: chrome://browser/content/downloads/allDownloadsViewOverlay.js

Line: 1483
```

Frontend vs Backend:
[Bug 120684](https://bugzilla.mozilla.org/show_bug.cgi?id=120684) - use ChromeNodeList in toolkit's listboxes' selectedItems implementation
(https://hg.mozilla.org/mozilla-central/rev/fb998e8c0b94)

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
