### PR TITLE
[DevTools] Fix warnings: "Property contained reference to invalid variable"

### DIFF
--- a/devtools/client/webconsole/webconsole.xul
+++ b/devtools/client/webconsole/webconsole.xul
@@ -7,6 +7,8 @@
 %webConsoleDTD;
 ]>
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="resource://devtools/client/themes/common.css"
+                 type="text/css"?>
 <?xml-stylesheet href="chrome://devtools/skin/widgets.css"
                  type="text/css"?>
 <?xml-stylesheet href="chrome://devtools/skin/webconsole.css"


### PR DESCRIPTION
Tag #121

__Fix warnings:__
```
Warning: Property contained reference to invalid variable.
Error in parsing value for ‘background-color’. Falling back to ‘initial’.
Source File: chrome://devtools/skin/webconsole.css
Line: 406, Column: 9402
Source Code:
var(--theme-tab-toolbar-background)

Warning: Property contained reference to invalid variable.
Error in parsing value for ‘border-top-width’. Falling back to ‘initial’.
Source File: chrome://devtools/skin/webconsole.css
Line: 407, Column: 9459
Source Code:
1px solid var(--theme-splitter-color)

Warning: Property contained reference to invalid variable.
Error in parsing value for ‘border-top-width’. Falling back to ‘initial’.
Source File: chrome://devtools/skin/widgets.css
Line: 84, Column: 2850
Source Code:
var(--devtools-splitter-top-width)

Warning: Property contained reference to invalid variable.
Error in parsing value for ‘border-bottom-width’. Falling back to ‘initial’.
Source File: chrome://devtools/skin/widgets.css
Line: 85, Column: 2908
Source Code:
var(--devtools-splitter-bottom-width)
```
