### PR TITLE
[follow up] moebius#154: Notifications - user settings - the immediate duration of the alert (fix for "New layout of XUL Notifications")

### DIFF
--- a/toolkit/components/alerts/resources/content/alert.js
+++ b/toolkit/components/alerts/resources/content/alert.js
@@ -313,6 +313,7 @@ function onAlertClick() {
   let alertBox = document.getElementById("alertBox");
   if (alertBox.getAttribute("animate") == "true") {
     // Closed when the animation ends.
+    alertBox.style.animationDuration = ".6s";
     alertBox.setAttribute("clicked", "true");
   } else {
     window.close();
@@ -355,6 +356,7 @@ function onAlertClose() {
   let alertBox = document.getElementById("alertBox");
   if (alertBox.getAttribute("animate") == "true") {
     // Closed when the animation ends.
+    alertBox.style.animationDuration = ".6s";
     alertBox.setAttribute("closing", "true");
   } else {
     window.close();

--- a/toolkit/themes/shared/alert-common.css
+++ b/toolkit/themes/shared/alert-common.css
@@ -15,14 +15,12 @@
 }
 
 #alertBox[animate][clicked] {
-  animation-duration: .6s;
   animation-name: alert-clicked-animation;
 }
 
 /* This is used if the close button is clicked
    before the animation has finished. */
 #alertBox[animate][closing] {
-  animation-duration: .6s;
   animation-name: alert-closing-animation;
 }
 


### PR DESCRIPTION
Tags:
https://github.com/MoonchildProductions/moebius/pull/154
https://github.com/MoonchildProductions/UXP/pull/132

Follow up due to [bug 1201397 - New layout of XUL Notifications](https://bugzilla.mozilla.org/show_bug.cgi?id=1201397).

__Steps to reproduce:__

Install `Greasemonkey for Pale Moon`
Install: https://gist.github.com/janekptacijarabaci/e92b5c56d6be925e72423530384541b1
Go to https://www.github.com/
Click on one of the web notifications
A problem: The animation takes a long time

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
