### PR TITLE
[PALEMOON] [frontend vs backend] Fix sanitize ("History" - "Clear Recent History...")

### DIFF
--- a/application/palemoon/base/content/sanitize.js
+++ b/application/palemoon/base/content/sanitize.js
@@ -148,7 +148,8 @@ Sanitizer.prototype = {
 
             if (cookie.creationTime > this.range[0])
               // This cookie was created after our cutoff, clear it
-              cookieMgr.remove(cookie.host, cookie.name, cookie.path, false);
+              cookieMgr.remove(cookie.host, cookie.name, cookie.path,
+                               false, cookie.originAttributes);
           }
         }
         else {
@@ -213,10 +214,16 @@ Sanitizer.prototype = {
     history: {
       clear: function ()
       {
-        if (this.range)
-          PlacesUtils.history.removeVisitsByTimeframe(this.range[0], this.range[1]);
-        else
-          PlacesUtils.history.removeAllPages();
+        if (this.range) {
+          PlacesUtils.history.removeVisitsByFilter({
+            beginDate: new Date(this.range[0] / 1000),
+            endDate: new Date(this.range[1] / 1000)
+          }).catch(Components.utils.reportError);;
+        } else {
+          // Remove everything.
+          PlacesUtils.history.clear()
+          .catch(Components.utils.reportError);
+        }
 
         try {
           var os = Components.classes["@mozilla.org/observer-service;1"]


### PR DESCRIPTION
Tag #121 

Throws an errors:
```
Error sanitizing history: TypeError:
PlacesUtils.history.removeAllPages is not a function
sanitize.js:89
```
```
“nsICookieManager.remove()” is changed.
Update your code and pass the correct originAttributes.
Read more on MDN: 
https://developer.mozilla.org/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsICookieManager
sanitize.js:148:14
```

Bug(s):
- [Bug 1089695](https://bugzilla.mozilla.org/show_bug.cgi?id=1089695)
  - Port sanitize.js to History.removeByFilter
- [Bug 1245184](https://bugzilla.mozilla.org/show_bug.cgi?id=1245184)
  - nsICookieManager.remove should use the OriginAttributes
- [Bug 1259169](https://bugzilla.mozilla.org/show_bug.cgi?id=1259169)
  - nsICookieManager::remove() should be back-compatible

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
