### PR TITLE
[PALEMOON] [frontend vs backend] Fix of non-existent CSS files

### DIFF
--- a/toolkit/themes/linux/global/inContentUI.css
+++ b/toolkit/themes/linux/global/inContentUI.css
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * The default namespace for this file is XUL. Be sure to prefix rules that
+ * are applicable to both XUL and HTML with '*|'.
+ */
+@namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
+@namespace html url("http://www.w3.org/1999/xhtml");
+
+/* Page background */
+*|*:root {
+  -moz-appearance: none;
+  padding: 18px;
+  background-color: Window;
+  background-image: /* Texture */
+                    url("chrome://global/skin/inContentUI/background-texture.png");
+  color: WindowText;
+}
+
+/* Use the new in-content colors for #contentAreaDownloadsView. After landing
+   of bug 989469 the colors can be moved to *|*:root */
+*|*#contentAreaDownloadsView {
+  background: #f1f1f1;
+  color: #424e5a;
+}
+
+html|html {
+  font: message-box;
+}
+
+/* Content */
+*|*.main-content {
+  /* Needed to allow the radius to clip the inner content, see bug 595656 */
+  overflow: hidden;
+  background-color: -moz-Field;
+  color: -moz-FieldText;
+  border: 1px solid ThreeDShadow;
+  border-radius: 5px;
+}

--- a/toolkit/themes/linux/global/jar.mn
+++ b/toolkit/themes/linux/global/jar.mn
@@ -16,6 +16,7 @@ toolkit.jar:
    skin/classic/global/findBar.css
    skin/classic/global/global.css
    skin/classic/global/groupbox.css
+   skin/classic/global/inContentUI.css
    skin/classic/global/listbox.css
    skin/classic/global/menu.css
    skin/classic/global/menulist.css

