### PR TITLE
[PALEMOON] Engine Manager throws a warning (deprecated)

### DIFF
--- a/application/palemoon/components/search/content/engineManager.js
+++ b/application/palemoon/components/search/content/engineManager.js
@@ -110,7 +110,7 @@ var gEngineManagerDialog = {
     document.getElementById("engineList").focus();
   },
 
-  editKeyword: Task.async(function* () {
+  editKeyword: Task.async(function* engineManager_editKeyword() {
     var selectedEngine = gEngineView.selectedEngine;
     if (!selectedEngine)
       return;

--- a/application/palemoon/components/search/content/engineManager.xul
+++ b/application/palemoon/components/search/content/engineManager.xul
@@ -36,7 +36,7 @@
              oncommand="gEngineManagerDialog.bump(-1);"
              disabled="true"/>
     <command id="cmd_editkeyword"
-             oncommand="gEngineManagerDialog.editKeyword();"
+             oncommand="gEngineManagerDialog.editKeyword().catch(Components.utils.reportError);"
              disabled="true"/>
   </commandset>
 


### PR DESCRIPTION
Tag #121 

Engine Manager throws a warning (deprecated):
```
nsNavBookmarks::GetURIForKeyword is deprecated and will be removed in the next version.
```

__Steps to reproduce:__

Go to `Manage Search Engines...`
The button: `Edit Keyword`

Bug(s):
https://bugzilla.mozilla.org/show_bug.cgi?id=1094844

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
