### PR TITLE
[PALEMOON] [DevTools] Storage inspector throws "AddonPathService.mapURIToAddonId is not a function" when url changes

### DIFF
--- a/toolkit/mozapps/extensions/AddonPathService.cpp
+++ b/toolkit/mozapps/extensions/AddonPathService.cpp
@@ -128,6 +128,16 @@ AddonPathService::InsertPath(const nsAString& path, const nsAString& addonIdStri
   return NS_OK;
 }
 
+NS_IMETHODIMP
+AddonPathService::MapURIToAddonId(nsIURI* aURI, nsAString& addonIdString)
+{
+  if (JSAddonId* id = MapURIToAddonID(aURI)) {
+    JSFlatString* flat = JS_ASSERT_STRING_IS_FLAT(JS::StringOfAddonId(id));
+    AssignJSFlatString(addonIdString, flat);
+  }
+  return NS_OK;
+}
+
 static nsresult
 ResolveURI(nsIURI* aURI, nsAString& out)
 {

--- a/toolkit/mozapps/extensions/amIAddonPathService.idl
+++ b/toolkit/mozapps/extensions/amIAddonPathService.idl
@@ -5,6 +5,8 @@
 
 #include "nsISupports.idl"
 
+interface nsIURI;
+
 /**
  * This service maps file system paths where add-ons reside to the ID
  * of the add-on. Paths are added by the add-on manager. They can
@@ -26,4 +28,10 @@ interface amIAddonPathService : nsISupports
    * associated with the given add-on ID.
    */
   void insertPath(in AString path, in AString addonId);
+
+  /**
+   * Given a URI to a file, return the ID of the add-on that the file belongs
+   * to. Returns an empty string if there is no add-on there.
+   */
+  AString mapURIToAddonId(in nsIURI aURI);
 };

--- a/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+++ b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
@@ -52,6 +52,10 @@ XPCOMUtils.defineLazyServiceGetter(this,
                                    "ResProtocolHandler",
                                    "@mozilla.org/network/protocol;1?name=resource",
                                    "nsIResProtocolHandler");
+XPCOMUtils.defineLazyServiceGetter(this,
+                                   "AddonPathService",
+                                   "@mozilla.org/addon-path-service;1",
+                                   "amIAddonPathService");
 
 const nsIFile = Components.Constructor("@mozilla.org/file/local;1", "nsIFile",
                                        "initWithPath");
@@ -1887,8 +1891,7 @@ this.XPIProvider = {
     logger.info("Mapping " + aID + " to " + aFile.path);
     this._addonFileMap.set(aID, aFile.path);
 
-    let service = Cc["@mozilla.org/addon-path-service;1"].getService(Ci.amIAddonPathService);
-    service.insertPath(aFile.path, aID);
+    AddonPathService.insertPath(aFile.path, aID);
   },
 
   /**
@@ -3916,16 +3919,8 @@ this.XPIProvider = {
    * @see    amIAddonManager.mapURIToAddonID
    */
   mapURIToAddonID: function XPI_mapURIToAddonID(aURI) {
-    let resolved = this._resolveURIToFile(aURI);
-    if (!resolved || !(resolved instanceof Ci.nsIFileURL))
-      return null;
-
-    for (let [id, path] of this._addonFileMap) {
-      if (resolved.file.path.startsWith(path))
-        return id;
-    }
-
-    return null;
+    // Returns `null` instead of empty string if the URI can't be mapped.
+    return AddonPathService.mapURIToAddonId(aURI) || null;
   },
 
   /**

--- a/toolkit/mozapps/extensions/test/xpcshell/test_mapURIToAddonID.js
+++ b/toolkit/mozapps/extensions/test/xpcshell/test_mapURIToAddonID.js
@@ -95,8 +95,10 @@ function run_test_early() {
         "resource://gre/modules/addons/XPIProvider.jsm", {});
 
       // Make the early API call.
-      do_check_null(s.XPIProvider.mapURIToAddonID(uri));
+      // AddonManager still misses its provider and so doesn't work yet.
       do_check_null(AddonManager.mapURIToAddonID(uri));
+      // But calling XPIProvider directly works immediately
+      do_check_eq(s.XPIProvider.mapURIToAddonID(uri), id);
 
       // Actually start up the manager.
       startupManager(false);


### PR DESCRIPTION
__Steps to reproduce:__

- Go to: `about:newtab`
- `Tools` - `Web Developer` - `Storage inspector`
- Go to: `https://github.com/`

Throws an error in Browser Console:
```
"mapURIToAddonId threw an exception:
TypeError: AddonPathService.mapURIToAddonId is not a function
Stack: mapURIToAddonId@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://devtools/server/actors/utils/map-uri-to-addon-id.js:37:14
_mapSourceToAddon@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://devtools/server/actors/source.js:249:14
initialize@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://devtools/server/actors/source.js:161:5
constructor@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://gre/modules/commonjs/sdk/core/heritage.js:146:23
source@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://devtools/server/actors/utils/TabSources.js:161:17
createNonSourceMappedActor@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://devtools/server/actors/utils/TabSources.js:351:12
_addSource@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://devtools/server/actors/script.js:1930:23
onNewScript@resource://gre/modules/commonjs/toolkit/loader.js
-> resource://devtools/server/actors/script.js:1890:5
Line: 37, column: 14"
```

Bug(s):
https://bugzilla.mozilla.org/show_bug.cgi?id=1263935

@JustOff
Do you see a problem there, please?

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
