### PR TITLE
[PMkit] Fix Empty string passed to getElementById() warning in buttons.js

### DIFF
--- a/toolkit/jetpack/sdk/ui/buttons.js
+++ b/toolkit/jetpack/sdk/ui/buttons.js
@@ -50,7 +50,7 @@ function insertButton(aWindow, id, onBuild) {
   let toolbar = toolbarId != "" && doc.getElementById(toolbarId);
 
   if (toolbar) {
-    let nextItem = doc.getElementById(nextItemId);
+    let nextItem = nextItemId != "" && doc.getElementById(nextItemId);
     // If nextItem not in toolbar then retrieve it by reading currentset attribute
     if (!(nextItem && nextItem.parentNode && nextItem.parentNode.id == toolbarId)) {
       nextItem = null;


### PR DESCRIPTION
Just what it says in the tin.

Tag #120.