### PR TITLE
Build - throws a warning "interface 'nsISelectionPrivate' is scriptable but derives from non-scriptable 'nsISelection'"

### DIFF
--- a/dom/base/nsISelectionPrivate.idl
+++ b/dom/base/nsISelectionPrivate.idl
@@ -29,7 +29,7 @@ native nsDirection(nsDirection);
 native ScrollAxis(nsIPresShell::ScrollAxis);
 
 [scriptable, builtinclass, uuid(0c9f4f74-ee7e-4fe9-be6b-0ba856368178)]
-interface nsISelectionPrivate : nsISelection
+interface nsISelectionPrivate : nsISupports
  {
     const short ENDOFPRECEDINGLINE=0;
     const short STARTOFNEXTLINE=1;

--- a/layout/generic/Selection.h
+++ b/layout/generic/Selection.h
@@ -51,8 +51,9 @@ struct RangeData
 namespace mozilla {
 namespace dom {
 
-class Selection final : public nsISelectionPrivate,
+class Selection final : public nsISelection,
                         public nsWrapperCache,
+                        public nsISelectionPrivate,
                         public nsSupportsWeakReference
 {
 protected:
@@ -63,7 +64,7 @@ public:
   explicit Selection(nsFrameSelection *aList);
 
   NS_DECL_CYCLE_COLLECTING_ISUPPORTS
-  NS_DECL_CYCLE_COLLECTION_SCRIPT_HOLDER_CLASS_AMBIGUOUS(Selection, nsISelectionPrivate)
+  NS_DECL_CYCLE_COLLECTION_SCRIPT_HOLDER_CLASS_AMBIGUOUS(Selection, nsISelection)
   NS_DECL_NSISELECTION
   NS_DECL_NSISELECTIONPRIVATE
 

--- a/xpcom/idl-parser/xpidl/xpidl.py
+++ b/xpcom/idl-parser/xpidl/xpidl.py
@@ -529,7 +529,7 @@ class Interface(object):
                 raise IDLError("interface '%s' inherits from non-interface type '%s'" % (self.name, self.base), self.location)
 
             if self.attributes.scriptable and not realbase.attributes.scriptable:
-                print >>sys.stderr, IDLError("interface '%s' is scriptable but derives from non-scriptable '%s'" % (self.name, self.base), self.location, warning=True)
+                raise IDLError("interface '%s' is scriptable but derives from non-scriptable '%s'" % (self.name, self.base), self.location, warning=True)
 
             if self.attributes.scriptable and realbase.attributes.builtinclass and not self.attributes.builtinclass:
                 raise IDLError("interface '%s' is not builtinclass but derives from builtinclass '%s'" % (self.name, self.base), self.location)


### PR DESCRIPTION
Build - throws a warning (after `mach clobber`):
```
warning: interface 'nsISelectionPrivate' is scriptable
but derives from non-scriptable 'nsISelection',
../../../dist/idl/nsISelectionPrivate.idl
```

Bug(s):
[Bug 1216885](https://bugzilla.mozilla.org/show_bug.cgi?id=1216885) Make nsISelectionPrivate not inherit from nsISelection
[Bug 338865](https://bugzilla.mozilla.org/show_bug.cgi?id=338865) Scriptable XPIDL iface inheriting from noscript iface should throw error

---

I've created the new build (x32, Windows) - `Basilisk` / `Pale Moon UXP` - and tested.
