### PR TITLE
Make Add-on SDK (Jetpack) work on Pale Moon || Part 2

### DIFF
--- a/application/palemoon/base/content/nsContextMenu.js
+++ b/application/palemoon/base/content/nsContextMenu.js
@@ -4,6 +4,8 @@
 
 Components.utils.import("resource://gre/modules/PrivateBrowsingUtils.jsm");
 
+var gContextMenuContentData = null;
+
 function nsContextMenu(aXulMenu, aIsShift) {
   this.shouldDisplay = true;
   this.initMenu(aXulMenu, aIsShift);
@@ -39,6 +41,7 @@ nsContextMenu.prototype = {
   },
 
   hiding: function CM_hiding() {
+    gContextMenuContentData = null;
     InlineSpellCheckerUI.clearSuggestionsFromMenu();
     InlineSpellCheckerUI.clearDictionaryListFromMenu();
     InlineSpellCheckerUI.uninit();

--- a/toolkit/jetpack/moz.build
+++ b/toolkit/jetpack/moz.build
@@ -128,9 +128,10 @@ EXTRA_JS_MODULES.commonjs += [
     'test.js',
 ]
 
-EXTRA_JS_MODULES.commonjs.sdk += [
-    'sdk/webextension.js',
-]
+if not CONFIG['MC_PALEMOON']:
+    EXTRA_JS_MODULES.commonjs.sdk += [
+        'sdk/webextension.js',
+    ]
 
 EXTRA_JS_MODULES.commonjs.dev += [
     'dev/debuggee.js',
@@ -228,13 +229,16 @@ EXTRA_PP_JS_MODULES.commonjs.sdk += [
 ]
 
 EXTRA_JS_MODULES.commonjs.sdk.addon += [
-    'sdk/addon/bootstrap.js',
     'sdk/addon/events.js',
     'sdk/addon/host.js',
     'sdk/addon/installer.js',
     'sdk/addon/manager.js',
     'sdk/addon/runner.js',
     'sdk/addon/window.js',
+]
+
+EXTRA_PP_JS_MODULES.commonjs.sdk.addon += [
+    'sdk/addon/bootstrap.js',
 ]
 
 EXTRA_JS_MODULES.commonjs.sdk.browser += [

--- a/toolkit/jetpack/moz.build
+++ b/toolkit/jetpack/moz.build
@@ -128,7 +128,7 @@ EXTRA_JS_MODULES.commonjs += [
     'test.js',
 ]
 
-if not CONFIG['MC_PALEMOON']:
+if CONFIG['MOZ_WEBEXTENSIONS']:
     EXTRA_JS_MODULES.commonjs.sdk += [
         'sdk/webextension.js',
     ]

--- a/toolkit/jetpack/sdk/addon/bootstrap.js
+++ b/toolkit/jetpack/sdk/addon/bootstrap.js
@@ -134,8 +134,10 @@ Bootstrap.prototype = {
       const main = command === "test" ? "sdk/test/runner" : null;
       const prefsURI = `${baseURI}defaults/preferences/prefs.js`;
 
+#ifndef MC_PALEMOON
       // Init the 'sdk/webextension' module from the bootstrap addon parameter.
       require("sdk/webextension").initFromBootstrapAddonParam(addon);
+#endif
 
       const { startup } = require("sdk/addon/runner");
       startup(reason, {loader, main, prefsURI});

--- a/toolkit/jetpack/sdk/addon/bootstrap.js
+++ b/toolkit/jetpack/sdk/addon/bootstrap.js
@@ -134,7 +134,7 @@ Bootstrap.prototype = {
       const main = command === "test" ? "sdk/test/runner" : null;
       const prefsURI = `${baseURI}defaults/preferences/prefs.js`;
 
-#ifndef MC_PALEMOON
+#ifdef MOZ_WEBEXTENSIONS
       // Init the 'sdk/webextension' module from the bootstrap addon parameter.
       require("sdk/webextension").initFromBootstrapAddonParam(addon);
 #endif


### PR DESCRIPTION
* Provide `gContextMenuContentData` for `sdk/context-menu` (stealed from Basilisk)
* Remove embedded WebExtensions support (bug [1269347](https://bugzilla.mozilla.org/show_bug.cgi?id=1269347))

Tag #120.