### PR TITLE
[PALEMOON] Remove accidentally duplicated 'malformedURI.title' from netError.dtd

### DIFF
--- a/application/palemoon/locales/en-US/chrome/overrides/netError.dtd
+++ b/application/palemoon/locales/en-US/chrome/overrides/netError.dtd
@@ -51,7 +51,6 @@
 <p>&brandShortName; can’t load this page for some reason.</p>
 ">
 
-<!ENTITY malformedURI.title "The address isn't valid">
 <!ENTITY captivePortal.title "Login to network">
 <!ENTITY captivePortal.longDesc "
 <p>This network may require you to login to access the internet.</p>
@@ -59,7 +58,7 @@
 
 <!ENTITY openPortalLoginPage.label "Open Login Page">
 
-<!ENTITY malformedURI.title "The address isn’t valid">
+<!ENTITY malformedURI.title "The address isn't valid">
 <!ENTITY malformedURI.longDesc "
 <ul>
   <li>Web addresses are usually written like


### PR DESCRIPTION
Follow-up to https://github.com/MoonchildProductions/UXP/commit/3e670d8573a5b61d0bdd62fe19112c36061eb312.