### PR TITLE
palemoon#903 a #975: Customizable toolbars - persist the attribute "collapsed" (backward compatible)

### DIFF
--- a/toolkit/content/customizeToolbar.js
+++ b/toolkit/content/customizeToolbar.js
@@ -180,8 +180,8 @@ function persistCurrentSets()
         // Persist custom toolbar info on the <toolbarset/>
         // Attributes:
         // Names: "toolbarX" (X - the number of the toolbar)
-        // Values: "Name:HidingAttributeName-HidingAttributeValue:CurrentSet"
-        gToolbox.toolbarset.setAttribute("toolbar"+(++customCount),
+        // Values: "Name|HidingAttributeName-HidingAttributeValue|CurrentSet"
+        gToolbox.toolbarset.setAttribute("toolbar" + (++customCount),
                                          toolbar.toolbarName
                                          + gToolbarInfoSeparators[0]
                                          + hidingAttribute

--- a/toolkit/content/customizeToolbar.js
+++ b/toolkit/content/customizeToolbar.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const gToolbarInfoSeparators = ["|", "-"];
+
 var gToolboxDocument = null;
 var gToolbox = null;
 var gCurrentDragOverItem = null;
@@ -173,9 +175,20 @@ function persistCurrentSets()
         // Remove custom toolbars whose contents have been removed.
         gToolbox.removeChild(toolbar);
       } else if (gToolbox.toolbarset) {
+        var hidingAttribute = toolbar.getAttribute("type") == "menubar" ?
+                              "autohide" : "collapsed";
         // Persist custom toolbar info on the <toolbarset/>
+        // Attributes:
+        // Names: "toolbarX" (X - the number of the toolbar)
+        // Values: "Name:HidingAttributeName-HidingAttributeValue:CurrentSet"
         gToolbox.toolbarset.setAttribute("toolbar"+(++customCount),
-                                         toolbar.toolbarName + ":" + currentSet);
+                                         toolbar.toolbarName
+                                         + gToolbarInfoSeparators[0]
+                                         + hidingAttribute
+                                         + gToolbarInfoSeparators[1]
+                                         + toolbar.getAttribute(hidingAttribute)
+                                         + gToolbarInfoSeparators[0]
+                                         + currentSet);
         gToolboxDocument.persist(gToolbox.toolbarset.id, "toolbar"+customCount);
       }
     }
@@ -485,6 +498,11 @@ function addNewToolbar()
       continue;
     }
 
+    if (name.value.includes(gToolbarInfoSeparators[0])) {
+      message = stringBundle.getFormattedString("enterToolbarIllegalChars", [name.value]);
+      continue;
+    }
+
     var dupeFound = false;
 
      // Check for an existing toolbar with the same display name
@@ -506,7 +524,7 @@ function addNewToolbar()
     message = stringBundle.getFormattedString("enterToolbarDup", [name.value]);
   }
 
-  gToolbox.appendCustomToolbar(name.value, "");
+  gToolbox.appendCustomToolbar(name.value, "", [null, null]);
 
   toolboxChanged();
 