--- a/toolkit/themes/osx/global/inContentUI.css
+++ b/toolkit/themes/osx/global/inContentUI.css
@@ -1,0 +1,144 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+%include shared.inc
+
+/*
+ * The default namespace for this file is XUL. Be sure to prefix rules that
+ * are applicable to both XUL and HTML with '*|'.
+ */
+@namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
+@namespace html url("http://www.w3.org/1999/xhtml");
+
+/* Page background */
+*|*:root {
+  -moz-appearance: none;
+  padding: 18px;
+  background-image: /* Texture */
+                    url("chrome://global/skin/inContentUI/background-texture.png"),
+                    /* Gradient */
+                    linear-gradient(#ADB5C2, #BFC6D1);
+}
+
+/* Use the new in-content colors for #contentAreaDownloadsView. After landing
+   of bug 989469 the colors can be moved to *|*:root */
+*|*#contentAreaDownloadsView {
+  background: #f1f1f1;
+  color: #424e5a;
+}
+
+html|html {
+  font: message-box;
+}
+
+/* Content */
+*|*.main-content {
+  /* Needed to allow the radius to clip the inner content, see bug 595656 */
+  overflow: hidden;
+  background-image: linear-gradient(rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.25) 50%, rgba(255, 255, 255, 0.05));
+  border: 1px solid rgba(50, 65, 92, 0.4);
+  border-radius: 5px;
+}
+
+/* Buttons */
+*|button,
+menulist,
+colorpicker[type="button"] {
+  -moz-appearance: none;
+  padding: 1px 4px;
+  min-width: 60px;
+  border-radius: 3px;
+  border: 1px solid rgba(60,73,97,0.5);
+  box-shadow: inset 0 1px rgba(255,255,255,0.25), 0 1px rgba(255,255,255,0.25);
+  background-color: transparent;
+  background-image: linear-gradient(rgba(255,255,255,0.45), rgba(255,255,255,0.2));
+  background-clip: padding-box;
+  color: #252F3B;
+  text-shadow: @loweredShadow@;
+}
+
+button:-moz-focusring > .button-box,
+menulist:-moz-focusring:not([open="true"]) > .menulist-label-box,
+colorpicker[type="button"]:-moz-focusring:not([open="true"]) > .colorpicker-button-colorbox {
+  outline: 1px dotted #252F3B;
+}
+
+html|button[disabled],
+button[disabled="true"],
+menulist[disabled="true"],
+colorpicker[type="button"][disabled="true"] {
+  opacity: 0.8;
+  color: #505050;
+}
+
+html|button:not([disabled]):active:hover,
+button:not([disabled="true"]):active:hover,
+menulist[open="true"]:not([disabled="true"]),
+colorpicker[type="button"][open="true"]:not([disabled="true"]) {
+  box-shadow: inset 0 1px 3px rgba(0,0,0,.2), 0 1px rgba(255,255,255,0.25);
+  background-image: linear-gradient(rgba(45,54,71,0.3), rgba(45,54,71,0.1));
+  border-color: rgba(60,73,97,0.7);
+}
+
+menulist {
+  -moz-padding-end: 0;
+  margin-left: 5px;
+  margin-right: 5px;
+}
+
+/* Tweak margins so the focus ring is in the right place. */
+menulist > .menulist-label-box {
+  -moz-margin-end: 3px;
+  margin-top: 1px;
+}
+
+menulist > .menulist-label-box > .menulist-label {
+  margin-top: 0px !important;
+  margin-bottom: 0px !important;
+}
+
+menulist > .menulist-dropmarker {
+  -moz-appearance: none;
+  display: -moz-box;
+  background: transparent;
+  border: none;
+  -moz-border-start: 1px solid rgba(60,73,97,0.5);
+  margin-top: -1px;
+  margin-bottom: -1px;
+}
+
+colorpicker[type="button"] {
+  margin: 1px 5px 2px 5px;
+  padding: 3px;
+  height: 25px;
+}
+
+spinbuttons {
+  -moz-appearance: none;
+}
+
+spinbuttons > .spinbuttons-box > .spinbuttons-button {
+  min-width: 12px;
+}
+
+.spinbuttons-button > .button-box > .button-text {
+  display: none;
+}
+
+.spinbuttons-button[disabled="true"] > .button-box > .button-icon {
+  opacity: 0.5;
+}
+
+spinbuttons > .spinbuttons-box > .spinbuttons-up {
+  list-style-image: url("chrome://global/skin/arrow/arrow-up.gif");
+  border-bottom-width: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+spinbuttons > .spinbuttons-box > .spinbuttons-down {
+  list-style-image: url("chrome://global/skin/arrow/arrow-dn.gif");
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}

--- a/toolkit/themes/osx/global/jar.mn
+++ b/toolkit/themes/osx/global/jar.mn
@@ -21,6 +21,7 @@ toolkit.jar:
 * skin/classic/global/findBar.css
 * skin/classic/global/global.css
   skin/classic/global/groupbox.css
+  skin/classic/global/inContentUI.css
   skin/classic/global/linkTree.css
   skin/classic/global/listbox.css
   skin/classic/global/menu.css

--- a/toolkit/themes/osx/global/jar.mn
+++ b/toolkit/themes/osx/global/jar.mn
@@ -21,7 +21,7 @@ toolkit.jar:
 * skin/classic/global/findBar.css
 * skin/classic/global/global.css
   skin/classic/global/groupbox.css
-  skin/classic/global/inContentUI.css
+* skin/classic/global/inContentUI.css
   skin/classic/global/linkTree.css
   skin/classic/global/listbox.css
   skin/classic/global/menu.css

--- a/toolkit/themes/windows/global/inContentUI.css
+++ b/toolkit/themes/windows/global/inContentUI.css
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * The default namespace for this file is XUL. Be sure to prefix rules that
+ * are applicable to both XUL and HTML with '*|'.
+ */
+@namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
+@namespace html url("http://www.w3.org/1999/xhtml");
+
+/* Page background */
+*|*:root {
+  -moz-appearance: none;
+  padding: 18px;
+  background-repeat: repeat;
+  color: -moz-dialogText;
+  background-color: -moz-dialog;
+  background-image: /* Texture */
+                    url("chrome://global/skin/inContentUI/background-texture.png");
+}
+
+html|html {
+  font: message-box;
+}
+
+@media (-moz-windows-default-theme) and (-moz-os-version: windows-vista),
+       (-moz-windows-default-theme) and (-moz-os-version: windows-win7) {
+  *|*:root {
+    color: #000;
+    background-color: #CCD9EA;
+  }
+}
+
+@media (-moz-windows-glass) {
+  *|*:root {
+    /* Blame shorlander for this monstrosity. */
+    background-image: /* Side gradients */
+                      linear-gradient(to right,
+                                      rgba(255,255,255,0.2), transparent 40%,
+                                      transparent 60%, rgba(255,255,255,0.2)),
+                      /* Aero-style light beams */
+                      -moz-linear-gradient(left 32deg,
+                                           /* First light beam */
+                                           transparent 19.5%, rgba(255,255,255,0.1) 20%,
+                                           rgba(255,255,255,0.1) 21.5%, rgba(255,255,255,0.2) 22%,
+                                           rgba(255,255,255,0.2) 25.5%, rgba(255,255,255,0.1) 26%,
+                                           rgba(255,255,255,0.1) 27.5%, transparent 28%,
+                                           /* Second light beam */
+                                           transparent 49.5%, rgba(255,255,255,0.1) 50%,
+                                           rgba(255,255,255,0.1) 52.5%, rgba(255,255,255,0.2) 53%,
+                                           rgba(255,255,255,0.2) 54.5%, rgba(255,255,255,0.1) 55%,
+                                           rgba(255,255,255,0.1) 57.5%, transparent 58%,
+                                           /* Third light beam */
+                                           transparent 87%, rgba(255,255,255,0.2) 90%),
+                      /* Texture */
+                      url("chrome://global/skin/inContentUI/background-texture.png");
+  }
+}
+
+/* Use the new in-content colors for #contentAreaDownloadsView. After landing
+   of bug 989469 the colors can be moved to *|*:root */
+*|*#contentAreaDownloadsView {
+  background: #f1f1f1;
+  color: #424e5a;
+}
+
+/* Content */
+*|*.main-content {
+  /* Needed to allow the radius to clip the inner content, see bug 595656 */
+  overflow: hidden;
+  background-color: rgba(255, 255, 255, 0.35);
+  background-image: linear-gradient(rgba(255, 255, 255, 0),
+                                    rgba(255, 255, 255, 0.75));
+  border: 1px solid #C3CEDF;
+}
+
+%ifdef XP_WIN
+@media (-moz-os-version: windows-vista),
+       (-moz-os-version: windows-win7) {
+%endif
+  *|*.main-content {
+    border-radius: 5px;
+  }
+%ifdef XP_WIN
+}
+%endif
+
+@media (-moz-windows-glass) {
+  /* Buttons */
+  *|button,
+  menulist,
+  colorpicker[type="button"] {
+    -moz-appearance: none;
+    color: black;
+    padding: 0 5px;
+    background: linear-gradient(rgba(251, 252, 253, 0.95), transparent 49%, 
+                                rgba(211, 212, 213, 0.45) 51%, rgba(225, 226, 229, 0.3));
+    background-clip: padding-box;
+    border-radius: 3px;
+    border: 1px solid rgba(31, 64, 100, 0.4);
+    border-top-color: rgba(31, 64, 100, 0.3);
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.25) inset,
+                0 0 2px 1px rgba(255, 255, 255, 0.25) inset;
+  }
+
+  menulist {
+    -moz-padding-end: 0;
+  }
+
+  colorpicker[type="button"]:-moz-focusring:not([open="true"]) > .colorpicker-button-colorbox {
+    outline: 1px dotted ThreeDDarkShadow;
+  }
+
+  html|button[disabled],
+  button[disabled="true"],
+  menulist[disabled="true"],
+  colorpicker[type="button"][disabled="true"] {
+    -moz-border-top-colors: rgba(31, 64, 100, 0.3) !important;
+    -moz-border-right-colors: rgba(31, 64, 100, 0.4) !important;
+    -moz-border-bottom-colors: rgba(31, 64, 100, 0.4) !important;
+    -moz-border-left-colors: rgba(31, 64, 100, 0.4) !important;
+    opacity: 0.8;
+    color: #505050;
+  }
+
+  html|button:not([disabled]):active:hover,
+  button:not([disabled="true"]):active:hover,
+  menulist[open="true"]:not([disabled="true"]),
+  colorpicker[type="button"][open="true"]:not([disabled="true"]) {
+    background-color: rgba(61, 76, 92, 0.2);
+    border-color: rgba(39, 53, 68, 0.5);
+    box-shadow: 0 0 3px 1px rgba(39, 53, 68, 0.2) inset;
+  }
+
+  button > .button-box {
+    padding: 1px !important;
+  }
+
+  spinbuttons > .spinbuttons-box > .spinbuttons-button {
+    border-radius: 0;
+    padding: 0 4px;
+  }
+
+  spinbuttons > .spinbuttons-box > .spinbuttons-up {
+    list-style-image: url("chrome://global/skin/arrow/arrow-up.gif");
+    border-bottom-width: 0;
+  }
+
+  spinbuttons > .spinbuttons-box > .spinbuttons-down {
+    list-style-image: url("chrome://global/skin/arrow/arrow-dn.gif");
+  }
+}
+
+colorpicker[type="button"] {
+  margin: 1px 5px 2px 5px;
+  padding: 3px;
+  height: 25px;
+}

