### PR TITLE
[PALEMOON] Fix feeds - "Subscribe to this page..."

### DIFF
--- a/application/palemoon/components/feeds/FeedWriter.js
+++ b/application/palemoon/components/feeds/FeedWriter.js
@@ -1173,7 +1173,7 @@ FeedWriter.prototype = {
 
     var secman = Cc["@mozilla.org/scriptsecuritymanager;1"].
                  getService(Ci.nsIScriptSecurityManager);
-    this._feedPrincipal = secman.getSimpleCodebasePrincipal(this._feedURI);
+    this._feedPrincipal = secman.createCodebasePrincipal(this._feedURI, {});
 
     LOG("Subscribe Preview: feed uri = " + this._window.location.href);
 


### PR DESCRIPTION
Issue #121

__Steps to reproduce:__

Go to `https://forum.palemoon.org/`

`Subscribe to this page...`

__Before #311:__
```
NS_ERROR_FAILURE: Component returned failure code:
0x80004005 (NS_ERROR_FAILURE) [nsIChannel.asyncOpen2]
FeedConverter.js:263
```

__After #311:__
```
secman.getSimpleCodebasePrincipal is not a function
FeedWriter.js:1176

```

__Bug(s):__
[Bug 1259871 - Replace getSimpleCodebasePrincipal with createCodebasePrincipal](https://hg.mozilla.org/mozilla-central/rev/62903b5a04a7)

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
