### PR TITLE
Set default MOZ_OPTIMIZE_FLAGS to -O2 when using GCC

### DIFF
--- a/old-configure.in
+++ b/old-configure.in
@@ -936,7 +936,7 @@ case "$target" in
     fi
 
     MOZ_GFX_OPTIMIZE_MOBILE=1
-    MOZ_OPTIMIZE_FLAGS="-Os"
+    MOZ_OPTIMIZE_FLAGS="-O2"
     if test -z "$CLANG_CC"; then
        MOZ_OPTIMIZE_FLAGS="-freorder-blocks -fno-reorder-functions $MOZ_OPTIMIZE_FLAGS"
     fi
@@ -945,7 +945,7 @@ case "$target" in
 *-*linux*)
     if test "$GNU_CC" -o "$GNU_CXX"; then
         MOZ_PGO_OPTIMIZE_FLAGS="-O3"
-        MOZ_OPTIMIZE_FLAGS="-Os"
+        MOZ_OPTIMIZE_FLAGS="-O2"
         if test -z "$CLANG_CC"; then
            MOZ_OPTIMIZE_FLAGS="-freorder-blocks $MOZ_OPTIMIZE_FLAGS"
         fi


### PR DESCRIPTION
Just what it says in the tin. See also [Pale Moon 457](https://github.com/MoonchildProductions/Pale-Moon/pull/457).

Tested and browser runs stable with a small but noticeable performance boost.