### PR TITLE
Provide LoadInfo for NewChannel() call in 'about' protocol handler

### DIFF
--- a/application/palemoon/components/about/AboutRedirector.cpp
+++ b/application/palemoon/components/about/AboutRedirector.cpp
@@ -137,8 +137,13 @@ AboutRedirector::NewChannel(nsIURI* aURI,
   for (int i = 0; i < kRedirTotal; i++) {
     if (!strcmp(path.get(), kRedirMap[i].id)) {
       nsCOMPtr<nsIChannel> tempChannel;
-      rv = ioService->NewChannel(nsDependentCString(kRedirMap[i].url),
-                                 nullptr, nullptr, getter_AddRefs(tempChannel));
+      nsCOMPtr<nsIURI> tempURI;
+      rv = NS_NewURI(getter_AddRefs(tempURI),
+                     nsDependentCString(kRedirMap[i].url));
+      NS_ENSURE_SUCCESS(rv, rv);
+      rv = NS_NewChannelInternal(getter_AddRefs(tempChannel),
+                                 tempURI,
+                                 aLoadInfo);
       NS_ENSURE_SUCCESS(rv, rv);
 
       tempChannel->SetOriginalURI(aURI);


### PR DESCRIPTION
This addresses the following warnings in `about:permissions`:
```
Warning: ‘nsIOService::NewChannel()’ deprecated, please use ‘nsIOService::NewChannel2()’  SessionStore.jsm:3226:8
Warning: ‘nsIAboutModule->newChannel(aURI)’ deprecated, please use ‘nsIAboutModule->newChannel(aURI, aLoadInfo)’  SessionStore.jsm:3226:8
Warning: ‘nsIOService::NewChannel()’ deprecated, please use ‘nsIOService::NewChannel2()’  browser.js:9146:4
Warning: ‘nsIAboutModule->newChannel(aURI)’ deprecated, please use ‘nsIAboutModule->newChannel(aURI, aLoadInfo)’  browser.js:9146:4
```
Based on bugs [1087442](https://bugzilla.mozilla.org/show_bug.cgi?id=1087442) and [1119005](https://bugzilla.mozilla.org/show_bug.cgi?id=1119005).

See also #143, tag #121.