### PR TITLE
Fix a build warning for extensions.js (Basilisk / webextensions folder)

### DIFF
--- a/toolkit/mozapps/webextensions/jar.mn
+++ b/toolkit/mozapps/webextensions/jar.mn
@@ -7,7 +7,7 @@ toolkit.jar:
 % content mozapps %content/mozapps/
 * content/mozapps/extensions/extensions.xul                     (content/extensions.xul)
   content/mozapps/extensions/extensions.css                     (content/extensions.css)
-* content/mozapps/extensions/extensions.js                      (content/extensions.js)
+  content/mozapps/extensions/extensions.js                      (content/extensions.js)
 * content/mozapps/extensions/extensions.xml                     (content/extensions.xml)
   content/mozapps/extensions/updateinfo.xsl                     (content/updateinfo.xsl)
   content/mozapps/extensions/about.xul                          (content/about.xul)


### PR DESCRIPTION
Ad https://github.com/MoonchildProductions/Pale-Moon/issues/1464

Build - warnings:

```
[drive]:\[path]\toolkit\mozapps\webextensions\content/extensions.js:
WARNING: no preprocessor directives found
```
