### PR TITLE
Align SessionStore.jsm with the updated nsICookieManager2.add() API

### DIFF
--- a/application/palemoon/components/sessionstore/SessionStore.jsm
+++ b/application/palemoon/components/sessionstore/SessionStore.jsm
@@ -3655,7 +3655,7 @@ let SessionStoreInternal = {
       try {
         Services.cookies.add(cookie.host, cookie.path || "", cookie.name || "",
                              cookie.value, !!cookie.secure, !!cookie.httponly, true,
-                             "expiry" in cookie ? cookie.expiry : MAX_EXPIRY);
+                             "expiry" in cookie ? cookie.expiry : MAX_EXPIRY, {});
       }
       catch (ex) { Cu.reportError(ex); } // don't let a single cookie stop recovering
     }


### PR DESCRIPTION
This addresses "`nsICookieManager2.add()` is changed. Update your code and pass the correct `originAttributes`. Read more on MDN: https://developer.mozilla.org/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsICookieManager2 SessionStore.jsm:3652:8" warning.

Follow-up to #163, tag #121.