### PR TITLE
[fix typo] palemoon#903 and #975: Customizable toolbars - persist the attribute "collapsed" (backward compatible)

### DIFF
--- a/toolkit/content/widgets/toolbar.xml
+++ b/toolkit/content/widgets/toolbar.xml
@@ -54,7 +54,7 @@
           // Look to see if there is a toolbarset.
           this.toolbarset = this.firstChild;
           while (this.toolbarset && this.toolbarset.localName != "toolbarset") {
-            this.toolbarset = toolbarset.nextSibling;
+            this.toolbarset = this.toolbarset.nextSibling;
           }
 
           if (this.toolbarset) {


### PR DESCRIPTION
Tags:

https://github.com/MoonchildProductions/Pale-Moon/pull/903
https://github.com/MoonchildProductions/Pale-Moon/pull/975

Also:
https://github.com/MoonchildProductions/UXP/issues/242

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
