### PR TITLE
[PALEMOON] Fix a warning: "unreachable code after return statement" in urlbarBindings.xml

### DIFF
--- a/application/palemoon/base/content/urlbarBindings.xml
+++ b/application/palemoon/base/content/urlbarBindings.xml
@@ -1913,7 +1913,7 @@
             viewsLeft = 0;
             return;
             // XXX
-            
+            /*
             if (Services.prefs.prefHasUserValue("services.sync.username") &&
                this._notificationType != "addons-sync-disabled") {
               // If the user has already setup Sync, don't show the notification.
@@ -1947,6 +1947,7 @@
               this._promomessage.firstChild.textContent = this._notificationMessage;
               this._promomessage.height = this._promomessage.getBoundingClientRect().height;
             }.bind(this), true);
+            */
           }
         ]]></body>
       </method>


### PR DESCRIPTION
Tag #121

After starting the browser throws an warning in Browser Console:
```
unreachable code after return statement
urlbarBindings.xml:1910:12
```

See also:
#164