--- a/toolkit/content/widgets/toolbar.xml
+++ b/toolkit/content/widgets/toolbar.xml
@@ -76,6 +76,7 @@
               switch (infoSplitLen) {
                 case 3:
                   // Pale Moon 27.2+
+                  // Basilisk (UXP)
                   infoHidingAttribute = infoSplit[1]
                       .split(this.toolbarInfoSeparators[1]);
                   infoCurrentSet = infoSplit[2];
@@ -83,7 +84,7 @@
                 case 2:
                   // Legacy:
                   // - toolbars from Pale Moon 27.0 - 27.1.x
-                  // - Basilisk
+                  // - Basilisk (moebius)
                   // The previous value (hiddingAttribute) isn't stored.
                   infoHidingAttribute = [hiddingAttribute, "false"];
                   infoCurrentSet = infoSplit[1];

--- a/toolkit/content/widgets/toolbar.xml
+++ b/toolkit/content/widgets/toolbar.xml
@@ -49,6 +49,7 @@
 
       <constructor>
         <![CDATA[
+          this.toolbarInfoSeparators = ["|", "-"];
           // Look to see if there is a toolbarset.
           this.toolbarset = this.firstChild;
           while (this.toolbarset && this.toolbarset.localName != "toolbarset")
@@ -57,10 +58,14 @@
           if (this.toolbarset) {
             // Create each toolbar described by the toolbarset.
             var index = 0;
-            while (toolbarset.hasAttribute("toolbar"+(++index))) {
-              var toolbarInfo = toolbarset.getAttribute("toolbar"+index);
-              var infoSplit = toolbarInfo.split(":");
-              this.appendCustomToolbar(infoSplit[0], infoSplit[1]);
+            while (this.toolbarset.hasAttribute("toolbar" + (++index))) {
+              var toolbarInfo = this.toolbarset.getAttribute("toolbar"+index);
+              var infoSplit = toolbarInfo.split(this.toolbarInfoSeparators[0]);
+              var infoName = infoSplit[0];
+              var infoHidingAttribute = infoSplit[1].split(this.toolbarInfoSeparators[1]);
+              var infoCurrentSet = infoSplit[2];
+
+              this.appendCustomToolbar(infoName, infoCurrentSet, infoHidingAttribute);
             }
           }
         ]]>
@@ -69,6 +74,7 @@
       <method name="appendCustomToolbar">
         <parameter name="aName"/>
         <parameter name="aCurrentSet"/>
+        <parameter name="aHidingAttribute"/>
         <body>
           <![CDATA[
             if (!this.toolbarset)
@@ -84,6 +90,10 @@
             toolbar.setAttribute("iconsize", this.getAttribute("iconsize"));
             toolbar.setAttribute("context", this.toolbarset.getAttribute("context"));
             toolbar.setAttribute("class", "chromeclass-toolbar");
+            // Restore persist the hiding attribute.
+            if (aHidingAttribute[0]) {
+              toolbar.setAttribute(aHidingAttribute[0], aHidingAttribute[1]);
+            }
 
             this.insertBefore(toolbar, this.toolbarset);
             return toolbar;

--- a/toolkit/content/widgets/toolbar.xml
+++ b/toolkit/content/widgets/toolbar.xml
@@ -30,7 +30,7 @@
       </field>
 
       <field name="externalToolbars">
-       []
+        []
       </field>
 
       <!-- Set by customizeToolbar.js -->
@@ -50,22 +50,52 @@
       <constructor>
         <![CDATA[
           this.toolbarInfoSeparators = ["|", "-"];
+          this.toolbarInfoLegacySeparator = ":";
           // Look to see if there is a toolbarset.
           this.toolbarset = this.firstChild;
-          while (this.toolbarset && this.toolbarset.localName != "toolbarset")
+          while (this.toolbarset && this.toolbarset.localName != "toolbarset") {
             this.toolbarset = toolbarset.nextSibling;
+          }
 
           if (this.toolbarset) {
             // Create each toolbar described by the toolbarset.
             var index = 0;
             while (this.toolbarset.hasAttribute("toolbar" + (++index))) {
-              var toolbarInfo = this.toolbarset.getAttribute("toolbar"+index);
-              var infoSplit = toolbarInfo.split(this.toolbarInfoSeparators[0]);
-              var infoName = infoSplit[0];
-              var infoHidingAttribute = infoSplit[1].split(this.toolbarInfoSeparators[1]);
-              var infoCurrentSet = infoSplit[2];
-
-              this.appendCustomToolbar(infoName, infoCurrentSet, infoHidingAttribute);
+              let hiddingAttribute =
+                  this.toolbarset.getAttribute("type") == "menubar"
+                      ? "autohide" : "collapsed";
+              let toolbarInfo = this.toolbarset.getAttribute("toolbar" + index);
+              let infoSplit = toolbarInfo.split(this.toolbarInfoSeparators[0]);
+              if (infoSplit.length == 1) {
+                infoSplit = toolbarInfo.split(this.toolbarInfoLegacySeparator);
+              }
+              let infoName = infoSplit[0];
+              let infoHidingAttribute = [null, null];
+              let infoCurrentSet = "";
+              let infoSplitLen = infoSplit.length;
+              switch (infoSplitLen) {
+                case 3:
+                  // Pale Moon 27.2+
+                  infoHidingAttribute = infoSplit[1]
+                      .split(this.toolbarInfoSeparators[1]);
+                  infoCurrentSet = infoSplit[2];
+                  break;
+                case 2:
+                  // Legacy:
+                  // - toolbars from Pale Moon 27.0 - 27.1.x
+                  // - Basilisk
+                  // The previous value (hiddingAttribute) isn't stored.
+                  infoHidingAttribute = [hiddingAttribute, "false"];
+                  infoCurrentSet = infoSplit[1];
+                  break;
+                default:
+                  Components.utils.reportError(
+                      "Customizable toolbars - an invalid value:" + "\n"
+                      + '"toolbar' + index + '" = "' + toolbarInfo + '"');
+                  break;
+              }
+              this.appendCustomToolbar(
+                  infoName, infoCurrentSet, infoHidingAttribute);
             }
           }
         ]]>

--- a/toolkit/locales/en-US/chrome/global/customizeToolbar.properties
+++ b/toolkit/locales/en-US/chrome/global/customizeToolbar.properties
@@ -5,6 +5,7 @@
 enterToolbarTitle=New Toolbar
 enterToolbarName=Enter a name for this toolbar:
 enterToolbarDup=There is already a toolbar with the name “%S”. Please enter a different name.
+enterToolbarIllegalChars=The name contains illegal character "|". Please enter a different name.
 enterToolbarBlank=You must enter a name to create a new toolbar.
 separatorTitle=Separator
 springTitle=Flexible Space


### PR DESCRIPTION
Tags:
https://github.com/MoonchildProductions/Pale-Moon/pull/903
https://github.com/MoonchildProductions/Pale-Moon/pull/975

---

I've created the new build (x32, Windows):
- `Basilisk` (with `Classic Theme Restorer 1.7.3.4`) / `Pale Moon UXP` - and tested.
