### PR TITLE
moebius#221: WebExtensions - commands API does not support shortcuts with space or numbers

### DIFF
--- a/browser/components/webextensions/ext-commands.js
+++ b/browser/components/webextensions/ext-commands.js
@@ -163,11 +163,12 @@ CommandList.prototype = {
     // The modifiers are the remaining elements.
     keyElement.setAttribute("modifiers", this.getModifiersAttribute(parts));
 
-    if (/^[A-Z0-9]$/.test(chromeKey)) {
+    if (/^[A-Z]$/.test(chromeKey)) {
       // We use the key attribute for all single digits and characters.
       keyElement.setAttribute("key", chromeKey);
     } else {
       keyElement.setAttribute("keycode", this.getKeycodeAttribute(chromeKey));
+      keyElement.setAttribute("event", "keydown");
     }
 
     return keyElement;
@@ -187,6 +188,9 @@ CommandList.prototype = {
    * @returns {string} The constructed value for the Key's 'keycode' attribute.
    */
   getKeycodeAttribute(chromeKey) {
+    if (/[0-9]/.test(chromeKey)) {
+      return `VK_${chromeKey}`;
+    }
     return `VK${chromeKey.replace(/([A-Z])/g, "_$&").toUpperCase()}`;
   },
 


### PR DESCRIPTION
Tag https://github.com/MoonchildProductions/moebius/pull/221

---

I've created the new build (x32, Windows) - `Basilisk` - and __not tested__.
