### PR TITLE
Fix regex escaping in old-configure and js/src/old-configure

### DIFF
--- a/js/src/old-configure.in
+++ b/js/src/old-configure.in
@@ -734,12 +734,14 @@ case "$target" in
           dnl VS2012+ defaults to -arch:SSE2. We want to target nothing
           dnl more recent, so set that explicitly here unless another
           dnl target arch has already been set.
+          changequote(,)
           if test -z `echo $CFLAGS | grep -i [-/]arch:` ; then
             CFLAGS="$CFLAGS -arch:SSE2"
-            fi
+          fi
           if test -z `echo $CXXFLAGS | grep -i [-/]arch:` ; then
             CXXFLAGS="$CXXFLAGS -arch:SSE2"
           fi
+          changequote([,])
         fi
         dnl VS2013+ requires -FS when parallel building by make -jN.
         dnl If nothing, compiler sometimes causes C1041 error.

--- a/old-configure.in
+++ b/old-configure.in
@@ -1030,12 +1030,14 @@ case "$target" in
             dnl VS2012+ defaults to -arch:SSE2. We want to target nothing
             dnl more recent, so set that explicitly here unless another
             dnl target arch has already been set.
+            changequote(,)
             if test -z `echo $CFLAGS | grep -i [-/]arch:`; then
               CFLAGS="$CFLAGS -arch:SSE2"
             fi
             if test -z `echo $CXXFLAGS | grep -i [-/]arch:`; then
               CXXFLAGS="$CXXFLAGS -arch:SSE2"
             fi
+            changequote([,])
             SSE_FLAGS="-arch:SSE"
             SSE2_FLAGS="-arch:SSE2"
             dnl MSVC allows the use of intrinsics without any flags


### PR DESCRIPTION
This eliminates the error messages caused by autoconf quoting problems when building on Windows:

```
grep: invalid option -- /
Usage: grep [OPTION]... PATTERN [FILE]...
Try `grep --help' for more information.
```
Even with the error, the result for a default config is the same, but problems might have occurred if manually specifying -arch flag.

Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1334268.

Resolves #328.