### PR TITLE
Suppress false-positive warning about unreachable code after return in nsContextMenu.js

### DIFF
--- a/application/palemoon/base/content/nsContextMenu.js
+++ b/application/palemoon/base/content/nsContextMenu.js
@@ -1394,9 +1394,8 @@ nsContextMenu.prototype = {
 
   isDisabledForEvents: function(aNode) {
     let ownerDoc = aNode.ownerDocument;
-    return
-      ownerDoc.defaultView &&
-      ownerDoc.defaultView
+    return ownerDoc.defaultView &&
+           ownerDoc.defaultView
               .QueryInterface(Components.interfaces.nsIInterfaceRequestor)
               .getInterface(Components.interfaces.nsIDOMWindowUtils)
               .isNodeDisabledForEvents(aNode);


### PR DESCRIPTION
This addresses "unreachable code after return statement[[Learn More]](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Errors/Stmt_after_return)  `nsContextMenu.js:1381:6`" false-positive warning.

Tag #121.