### PR TITLE
Fix accessing the bootstrap methods when they are declared in the new lexical scope

### DIFF
--- a/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+++ b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
@@ -4436,7 +4436,18 @@ this.XPIProvider = {
       if (aAddon.type == "locale")
         return;
 
-      if (!(aMethod in this.bootstrapScopes[aAddon.id])) {
+      let method = undefined;
+      try {
+        method = Components.utils.evalInSandbox(`${aMethod};`,
+                                                this.bootstrapScopes[aAddon.id],
+                                                "ECMAv5");
+      }
+      catch (e) {
+        // An exception will be caught if the expected method is not defined.
+        // That will be logged below.
+      }
+
+      if (!method) {
         logger.warn("Add-on " + aAddon.id + " is missing bootstrap method " + aMethod);
         return;
       }
@@ -4455,9 +4466,9 @@ this.XPIProvider = {
       }
 
       logger.debug("Calling bootstrap method " + aMethod + " on " + aAddon.id + " version " +
-          aAddon.version);
+                  aAddon.version);
       try {
-        this.bootstrapScopes[aAddon.id][aMethod](params, aReason);
+        method(params, aReason);
       }
       catch (e) {
         logger.warn("Exception running bootstrap method " + aMethod + " on " + aAddon.id, e);

--- a/toolkit/mozapps/extensions/test/addons/test_bootstrap_const/bootstrap.js
+++ b/toolkit/mozapps/extensions/test/addons/test_bootstrap_const/bootstrap.js
@@ -1,0 +1,5 @@
+Components.utils.import("resource://gre/modules/Services.jsm");
+
+const install = function() {
+  Services.obs.notifyObservers(null, "addon-install", "");
+}

--- a/toolkit/mozapps/extensions/test/addons/test_bootstrap_const/install.rdf
+++ b/toolkit/mozapps/extensions/test/addons/test_bootstrap_const/install.rdf
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+
+<RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:em="http://www.mozilla.org/2004/em-rdf#">
+
+  <Description about="urn:mozilla:install-manifest">
+    <em:id>bootstrap@tests.mozilla.org</em:id>
+    <em:version>1.0</em:version>
+    <em:bootstrap>true</em:bootstrap>
+
+    <!-- Front End MetaData -->
+    <em:name>Test Bootstrap</em:name>
+    <em:description>Test Description</em:description>
+
+    <em:targetApplication>
+      <Description>
+        <em:id>xpcshell@tests.mozilla.org</em:id>
+        <em:minVersion>1</em:minVersion>
+        <em:maxVersion>1</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+
+  </Description>
+</RDF>

--- a/toolkit/mozapps/extensions/test/xpcshell/test_bootstrap_const.js
+++ b/toolkit/mozapps/extensions/test/xpcshell/test_bootstrap_const.js
@@ -1,0 +1,17 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+createAppInfo("xpcshell@tests.mozilla.org", "XPCShell", "1", "1");
+startupManager();
+
+add_task(function*() {
+  let sawInstall = false;
+  Services.obs.addObserver(function() {
+    sawInstall = true;
+  }, "addon-install", false);
+
+  yield promiseInstallAllFiles([do_get_addon("test_bootstrap_const")]);
+
+  ok(sawInstall);
+});

--- a/toolkit/mozapps/extensions/test/xpcshell/xpcshell-shared.ini
+++ b/toolkit/mozapps/extensions/test/xpcshell/xpcshell-shared.ini
@@ -29,6 +29,7 @@ skip-if = os == "android"
 [test_bootstrap.js]
 # Bug 676992: test consistently hangs on Android
 skip-if = os == "android"
+[test_bootstrap_const.js]
 [test_bootstrap_resource.js]
 [test_bug299716.js]
 # Bug 676992: test consistently hangs on Android


### PR DESCRIPTION
Based on [bug 1217070](https://bugzilla.mozilla.org/show_bug.cgi?id=1217070).

Tag #155.