### PR TITLE
[PALEMOON] Replace `owner` with `triggeringPrincipal` to match the updated API

### DIFF
--- a/application/palemoon/base/content/openLocation.js
+++ b/application/palemoon/base/content/openLocation.js
@@ -83,7 +83,7 @@ function open()
           var flags = webNav.LOAD_FLAGS_ALLOW_THIRD_PARTY_FIXUP |
                       webNav.LOAD_FLAGS_FIXUP_SCHEME_TYPOS;
           if (!mayInheritPrincipal)
-            flags |= webNav.LOAD_FLAGS_DISALLOW_INHERIT_OWNER;
+            flags |= webNav.LOAD_FLAGS_DISALLOW_INHERIT_PRINCIPAL;
           browser.gBrowser.loadURIWithFlags(url, flags, null, null, postData);
           break;
         case "1":

--- a/application/palemoon/base/content/urlbarBindings.xml
+++ b/application/palemoon/base/content/urlbarBindings.xml
@@ -305,12 +305,12 @@
 
             function loadCurrent() {
               let flags = Ci.nsIWebNavigation.LOAD_FLAGS_ALLOW_THIRD_PARTY_FIXUP;
-              // Pass LOAD_FLAGS_DISALLOW_INHERIT_OWNER to prevent any loads from
+              // Pass LOAD_FLAGS_DISALLOW_INHERIT_PRINCIPAL to prevent any loads from
               // inheriting the currently loaded document's principal, unless this
               // URL is marked as safe to inherit (e.g. came from a bookmark
               // keyword).
               if (!mayInheritPrincipal)
-                flags |= Ci.nsIWebNavigation.LOAD_FLAGS_DISALLOW_INHERIT_OWNER;
+                flags |= Ci.nsIWebNavigation.LOAD_FLAGS_DISALLOW_INHERIT_PRINCIPAL;
               // If the value wasn't typed, we know that we decoded the value as
               // UTF-8 (see losslessDecodeURI)
               if (!this.valueIsTyped)

--- a/application/palemoon/base/content/utilityOverlay.js
+++ b/application/palemoon/base/content/utilityOverlay.js
@@ -333,7 +333,7 @@ function openLinkIn(url, where, params) {
       flags |= Ci.nsIWebNavigation.LOAD_FLAGS_FIXUP_SCHEME_TYPOS;
     }
     if (aDisallowInheritPrincipal)
-      flags |= Ci.nsIWebNavigation.LOAD_FLAGS_DISALLOW_INHERIT_OWNER;
+      flags |= Ci.nsIWebNavigation.LOAD_FLAGS_DISALLOW_INHERIT_PRINCIPAL;
     if (aForceAllowDataURI) {
       flags |= Ci.nsIWebNavigation.LOAD_FLAGS_FORCE_ALLOW_DATA_URI;
     }


### PR DESCRIPTION
This aligns `Pale Moon` application and SessionStore modules with the `UXP` API.

Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1286472.

Resolves #305.