### PR TITLE
Make Add-on SDK (Jetpack) work on Pale Moon || Part 1

### DIFF
--- a/toolkit/jetpack/modules/system/Startup.js
+++ b/toolkit/jetpack/modules/system/Startup.js
@@ -15,6 +15,7 @@ const appStartupSrv = Cc["@mozilla.org/toolkit/app-startup;1"]
                        .getService(Ci.nsIAppStartup);
 
 const NAME2TOPIC = {
+  'Palemoon': 'sessionstore-windows-restored',
   'Firefox': 'sessionstore-windows-restored',
   'Fennec': 'sessionstore-windows-restored',
   'SeaMonkey': 'sessionstore-windows-restored',

--- a/toolkit/jetpack/moz.build
+++ b/toolkit/jetpack/moz.build
@@ -219,9 +219,12 @@ EXTRA_JS_MODULES.commonjs.sdk += [
     'sdk/tabs.js',
     'sdk/test.js',
     'sdk/timers.js',
-    'sdk/ui.js',
     'sdk/url.js',
     'sdk/windows.js',
+]
+
+EXTRA_PP_JS_MODULES.commonjs.sdk += [
+    'sdk/ui.js',
 ]
 
 EXTRA_JS_MODULES.commonjs.sdk.addon += [

--- a/toolkit/jetpack/moz.build
+++ b/toolkit/jetpack/moz.build
@@ -85,10 +85,18 @@ if CONFIG['MOZ_WIDGET_TOOLKIT'] != "gonk":
         'sdk/ui/toolbar.js',
     ]
 
+    if CONFIG['MC_PALEMOON']:
+        EXTRA_JS_MODULES.commonjs.sdk.ui += [
+            'sdk/ui/buttons.js',
+        ]
+
     EXTRA_JS_MODULES.commonjs.sdk.ui.button += [
         'sdk/ui/button/action.js',
         'sdk/ui/button/contract.js',
         'sdk/ui/button/toggle.js',
+    ]
+
+    EXTRA_PP_JS_MODULES.commonjs.sdk.ui.button += [
         'sdk/ui/button/view.js',
     ]
 

--- a/toolkit/jetpack/sdk/clipboard.js
+++ b/toolkit/jetpack/sdk/clipboard.js
@@ -8,6 +8,7 @@ module.metadata = {
   "stability": "stable",
   "engines": {
     // TODO Fennec Support 789757
+    "Palemoon": "*",
     "Firefox": "*",
     "SeaMonkey": "*",
     "Thunderbird": "*"

--- a/toolkit/jetpack/sdk/context-menu.js
+++ b/toolkit/jetpack/sdk/context-menu.js
@@ -7,6 +7,7 @@ module.metadata = {
   "stability": "stable",
   "engines": {
     // TODO Fennec support Bug 788334
+    "Palemoon": "*",
     "Firefox": "*",
     "SeaMonkey": "*"
   }

--- a/toolkit/jetpack/sdk/places/bookmarks.js
+++ b/toolkit/jetpack/sdk/places/bookmarks.js
@@ -7,6 +7,7 @@
 module.metadata = {
   "stability": "unstable",
   "engines": {
+    "Palemoon": "*",
     "Firefox": "*",
     "SeaMonkey": "*"
   }

--- a/toolkit/jetpack/sdk/places/events.js
+++ b/toolkit/jetpack/sdk/places/events.js
@@ -7,6 +7,7 @@
 module.metadata = {
   'stability': 'experimental',
   'engines': {
+    'Palemoon': '*',
     'Firefox': '*',
     "SeaMonkey": '*'
   }

--- a/toolkit/jetpack/sdk/places/favicon.js
+++ b/toolkit/jetpack/sdk/places/favicon.js
@@ -7,6 +7,7 @@
 module.metadata = {
   "stability": "unstable",
   "engines": {
+    "Palemoon": "*",
     "Firefox": "*",
     "SeaMonkey": "*"
   }

--- a/toolkit/jetpack/sdk/places/history.js
+++ b/toolkit/jetpack/sdk/places/history.js
@@ -7,6 +7,7 @@
 module.metadata = {
   "stability": "unstable",
   "engines": {
+    "Palemoon": "*",
     "Firefox": "*",
     "SeaMonkey": "*"
   }

--- a/toolkit/jetpack/sdk/places/host/host-bookmarks.js
+++ b/toolkit/jetpack/sdk/places/host/host-bookmarks.js
@@ -7,6 +7,7 @@
 module.metadata = {
   "stability": "experimental",
   "engines": {
+    "Palemoon": "*",
     "Firefox": "*",
     "SeaMonkey": "*"
   }

--- a/toolkit/jetpack/sdk/places/host/host-query.js
+++ b/toolkit/jetpack/sdk/places/host/host-query.js
@@ -6,6 +6,7 @@
 module.metadata = {
   "stability": "experimental",
   "engines": {
+    "Palemoon": "*",
     "Firefox": "*",
     "SeaMonkey": "*"
   }

--- a/toolkit/jetpack/sdk/places/host/host-tags.js
+++ b/toolkit/jetpack/sdk/places/host/host-tags.js
@@ -7,6 +7,7 @@
 module.metadata = {
   "stability": "experimental",
   "engines": {
+    "Palemoon": "*",
     "Firefox": "*",
     "SeaMonkey": "*"
   }

--- a/toolkit/jetpack/sdk/places/utils.js
+++ b/toolkit/jetpack/sdk/places/utils.js
@@ -7,6 +7,7 @@
 module.metadata = {
   "stability": "experimental",
   "engines": {
+    "Palemoon": "*",
     "Firefox": "*",
     "SeaMonkey": "*"
   }

--- a/toolkit/jetpack/sdk/selection.js
+++ b/toolkit/jetpack/sdk/selection.js
@@ -7,6 +7,7 @@
 module.metadata = {
   "stability": "stable",
   "engines": {
+    "Palemoon": "*",
     "Firefox": "*",
     "SeaMonkey": "*"
   }

--- a/toolkit/jetpack/sdk/system/xul-app.jsm
+++ b/toolkit/jetpack/sdk/system/xul-app.jsm
@@ -41,6 +41,7 @@ var platformVersion = exports.platformVersion = appInfo.platformVersion;
 // GUID.
 
 var ids = exports.ids = {
+  Palemoon: "{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}",
   Firefox: "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
   Mozilla: "{86c18b42-e466-45a9-ae7a-9b95ba6f5640}",
   SeaMonkey: "{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}",

--- a/toolkit/jetpack/sdk/ui.js
+++ b/toolkit/jetpack/sdk/ui.js
@@ -6,6 +6,7 @@
 module.metadata = {
   'stability': 'experimental',
   'engines': {
+    'Palemoon': '> 27',
     'Firefox': '> 28'
   }
 };

--- a/toolkit/jetpack/sdk/ui.js
+++ b/toolkit/jetpack/sdk/ui.js
@@ -13,6 +13,8 @@ module.metadata = {
 
 exports.ActionButton = require('./ui/button/action').ActionButton;
 exports.ToggleButton = require('./ui/button/toggle').ToggleButton;
+#ifndef MC_PALEMOON
 exports.Sidebar = require('./ui/sidebar').Sidebar;
 exports.Frame = require('./ui/frame').Frame;
 exports.Toolbar = require('./ui/toolbar').Toolbar;
+#endif

--- a/toolkit/jetpack/sdk/ui/button/action.js
+++ b/toolkit/jetpack/sdk/ui/button/action.js
@@ -6,6 +6,7 @@
 module.metadata = {
   'stability': 'experimental',
   'engines': {
+    'Palemoon': '> 27',
     'Firefox': '> 28'
   }
 };

--- a/toolkit/jetpack/sdk/ui/button/toggle.js
+++ b/toolkit/jetpack/sdk/ui/button/toggle.js
@@ -6,6 +6,7 @@
 module.metadata = {
   'stability': 'experimental',
   'engines': {
+    'Palemoon': '> 27',
     'Firefox': '> 28'
   }
 };

--- a/toolkit/jetpack/sdk/ui/button/view.js
+++ b/toolkit/jetpack/sdk/ui/button/view.js
@@ -6,6 +6,7 @@
 module.metadata = {
   'stability': 'experimental',
   'engines': {
+    'Palemoon': '> 27',
     'Firefox': '> 28'
   }
 };

--- a/toolkit/jetpack/sdk/ui/button/view/events.js
+++ b/toolkit/jetpack/sdk/ui/button/view/events.js
@@ -7,6 +7,7 @@
 module.metadata = {
   'stability': 'experimental',
   'engines': {
+    'Palemoon': '*',
     'Firefox': '*',
     'SeaMonkey': '*',
     'Thunderbird': '*'

--- a/toolkit/jetpack/sdk/ui/buttons.js
+++ b/toolkit/jetpack/sdk/ui/buttons.js
@@ -1,0 +1,198 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * PMkit shim for 'sdk/ui/button', (c) JustOff, 2017 */
+"use strict";
+
+module.metadata = {
+  "stability": "experimental",
+  "engines": {
+    "Palemoon": "> 27"
+  }
+};
+
+const { Ci, Cc } = require('chrome');
+const prefs = require('../preferences/service');
+
+const buttonsList = new Map();
+const LOCATION_PREF_ROOT = "extensions.sdk-button-location.";
+
+let gWindowListener;
+
+function getLocation(id) {
+  let toolbarId = "nav-bar", nextItemId = "";
+  let location = prefs.get(LOCATION_PREF_ROOT + id);
+  if (location && location.indexOf(",") !== -1) {
+    [toolbarId, nextItemId] = location.split(",");
+  }
+  return [toolbarId, nextItemId];
+}
+
+function saveLocation(id, toolbarId, nextItemId) {
+  let _toolbarId = toolbarId || "";
+  let _nextItemId = nextItemId || "";
+  prefs.set(LOCATION_PREF_ROOT + id, [_toolbarId, _nextItemId].join(","));
+}
+
+// Insert button into window
+function insertButton(aWindow, id, onBuild) {
+  // Build button and save reference to it
+  let doc = aWindow.document;
+  let b = onBuild(doc, id);
+  aWindow[id] = b;
+
+  // Add to the customization palette
+  let toolbox = doc.getElementById("navigator-toolbox");
+  toolbox.palette.appendChild(b);
+
+  // Retrieve button location from preferences
+  let [toolbarId, nextItemId] = getLocation(id);
+  let toolbar = toolbarId != "" && doc.getElementById(toolbarId);
+
+  if (toolbar) {
+    let nextItem = doc.getElementById(nextItemId);
+    // If nextItem not in toolbar then retrieve it by reading currentset attribute
+    if (!(nextItem && nextItem.parentNode && nextItem.parentNode.id == toolbarId)) {
+      nextItem = null;
+      let currentSet = toolbar.getAttribute("currentset");
+      let ids = (currentSet == "__empty") ? [] : currentSet.split(",");
+      let idx = ids.indexOf(id);
+      if (idx != -1) {
+        for (let i = idx; i < ids.length; i++) {
+          nextItem = doc.getElementById(ids[i]);
+          if (nextItem)
+            break;
+        }
+      }
+    }
+    // Finally insert button in the right toolbar and in the right position
+    toolbar.insertItem(id, nextItem, null, false);
+  }
+}
+
+// Remove button from window
+function removeButton(aWindow, id) {
+  let b = aWindow[id];
+  b.parentNode.removeChild(b);
+  delete aWindow[id];
+}
+
+// Save locations of buttons after customization
+function afterCustomize(e) {
+  for (let [id] of buttonsList) {
+    let toolbox = e.target;
+    let b = toolbox.parentNode.querySelector("#" + id);
+    let toolbarId = null, nextItemId = null;
+    if (b) {
+      let parent = b.parentNode;
+      let nextItem = b.nextSibling;
+      if (parent && parent.localName == "toolbar") {
+        toolbarId = parent.id;
+        nextItemId = nextItem && nextItem.id;
+      }
+    }
+    saveLocation(id, toolbarId, nextItemId);
+  }
+}
+
+// Global window observer
+function browserWindowObserver(handlers) {
+  this.handlers = handlers;
+}
+
+browserWindowObserver.prototype = {
+  observe: function(aSubject, aTopic, aData) {
+    if (aTopic == "domwindowopened") {
+      aSubject.QueryInterface(Ci.nsIDOMWindow).addEventListener("load", this, false);
+    } else if (aTopic == "domwindowclosed") {
+      if (aSubject.document.documentElement.getAttribute("windowtype") == "navigator:browser") {
+        this.handlers.onShutdown(aSubject);
+      }
+    }
+  },
+
+  handleEvent: function(aEvent) {
+    let aWindow = aEvent.currentTarget;
+    aWindow.removeEventListener(aEvent.type, this, false);
+
+    if (aWindow.document.documentElement.getAttribute("windowtype") == "navigator:browser") {
+      this.handlers.onStartup(aWindow);
+    }
+  }
+};
+
+// Run on every window startup
+function browserWindowStartup(aWindow) {
+  for (let [id, onBuild] of buttonsList) {
+    insertButton(aWindow, id, onBuild);
+  }
+  aWindow.addEventListener("aftercustomization", afterCustomize, false);
+};
+
+// Run on every window shutdown
+function browserWindowShutdown(aWindow) {
+  for (let [id, onBuild] of buttonsList) {
+    removeButton(aWindow, id);
+  }
+  aWindow.removeEventListener("aftercustomization", afterCustomize, false);
+}
+
+// Main object
+const buttons = {
+  createButton: function(aProperties) {
+    // If no buttons were inserted yet, setup global window observer
+    if (buttonsList.size == 0) {
+      let ww = Cc["@mozilla.org/embedcomp/window-watcher;1"].getService(Ci.nsIWindowWatcher);
+      gWindowListener = new browserWindowObserver({
+        onStartup: browserWindowStartup,
+        onShutdown: browserWindowShutdown
+      });
+      ww.registerNotification(gWindowListener);
+    }
+
+    // Add button to list
+    buttonsList.set(aProperties.id, aProperties.onBuild);
+
+    // Inster button to all open windows
+    let wm = Cc["@mozilla.org/appshell/window-mediator;1"].getService(Ci.nsIWindowMediator);
+    let winenu = wm.getEnumerator("navigator:browser");
+    while (winenu.hasMoreElements()) {
+      let win = winenu.getNext();
+      insertButton(win, aProperties.id, aProperties.onBuild);
+      // When first button inserted, add afterCustomize listener
+      if (buttonsList.size == 1) {
+        win.addEventListener("aftercustomization", afterCustomize, false);
+      }
+    }
+  },
+
+  destroyButton: function(id) {
+    // Remove button from list
+    buttonsList.delete(id);
+
+    // If no more buttons exist, remove global window observer
+    if (buttonsList.size == 0) {
+      let ww = Cc["@mozilla.org/embedcomp/window-watcher;1"].getService(Ci.nsIWindowWatcher);
+      ww.unregisterNotification(gWindowListener);
+      gWindowListener = null;
+    }
+
+    // Remove button from all open windows
+    let wm = Cc["@mozilla.org/appshell/window-mediator;1"].getService(Ci.nsIWindowMediator);
+    let winenu = wm.getEnumerator("navigator:browser");
+    while (winenu.hasMoreElements()) {
+      let win = winenu.getNext();
+      removeButton(win, id);
+      // If no more buttons exist, remove afterCustomize listener
+      if (buttonsList.size == 0) {
+        win.removeEventListener("aftercustomization", afterCustomize, false);
+      }
+    }
+  },
+
+  getNode: function(id, window) {
+    return window[id];
+  }
+};
+
+exports.buttons = buttons;

--- a/toolkit/jetpack/sdk/ui/state.js
+++ b/toolkit/jetpack/sdk/ui/state.js
@@ -8,6 +8,7 @@
 module.metadata = {
   'stability': 'experimental',
   'engines': {
+    'Palemoon': '*',
     'Firefox': '*',
     'SeaMonkey': '*',
     'Thunderbird': '*'

--- a/toolkit/jetpack/sdk/ui/state/events.js
+++ b/toolkit/jetpack/sdk/ui/state/events.js
@@ -7,6 +7,7 @@
 module.metadata = {
   'stability': 'experimental',
   'engines': {
+    'Palemoon': '*',
     'Firefox': '*',
     'SeaMonkey': '*',
     'Thunderbird': '*'


### PR DESCRIPTION
- Add `Pale Moon` as a target engine to `sdk/system/xul-app.jsm`
- Add `Pale Moon` to `modules/system/Startup.js` (bugs [851426](https://bugzilla.mozilla.org/show_bug.cgi?id=851426) and [1042239](https://bugzilla.mozilla.org/show_bug.cgi?id=1042239))
- Update `module.metadata` with the `Pale Moon` engine where appropriate in `sdk/*`
- Add the `PMkit` shim for `sdk/ui/button` ([PM27#808](https://github.com/MoonchildProductions/Pale-Moon/pull/808), [PM27#818](https://github.com/MoonchildProductions/Pale-Moon/pull/818), [PM27#918](https://github.com/MoonchildProductions/Pale-Moon/pull/918))
- Allow access to `sdk/ui/buttons` via `require('sdk/ui')` ([PM27#811](https://github.com/MoonchildProductions/Pale-Moon/pull/811))

Tag #120.