### PR TITLE
moebius#121: DOM - Selection API - getSelection() should exist on XMLDocument / Selection.type

### DIFF
--- a/dom/base/nsDocument.cpp
+++ b/dom/base/nsDocument.cpp
@@ -12846,3 +12846,19 @@ nsDocument::CheckCustomElementName(const ElementCreationOptions& aOptions,
 
   return is;
 }
+
+Selection*
+nsIDocument::GetSelection(ErrorResult& aRv)
+{
+  nsCOMPtr<nsPIDOMWindowInner> window = GetInnerWindow();
+  if (!window) {
+    return nullptr;
+  }
+
+  NS_ASSERTION(window->IsInnerWindow(), "Should have inner window here!");
+  if (!window->IsCurrentInnerWindow()) {
+    return nullptr;
+  }
+
+  return nsGlobalWindow::Cast(window)->GetSelection(aRv);
+}

--- a/dom/base/nsIDocument.h
+++ b/dom/base/nsIDocument.h
@@ -151,6 +151,7 @@ class NodeIterator;
 enum class OrientationType : uint32_t;
 class ProcessingInstruction;
 class Promise;
+class Selection;
 class StyleSheetList;
 class SVGDocument;
 class SVGSVGElement;
@@ -897,6 +898,8 @@ public:
    * Return the root element for this document.
    */
   Element* GetRootElement() const;
+
+  mozilla::dom::Selection* GetSelection(mozilla::ErrorResult& aRv);
 
   /**
    * Retrieve information about the viewport as a data structure.

--- a/dom/html/nsHTMLDocument.cpp
+++ b/dom/html/nsHTMLDocument.cpp
@@ -2149,24 +2149,8 @@ NS_IMETHODIMP
 nsHTMLDocument::GetSelection(nsISelection** aReturn)
 {
   ErrorResult rv;
-  NS_IF_ADDREF(*aReturn = GetSelection(rv));
+  NS_IF_ADDREF(*aReturn = nsDocument::GetSelection(rv));
   return rv.StealNSResult();
-}
-
-Selection*
-nsHTMLDocument::GetSelection(ErrorResult& aRv)
-{
-  nsCOMPtr<nsPIDOMWindowInner> window = do_QueryInterface(GetScopeObject());
-  if (!window) {
-    return nullptr;
-  }
-
-  NS_ASSERTION(window->IsInnerWindow(), "Should have inner window here!");
-  if (!window->IsCurrentInnerWindow()) {
-    return nullptr;
-  }
-
-  return nsGlobalWindow::Cast(window)->GetSelection(aRv);
 }
 
 NS_IMETHODIMP

--- a/dom/html/nsHTMLDocument.h
+++ b/dom/html/nsHTMLDocument.h
@@ -242,7 +242,6 @@ public:
   {
     // Deprecated
   }
-  mozilla::dom::Selection* GetSelection(mozilla::ErrorResult& aRv);
   // The XPCOM CaptureEvents works fine for us.
   // The XPCOM ReleaseEvents works fine for us.
   // We're picking up GetLocation from Document

--- a/dom/webidl/Document.webidl
+++ b/dom/webidl/Document.webidl
@@ -430,6 +430,12 @@ partial interface Document {
   void removeAnonymousContent(AnonymousContent aContent);
 };
 
+// http://w3c.github.io/selection-api/#extensions-to-document-interface
+partial interface Document {
+  [Throws]
+  Selection? getSelection();
+};
+
 // Extension to give chrome JS the ability to determine whether
 // the user has interacted with the document or not.
 partial interface Document {

--- a/dom/webidl/HTMLDocument.webidl
+++ b/dom/webidl/HTMLDocument.webidl
@@ -73,10 +73,6 @@ interface HTMLDocument : Document {
 
   readonly attribute HTMLAllCollection all;
 
-  // https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html#selections
-  [Throws]
-  Selection? getSelection();
-
   // @deprecated These are old Netscape 4 methods. Do not use,
   //             the implementation is no-op.
   // XXXbz do we actually need these anymore?

--- a/dom/webidl/Selection.webidl
+++ b/dom/webidl/Selection.webidl
@@ -33,6 +33,7 @@ interface Selection {
   void               deleteFromDocument();
 
   readonly attribute unsigned long rangeCount;
+  readonly attribute DOMString     type;
   [Throws]
   Range              getRangeAt(unsigned long index);
   [Throws]
@@ -77,7 +78,7 @@ partial interface Selection {
   void  removeSelectionListener(nsISelectionListener listenerToRemove);
 
   [ChromeOnly,BinaryName="rawType"]
-  readonly attribute short type;
+  readonly attribute short selectionType;
 
   [ChromeOnly,Throws,Pref="dom.testing.selection.GetRangesForInterval"]
   sequence<Range> GetRangesForInterval(Node beginNode, long beginOffset, Node endNode, long endOffset,

--- a/layout/generic/Selection.h
+++ b/layout/generic/Selection.h
@@ -179,6 +179,9 @@ public:
   {
     return mRanges.Length();
   }
+
+  void GetType(nsAString& aOutType) const;
+
   nsRange* GetRangeAt(uint32_t aIndex, mozilla::ErrorResult& aRv);
   void AddRange(nsRange& aRange, mozilla::ErrorResult& aRv);
   void RemoveRange(nsRange& aRange, mozilla::ErrorResult& aRv);

--- a/layout/generic/nsSelection.cpp
+++ b/layout/generic/nsSelection.cpp
@@ -5349,6 +5349,18 @@ Selection::GetRangeCount(int32_t* aRangeCount)
   return NS_OK;
 }
 
+void
+Selection::GetType(nsAString& aOutType) const
+{
+  if (!RangeCount()) {
+    aOutType.AssignLiteral("None");
+  } else if (IsCollapsed()) {
+    aOutType.AssignLiteral("Caret");
+  } else {
+    aOutType.AssignLiteral("Range");
+  }
+}
+
 NS_IMETHODIMP
 Selection::GetRangeAt(int32_t aIndex, nsIDOMRange** aReturn)
 {

--- a/testing/web-platform/meta/selection/getSelection.html.ini
+++ b/testing/web-platform/meta/selection/getSelection.html.ini
@@ -1,14 +1,5 @@
 [getSelection.html]
   type: testharness
-  [getSelection() on HTML document with null defaultView must be null]
-    expected: FAIL
-
-  [getSelection() on XML document with null defaultView must be null]
-    expected: FAIL
-
-  [getSelection() on HTML document with null defaultView must be null inside an iframe onload]
-    expected: FAIL
-
   [window.getSelection() instanceof Selection in an iframe immediately after appendChild]
     expected: FAIL
 


### PR DESCRIPTION
Tag https://github.com/MoonchildProductions/moebius/pull/121

---

I've created the new build (x32, Windows) - `Basilisk` - and tested.
