### PR TITLE
[PALEMOON] [frontend vs backend] Added support for "referrerPolicy"

### DIFF
--- a/application/palemoon/base/content/nsContextMenu.js
+++ b/application/palemoon/base/content/nsContextMenu.js
@@ -753,7 +753,8 @@ nsContextMenu.prototype = {
     urlSecurityCheck(this.linkURL, doc.nodePrincipal);
     openLinkIn(this.linkURL, "window",
                { charset: doc.characterSet,
-                 referrerURI: doc.documentURIObject });
+                 referrerURI: doc.documentURIObject,
+                 referrerPolicy: doc.referrerPolicy });
   },
 
   // Open linked-to URL in a new private window.
@@ -763,6 +764,7 @@ nsContextMenu.prototype = {
     openLinkIn(this.linkURL, "window",
                { charset: doc.characterSet,
                  referrerURI: doc.documentURIObject,
+                 referrerPolicy: doc.referrerPolicy,
                  private: true });
   },
 
@@ -772,7 +774,8 @@ nsContextMenu.prototype = {
     urlSecurityCheck(this.linkURL, doc.nodePrincipal);
     openLinkIn(this.linkURL, "tab",
                { charset: doc.characterSet,
-                 referrerURI: doc.documentURIObject });
+                 referrerURI: doc.documentURIObject,
+                 referrerPolicy: doc.referrerPolicy });
   },
 
   // open URL in current tab

--- a/application/palemoon/base/content/tabbrowser.xml
+++ b/application/palemoon/base/content/tabbrowser.xml
@@ -1264,6 +1264,7 @@
         <parameter name="aAllowThirdPartyFixup"/>
         <body>
           <![CDATA[
+            var aReferrerPolicy;
             var aFromExternal;
             var aRelatedToCurrent;
             if (arguments.length == 2 &&
@@ -1271,6 +1272,7 @@
                 !(arguments[1] instanceof Ci.nsIURI)) {
               let params = arguments[1];
               aReferrerURI          = params.referrerURI;
+              aReferrerPolicy       = params.referrerPolicy;
               aCharset              = params.charset;
               aPostData             = params.postData;
               aLoadInBackground     = params.inBackground;
@@ -1284,6 +1286,7 @@
             var owner = bgLoad ? null : this.selectedTab;
             var tab = this.addTab(aURI, {
                                   referrerURI: aReferrerURI,
+                                  referrerPolicy: aReferrerPolicy,
                                   charset: aCharset,
                                   postData: aPostData,
                                   ownerTab: owner,
@@ -1409,6 +1412,7 @@
         <body>
           <![CDATA[
             const NS_XUL = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
+            var aReferrerPolicy;
             var aFromExternal;
             var aRelatedToCurrent;
             var aSkipAnimation;
@@ -1417,6 +1421,7 @@
                 !(arguments[1] instanceof Ci.nsIURI)) {
               let params = arguments[1];
               aReferrerURI          = params.referrerURI;
+              aReferrerPolicy       = params.referrerPolicy;
               aCharset              = params.charset;
               aPostData             = params.postData;
               aOwner                = params.ownerTab;
@@ -1588,7 +1593,13 @@
               if (aFromExternal)
                 flags |= Ci.nsIWebNavigation.LOAD_FLAGS_FROM_EXTERNAL;
               try {
-                b.loadURIWithFlags(aURI, flags, aReferrerURI, aCharset, aPostData);
+                b.loadURIWithFlags(aURI, {
+                                   flags: flags,
+                                   referrerURI: aReferrerURI,
+                                   referrerPolicy: aReferrerPolicy,
+                                   charset: aCharset,
+                                   postData: aPostData,
+                                   });
               } catch (ex) {
                 Cu.reportError(ex);
               }
@@ -2700,6 +2711,11 @@
         <parameter name="aPostData"/>
         <body>
           <![CDATA[
+            // Note - the callee understands both:
+            // (a) loadURIWithFlags(aURI, aFlags, ...)
+            // (b) loadURIWithFlags(aURI, { flags: aFlags, ... })
+            // Forwarding it as (a) here actually supports both (a) and (b),
+            // so you can call us either way too.
             return this.mCurrentBrowser.loadURIWithFlags(aURI, aFlags, aReferrerURI, aCharset, aPostData);
           ]]>
         </body>


### PR DESCRIPTION
Issue #121

__Steps to reproduce:__

## 1)

__Go to:__
`https://duckduckgo.com/?q=Only+%22|%22+%22Define%22+Only+at+%22Dictionary.com%22&norw=1&t=palemoon&ia=web`

__Open:__
`Only | Define Only at Dictionary.com` (HTTPS -> HTTP) into a new tab or window

__Open `Web Console`:__
`console.log(document.referrer);`

__Actual results:__
`[empty]`

__Expected results:__
`https://duckduckgo.com/`

## 2)

__Go to:__
`https://duckduckgo.com/?q=Only+|+Define+Only+at+Dictionary.com&t=palemoon&ia=definition`

__Open:__
`Only | Define Only at Dictionary.com` into a new private window

__Open `Web Console`:__
`console.log(document.referrer);`

__Expected results:__
`[empty]`

---

Bug(s):
https://bugzilla.mozilla.org/show_bug.cgi?id=1113431

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
