### PR TITLE
palemoon#583 and #1071: Fix: Plugin placeholder image/text (ask to activate) missing + overlay

### DIFF
--- a/toolkit/pluginproblem/content/pluginProblemBinding.css
+++ b/toolkit/pluginproblem/content/pluginProblemBinding.css
@@ -19,6 +19,11 @@ object:-moz-handler-crashed,
 object:-moz-handler-clicktoplay,
 object:-moz-handler-vulnerable-updatable,
 object:-moz-handler-vulnerable-no-update {
+%ifdef MC_PALEMOON
+  /* Initialize the overlay with visibility:hidden to prevent flickering if
+   * the plugin is too small to show the overlay */
+    visibility: hidden;
+%endif
     display: inline-block;
     overflow: hidden;
     opacity: 1 !important;

--- a/toolkit/pluginproblem/content/pluginProblemContent.css
+++ b/toolkit/pluginproblem/content/pluginProblemContent.css
@@ -51,6 +51,7 @@ a .mainBox:focus,
   line-height: initial;
 }
 
+%ifndef MC_PALEMOON
 /* Initialize the overlay with visibility:hidden to prevent flickering if
 * the plugin is too small to show the overlay */
 .mainBox > .hoverBox,
@@ -62,6 +63,7 @@ a .mainBox:focus,
 .visible > .closeIcon {
   visibility: visible;
 }
+%endif
 
 .mainBox[chromedir="rtl"] {
   direction: rtl;
@@ -97,6 +99,10 @@ a .msgTapToPlay,
 :-moz-handler-blocked .msgBlocked,
 :-moz-handler-crashed .msgCrashed {
   display: block;
+  position: relative;
+  left: 0;
+  top: 0;
+  z-index: 9999;
 }
 
 .submitStatus[status] {

--- a/toolkit/pluginproblem/jar.mn
+++ b/toolkit/pluginproblem/jar.mn
@@ -5,6 +5,6 @@
 toolkit.jar:
 % content pluginproblem %pluginproblem/ contentaccessible=yes
   pluginproblem/pluginProblem.xml                 (content/pluginProblem.xml)
-  pluginproblem/pluginProblemContent.css          (content/pluginProblemContent.css)
-  pluginproblem/pluginProblemBinding.css          (content/pluginProblemBinding.css)
+* pluginproblem/pluginProblemContent.css          (content/pluginProblemContent.css)
+* pluginproblem/pluginProblemBinding.css          (content/pluginProblemBinding.css)
   pluginproblem/pluginReplaceBinding.css          (content/pluginReplaceBinding.css)


### PR DESCRIPTION
Tags:
https://github.com/MoonchildProductions/Pale-Moon/pull/583
https://github.com/MoonchildProductions/Pale-Moon/pull/1071

---

I've created the new build (x32, Windows) - `Basilisk` / `Pale Moon UXP` - and tested.

---

An example:
http://www.wickham43.net/flashvideo.php

`Pale Moon UXP:`

__Before:__

![_old](https://user-images.githubusercontent.com/2373486/39203890-a9faf51c-47e5-11e8-8e05-f04d96f33258.png)

__After:__

![_new](https://user-images.githubusercontent.com/2373486/39203896-ae389e72-47e5-11e8-93d9-deb2cd3f2e8a.png)
