### PR TITLE
[PALEMOON] [frontend vs backend] Use "devtools-browser.css" instead of "global/skin/devtools/common.css" (does not exist) in browser.xul

### DIFF
--- a/application/palemoon/base/content/browser.xul
+++ b/application/palemoon/base/content/browser.xul
@@ -13,7 +13,7 @@
 
 <?xml-stylesheet href="chrome://browser/content/places/places.css" type="text/css"?>
 #ifdef MOZ_DEVTOOLS
-<?xml-stylesheet href="chrome://global/skin/devtools/common.css" type="text/css"?>
+<?xml-stylesheet href="chrome://devtools/skin/devtools-browser.css" type="text/css"?>
 #endif
 <?xml-stylesheet href="chrome://browser/skin/" type="text/css"?>
 


### PR DESCRIPTION
Tag #121 and #102 
