### PR TITLE
Fix a build warning for BrowserComponents.manifest

### DIFF
--- a/browser/components/moz.build
+++ b/browser/components/moz.build
@@ -37,11 +37,8 @@ XPIDL_SOURCES += [
 
 XPIDL_MODULE = 'browsercompsbase'
 
-EXTRA_PP_COMPONENTS += [
-    'BrowserComponents.manifest',
-]
-
 EXTRA_COMPONENTS += [
+    'BrowserComponents.manifest', 
     'nsBrowserContentHandler.js',
     'nsBrowserGlue.js',
 ]


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/Pale-Moon/issues/1464

Build - warnings:

```
[drive]:/[path]/browser/components/BrowserComponents.manifest: WARNING:
no useful preprocessor directives found
```
