### PR TITLE
[PALEMOON] [DevTools] Storage inspector throws an error when url changes

### DIFF
--- a/application/palemoon/base/content/newtab/grid.js
+++ b/application/palemoon/base/content/newtab/grid.js
@@ -59,8 +59,13 @@ var gGrid = {
    * Refreshes the grid and re-creates all sites.
    */
   refresh: function Grid_refresh() {
+    let cells = this.cells;
+    if (!cells) {
+      return;
+    }
+
     // Remove all sites.
-    this.cells.forEach(function (cell) {
+    cells.forEach(function (cell) {
       let node = cell.node;
       let child = node.firstElementChild;
 


### PR DESCRIPTION
Issue #102 

__Steps to reproduce:__

- Go to: `about:newtab`
- `Tools` - `Web Developer` - `Storage inspector`
- Go to: `https://github.com/`

Throws an error in Browser Console:
```
this.cells is null  newTab.js:489
```

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
