### PR TITLE
Align SessionStore.jsm with the updated getCookiesFromHost() API

### DIFF
--- a/application/palemoon/components/sessionstore/SessionStore.jsm
+++ b/application/palemoon/components/sessionstore/SessionStore.jsm
@@ -2404,7 +2404,7 @@ let SessionStoreInternal = {
       for (var [host, isPinned] in Iterator(internalWindow.hosts)) {
         let list;
         try {
-          list = Services.cookies.getCookiesFromHost(host);
+          list = Services.cookies.getCookiesFromHost(host, {});
         }
         catch (ex) {
           debug("getCookiesFromHost failed. Host: " + host);


### PR DESCRIPTION
This addresses "`nsICookieManager2.getCookiesFromHost()` is changed. Update your code and pass the correct originAttributes. Read more on MDN: https://developer.mozilla.org/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsICookieManager2 SessionStore.jsm:2405:17'" warning in #121.

I think we can't provide any meaningful `originAttribute` here, so `{}` is perfectly suitable to get rid of the warning.