### PR TITLE
[PALEMOON] [frontend vs backend] Places - Fix: "Keyword" reset (to an empty value) does not work

### DIFF
--- a/application/palemoon/components/places/content/editBookmarkOverlay.js
+++ b/application/palemoon/components/places/content/editBookmarkOverlay.js
@@ -12,6 +12,7 @@ var gEditItemOverlay = {
   _uris: [],
   _tags: [],
   _allTags: [],
+  _keyword: null,
   _multiEdit: false,
   _itemType: -1,
   _readOnly: false,
@@ -139,9 +140,8 @@ var gEditItemOverlay = {
       this._itemType = PlacesUtils.bookmarks.getItemType(this._itemId);
       if (this._itemType == Ci.nsINavBookmarksService.TYPE_BOOKMARK) {
         this._uri = PlacesUtils.bookmarks.getBookmarkURI(this._itemId);
-        this._initTextField("keywordField",
-                            PlacesUtils.bookmarks
-                                       .getKeywordForBookmark(this._itemId));
+        this._keyword = PlacesUtils.bookmarks.getKeywordForBookmark(this._itemId);
+        this._initTextField("keywordField", this._keyword);
         this._element("loadInSidebarCheckbox").checked =
           PlacesUtils.annotations.itemHasAnnotation(this._itemId,
                                                     PlacesUIUtils.LOAD_IN_SIDEBAR_ANNO);
@@ -610,9 +610,13 @@ var gEditItemOverlay = {
   },
 
   onKeywordFieldBlur: function EIO_onKeywordFieldBlur() {
-    var keyword = this._element("keywordField").value;
-    if (keyword != PlacesUtils.bookmarks.getKeywordForBookmark(this._itemId)) {
-      var txn = new PlacesEditBookmarkKeywordTransaction(this._itemId, keyword);
+    let oldKeyword = this._keyword;
+    let keyword = this._keyword = this._element("keywordField").value;
+    if (keyword != oldKeyword) {
+      var txn = new PlacesEditBookmarkKeywordTransaction(this._itemId,
+                                                         keyword,
+                                                         null,
+                                                         oldKeyword);
       PlacesUtils.transactionManager.doTransaction(txn);
     }
   },
@@ -1004,9 +1008,8 @@ var gEditItemOverlay = {
       }
       break;
     case "keyword":
-      this._initTextField("keywordField",
-                          PlacesUtils.bookmarks
-                                     .getKeywordForBookmark(this._itemId));
+      this._keyword = PlacesUtils.bookmarks.getKeywordForBookmark(this._itemId);
+      this._initTextField("keywordField", this._keyword);
       break;
     case PlacesUIUtils.DESCRIPTION_ANNO:
       this._initTextField("descriptionField",

--- a/application/palemoon/components/places/content/editBookmarkOverlay.js
+++ b/application/palemoon/components/places/content/editBookmarkOverlay.js
@@ -613,7 +613,7 @@ var gEditItemOverlay = {
     let oldKeyword = this._keyword;
     let keyword = this._keyword = this._element("keywordField").value;
     if (keyword != oldKeyword) {
-      var txn = new PlacesEditBookmarkKeywordTransaction(this._itemId,
+      let txn = new PlacesEditBookmarkKeywordTransaction(this._itemId,
                                                          keyword,
                                                          null,
                                                          oldKeyword);


### PR DESCRIPTION
Tag #121 

---

__Steps to reproduce:__

Open `Library` (the main menu: `Bookmarks` - `Organize Bookmarks`)
Find a bookmark (with some keyword value - or assign it first)
The right window: click once on `More` (the `Keyword` and `Description` are displayed)
Change the keyword value to "" (an empty value)

When you leaves an input field (`onblur` event) - e.g. to another bookmark - and come back, `Keyword` has still the original value.

__A reason:__
`PlacesEditBookmarkKeywordTransaction` - it now has four parameters (i.e. oldKeyword).

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