--- a/toolkit/themes/windows/global/jar.mn
+++ b/toolkit/themes/windows/global/jar.mn
@@ -27,7 +27,7 @@ toolkit.jar:
   skin/classic/global/console/itemSelected.png             (console/itemSelected.png)
   skin/classic/global/findBar.css
 * skin/classic/global/global.css
-  skin/classic/global/inContentUI.css
+* skin/classic/global/inContentUI.css
   skin/classic/global/listbox.css
   skin/classic/global/netError.css
   skin/classic/global/numberbox.css

--- a/toolkit/themes/windows/global/jar.mn
+++ b/toolkit/themes/windows/global/jar.mn
@@ -27,6 +27,7 @@ toolkit.jar:
   skin/classic/global/console/itemSelected.png             (console/itemSelected.png)
   skin/classic/global/findBar.css
 * skin/classic/global/global.css
+  skin/classic/global/inContentUI.css
   skin/classic/global/listbox.css
   skin/classic/global/netError.css
   skin/classic/global/numberbox.css


### PR DESCRIPTION
Tag #121

`inContentUI.css` no longer exists.

__Before:__

![_old](https://user-images.githubusercontent.com/2373486/39333404-4133438e-499a-11e8-8a46-c285ccdc32c7.png)

__After:__

![_new](https://user-images.githubusercontent.com/2373486/39344199-7ae97734-49d0-11e8-8587-9ce5ae0c2939.png)

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
