### PR TITLE
[PALEMOON] Downloads - throws an error

### DIFF
--- a/application/palemoon/components/downloads/content/downloads.js
+++ b/application/palemoon/components/downloads/content/downloads.js
@@ -590,6 +590,8 @@ const DownloadsPanel = {
   }
 };
 
+XPCOMUtils.defineConstant(this, "DownloadsPanel", DownloadsPanel);
+
 ////////////////////////////////////////////////////////////////////////////////
 //// DownloadsOverlayLoader
 
@@ -676,6 +678,8 @@ const DownloadsOverlayLoader = {
     }
   }
 };
+
+XPCOMUtils.defineConstant(this, "DownloadsOverlayLoader", DownloadsOverlayLoader);
 
 ////////////////////////////////////////////////////////////////////////////////
 //// DownloadsView
@@ -1053,6 +1057,8 @@ const DownloadsView = {
   }
 }
 
+XPCOMUtils.defineConstant(this, "DownloadsView", DownloadsView);
+
 ////////////////////////////////////////////////////////////////////////////////
 //// DownloadsViewItem
 
@@ -1414,6 +1420,8 @@ const DownloadsViewController = {
   }
 };
 
+XPCOMUtils.defineConstant(this, "DownloadsViewController", DownloadsViewController);
+
 ////////////////////////////////////////////////////////////////////////////////
 //// DownloadsViewItemController
 
@@ -1754,7 +1762,9 @@ const DownloadsSummary = {
     delete this._detailsNode;
     return this._detailsNode = node;
   }
-}
+};
+
+XPCOMUtils.defineConstant(this, "DownloadsSummary", DownloadsSummary);
 
 ////////////////////////////////////////////////////////////////////////////////
 //// DownloadsFooter
@@ -1811,3 +1821,5 @@ const DownloadsFooter = {
     return this._footerNode = node;
   }
 };
+
+XPCOMUtils.defineConstant(this, "DownloadsFooter", DownloadsFooter);

--- a/application/palemoon/components/downloads/content/indicator.js
+++ b/application/palemoon/components/downloads/content/indicator.js
@@ -254,6 +254,12 @@ const DownloadsButton = {
   }
 };
 
+Object.defineProperty(this, "DownloadsButton", {
+  value: DownloadsButton,
+  enumerable: true,
+  writable: false
+});
+
 ////////////////////////////////////////////////////////////////////////////////
 //// DownloadsIndicatorView
 
@@ -592,3 +598,9 @@ const DownloadsIndicatorView = {
       document.getElementById("downloads-indicator-progress");
   }
 };
+
+Object.defineProperty(this, "DownloadsIndicatorView", {
+  value: DownloadsIndicatorView,
+  enumerable: true,
+  writable: false
+});


### PR DESCRIPTION
Tag #121

Block #155 

__Steps to reproduce__

Go to: `about:logopage`
The context menu: `Save Image As...`

Throws an error:
```
Error: browserWin.DownloadsIndicatorView is undefined
Source File: resource:///modules/DownloadsCommon.jsm
Line: 1321
```
```
Error: this._window.DownloadsPanel is undefined
Source File: resource:///modules/statusbar/Downloads.jsm
Line: 522
```

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
