### PR TITLE
[DevTools] Storage inspector throws an error when use arrow keys

### DIFF
--- a/devtools/client/shared/widgets/TableWidget.js
+++ b/devtools/client/shared/widgets/TableWidget.js
@@ -463,7 +463,14 @@ TableWidget.prototype = {
       return;
     }
 
-    let selectedCell = this.tbody.querySelector(".theme-selected");
+    // We need to get the first *visible* selected cell. Some columns are hidden
+    // e.g. because they contain a unique compound key for cookies that is never
+    // displayed in the UI. To do this we get all selected cells and filter out
+    // any that are hidden.
+    let selectedCells = [...this.tbody.querySelectorAll(".theme-selected")]
+                                      .filter(cell => cell.clientWidth > 0);
+    // Select the first visible selected cell.
+    let selectedCell = selectedCells[0];
     if (!selectedCell) {
       return;
     }


### PR DESCRIPTION
Issue #102 

__Steps to reproduce:__

- Go to: `https://github.com/`
- `Tools` - `Web Developer` - `Storage inspector`
- `Cookies` - select a row
- Press the arrow key:

DOM_VK_UP
Throws an error in Browser Console:
```
TypeError: cell is undefined TableWidget.js:523:9
```

DOM_VK_DOWN
Throws an error in Browser Console:
```
TypeError: cell is undefined TableWidget.js:541:9
```

Bug(s):
https://bugzilla.mozilla.org/show_bug.cgi?id=1433844

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
