### PR TITLE
[PALEMOON] Replace the fullscreen permission dialog with a warning and update the permission management

### DIFF
--- a/application/palemoon/app/profile/palemoon.js
+++ b/application/palemoon/app/profile/palemoon.js
@@ -1058,11 +1058,6 @@ pref("browser.newtabpage.rows", 4);
 // Enable the DOM fullscreen API.
 pref("full-screen-api.enabled", true);
 
-// True if the fullscreen API requires approval upon a domain entering fullscreen.
-// Domains that have already had fullscreen permission granted won't re-request
-// approval.
-pref("full-screen-api.approval-required", true);
-
 // about:permissions
 // Maximum number of sites to return from the places database.
 // 0-100 (currently)

--- a/application/palemoon/base/content/browser-fullScreen.js
+++ b/application/palemoon/base/content/browser-fullScreen.js
@@ -91,7 +91,7 @@ var FullScreen = {
     if (!document.mozFullScreen)
       return;
 
-    // However, if we receive a "MozEnteredDomFullScreen" event for a document
+    // However, if we receive a "MozDOMFullscreen:NewOrigin" event for a document
     // which is not a subdocument of a currently active (ie. visible) browser
     // or iframe, we know that we've switched to a different frame since the
     // request to enter full-screen was made, so we should exit full-screen

--- a/application/palemoon/base/content/browser-fullScreen.js
+++ b/application/palemoon/base/content/browser-fullScreen.js
@@ -247,66 +247,20 @@ var FullScreen = {
 
     this.warningBox.setAttribute("hidden", true);
     this.warningBox.removeAttribute("fade-warning-out");
-    this.warningBox.removeAttribute("obscure-browser");
     this.warningBox = null;
-  },
-
-  setFullscreenAllowed: function(isApproved) {
-    // The "remember decision" checkbox is hidden when showing for documents that
-    // the permission manager can't handle (documents with URIs without a host).
-    // We simply require those to be approved every time instead.
-    let rememberCheckbox = document.getElementById("full-screen-remember-decision");
-    let uri = this.fullscreenDoc.nodePrincipal.URI;
-    if (!rememberCheckbox.hidden) {
-      if (rememberCheckbox.checked)
-        Services.perms.add(uri,
-                           "fullscreen",
-                           isApproved ? Services.perms.ALLOW_ACTION : Services.perms.DENY_ACTION,
-                           Services.perms.EXPIRE_NEVER);
-      else if (isApproved) {
-        // The user has only temporarily approved fullscren for this fullscreen
-        // session only. Add the permission (so Goanna knows to approve any further
-        // fullscreen requests for this host in this fullscreen session) but add
-        // a listener to revoke the permission when the chrome document exits
-        // fullscreen.
-        Services.perms.add(uri,
-                           "fullscreen",
-                           Services.perms.ALLOW_ACTION,
-                           Services.perms.EXPIRE_SESSION);
-        var onFullscreenchange = function onFullscreenchange(event) {
-          if (event.target == document && document.mozFullScreenElement == null) {
-            // The chrome document has left fullscreen. Remove the temporary permission grant.
-            Services.perms.remove(uri, "fullscreen");
-            document.removeEventListener("mozfullscreenchange", onFullscreenchange);
-          }
-        }
-        document.addEventListener("mozfullscreenchange", onFullscreenchange);
-      }
-    }
-    if (this.warningBox)
-      this.warningBox.setAttribute("fade-warning-out", "true");
-    // If the document has been granted fullscreen, notify Goanna so it can resume
-    // any pending pointer lock requests, otherwise exit fullscreen; the user denied
-    // the fullscreen request.
-    if (isApproved)
-      Services.obs.notifyObservers(this.fullscreenDoc, "fullscreen-approved", "");
-    else
-      document.mozCancelFullScreen();
   },
 
   warningBox: null,
   warningFadeOutTimeout: null,
   fullscreenDoc: null,
 
-  // Shows the fullscreen approval UI, or if the domain has already been approved
-  // for fullscreen, shows a warning that the site has entered fullscreen for a short
-  // duration.
+  // Shows a warning that the site has entered fullscreen for a short duration.
   showWarning: function(targetDoc) {
-    if (!document.mozFullScreen ||
-        !gPrefService.getBoolPref("full-screen-api.approval-required"))
+    let timeout = gPrefService.getIntPref("full-screen-api.warning.timeout");
+    if (!document.mozFullScreen || timeout <= 0)
       return;
 
-    // Set the strings on the fullscreen approval UI.
+    // Set the strings on the fullscreen warning UI.
     this.fullscreenDoc = targetDoc;
     let uri = this.fullscreenDoc.nodePrincipal.URI;
     let host = null;
@@ -314,11 +268,8 @@ var FullScreen = {
       host = uri.host;
     } catch (e) { }
     let hostLabel = document.getElementById("full-screen-domain-text");
-    let rememberCheckbox = document.getElementById("full-screen-remember-decision");
-    let isApproved = false;
     if (host) {
-      // Document's principal's URI has a host. Display a warning including the hostname and
-      // show UI to enable the user to permanently grant this host permission to enter fullscreen.
+      // Document's principal's URI has a host. Display a warning including the hostname.
       let utils = {};
       Cu.import("resource://gre/modules/DownloadUtils.jsm", utils);
       let displayHost = utils.DownloadUtils.getURIHost(uri.spec)[0];
@@ -326,17 +277,8 @@ var FullScreen = {
 
       hostLabel.textContent = bundle.formatStringFromName("fullscreen.entered", [displayHost], 1);
       hostLabel.removeAttribute("hidden");
-
-      rememberCheckbox.label = bundle.formatStringFromName("fullscreen.rememberDecision", [displayHost], 1);
-      rememberCheckbox.checked = false;
-      rememberCheckbox.removeAttribute("hidden");
-
-      // Note we only allow documents whose principal's URI has a host to
-      // store permission grants.
-      isApproved = Services.perms.testPermission(uri, "fullscreen") == Services.perms.ALLOW_ACTION;
     } else {
       hostLabel.setAttribute("hidden", "true");
-      rememberCheckbox.setAttribute("hidden", "true");
     }
 
     // Note: the warning box can be non-null if the warning box from the previous request
@@ -354,32 +296,12 @@ var FullScreen = {
       this.warningBox.removeAttribute("fade-warning-out");
     }
 
-    // If fullscreen mode has not yet been approved for the fullscreen
-    // document's domain, show the approval UI and don't auto fade out the
-    // fullscreen warning box. Otherwise, we're just notifying of entry into
-    // fullscreen mode. Note if the resource's host is null, we must be
-    // showing a local file or a local data URI, and we require explicit
-    // approval every time.
-    let authUI = document.getElementById("full-screen-approval-pane");
-    if (isApproved) {
-      authUI.setAttribute("hidden", "true");
-      this.warningBox.removeAttribute("obscure-browser");
-    } else {
-      // Partially obscure the <browser> element underneath the approval UI.
-      this.warningBox.setAttribute("obscure-browser", "true");
-      authUI.removeAttribute("hidden");
-    }
-
-    // If we're not showing the fullscreen approval UI, we're just notifying the user
-    // of the transition, so set a timeout to fade the warning out after a few moments.
-    if (isApproved)
-      this.warningFadeOutTimeout =
-        setTimeout(
-          function() {
-            if (this.warningBox)
-              this.warningBox.setAttribute("fade-warning-out", "true");
-          }.bind(this),
-          3000);
+    // Set a timeout to fade the warning out after a few moments.
+    this.warningFadeOutTimeout = setTimeout(() => {
+      if (this.warningBox) {
+        this.warningBox.setAttribute("fade-warning-out", "true");
+      }
+    }, timeout);
   },
 
   showNavToolbox: function(trackMouse = true) {

--- a/application/palemoon/base/content/browser.css
+++ b/application/palemoon/base/content/browser.css
@@ -504,6 +504,7 @@ window[chromehidden~="toolbar"] toolbar:not(.toolbar-primary):not(#nav-bar):not(
   width: 100%;
   height: 100%;
   z-index: 2147483647 !important;
+  pointer-events: none;
 }
 
 #full-screen-warning-container[fade-warning-out] {
@@ -512,22 +513,13 @@ window[chromehidden~="toolbar"] toolbar:not(.toolbar-primary):not(#nav-bar):not(
   opacity: 0.0;
 }
 
-/* When the modal fullscreen approval UI is showing, don't allow interaction
-   with the page, but when we're just showing the warning upon entering
-   fullscreen on an already approved page, do allow interaction with the page.
- */
-#full-screen-warning-container:not([obscure-browser]) {
-  pointer-events: none;
-}
-
 #full-screen-warning-message {
   /* We must specify a max-width, otherwise word-wrap:break-word doesn't
      work in descendant <description> and <label> elements. Bug 630864. */
   max-width: 800px;
 }
 
-#full-screen-domain-text,
-#full-screen-remember-decision > .checkbox-label-box > .checkbox-label {
+#full-screen-domain-text {
   word-wrap: break-word;
   /* We must specify a min-width, otherwise word-wrap:break-word doesn't work. Bug 630864. */
   min-width: 1px;

--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -1157,7 +1157,7 @@ var gBrowserInit = {
 
     // Called when we enter DOM full-screen mode. Note we can already be in browser
     // full-screen mode when we enter DOM full-screen mode.
-    window.addEventListener("MozEnteredDomFullscreen", onMozEnteredDomFullscreen, true);
+    window.addEventListener("MozDOMFullscreen:NewOrigin", onMozEnteredDomFullscreen, true);
 
     if (window.fullScreen)
       onFullScreen();

--- a/application/palemoon/base/content/browser.xul
+++ b/application/palemoon/base/content/browser.xul
@@ -974,18 +974,6 @@
       <vbox id="full-screen-warning-message" align="center">
         <description id="full-screen-domain-text"/>
         <description class="full-screen-description" value="&fullscreenExitHint.value;"/>
-        <vbox id="full-screen-approval-pane" align="center">
-          <description class="full-screen-description" value="&fullscreenApproval.value;"/>
-          <hbox>
-            <button label="&fullscreenAllowButton.label;"
-                    oncommand="FullScreen.setFullscreenAllowed(true);"
-                    class="full-screen-approval-button"/>
-            <button label="&fullscreenExitButton.label;"
-                    oncommand="FullScreen.setFullscreenAllowed(false);"
-                    class="full-screen-approval-button"/>
-          </hbox>
-          <checkbox id="full-screen-remember-decision"/>
-        </vbox>
       </vbox>
     </hbox>
   </hbox>

--- a/application/palemoon/base/content/pageinfo/pageInfo.xul
+++ b/application/palemoon/base/content/pageinfo/pageInfo.xul
@@ -52,7 +52,6 @@
     <command id="cmd_cookieDef"     oncommand="onCheckboxClick('cookie');"/>
     <command id="cmd_desktop-notificationDef" oncommand="onCheckboxClick('desktop-notification');"/>
     <command id="cmd_installDef"    oncommand="onCheckboxClick('install');"/>
-    <command id="cmd_fullscreenDef" oncommand="onCheckboxClick('fullscreen');"/>
     <command id="cmd_geoDef"        oncommand="onCheckboxClick('geo');"/>
     <command id="cmd_indexedDBDef"  oncommand="onCheckboxClick('indexedDB');"/>
     <command id="cmd_pluginsDef"    oncommand="onCheckboxClick('plugins');"/>
@@ -61,12 +60,9 @@
     <command id="cmd_cookieToggle"  oncommand="onRadioClick('cookie');"/>
     <command id="cmd_desktop-notificationToggle" oncommand="onRadioClick('desktop-notification');"/>
     <command id="cmd_installToggle" oncommand="onRadioClick('install');"/>
-    <command id="cmd_fullscreenToggle" oncommand="onRadioClick('fullscreen');"/>
     <command id="cmd_geoToggle"     oncommand="onRadioClick('geo');"/>
     <command id="cmd_indexedDBToggle" oncommand="onRadioClick('indexedDB');"/>
     <command id="cmd_pluginsToggle" oncommand="onPluginRadioClick(event);"/>
-    <command id="cmd_pointerLockDef"    oncommand="onCheckboxClick('pointerLock');"/>
-    <command id="cmd_pointerLockToggle" oncommand="onRadioClick('pointerLock');"/>
   </commandset>
 
   <keyset id="pageInfoKeySet">
@@ -402,31 +398,6 @@
               <radio class="permPluginTemplateRadioAsk" label="&permAskAlways;"/>
               <radio class="permPluginTemplateRadioAllow" label="&permAllow;"/>
               <radio class="permPluginTemplateRadioBlock" label="&permBlock;"/>
-            </radiogroup>
-          </hbox>
-        </vbox>
-        <vbox class="permission" id="permFullscreenRow">
-          <label class="permissionLabel" id="permFullscreenLabel"
-                 value="&permFullscreen;" control="fullscreenRadioGroup"/>
-          <hbox id="permFullscreenBox" role="group" aria-labelledby="permFullscreenLabel">
-            <checkbox id="fullscreenDef" command="cmd_fullscreenDef" label="&permUseDefault;"/>
-            <spacer flex="1"/>
-            <radiogroup id="fullscreenRadioGroup" orient="horizontal">
-              <radio id="fullscreen#0" command="cmd_fullscreenToggle" label="&permAskAlways;"/>
-              <radio id="fullscreen#1" command="cmd_fullscreenToggle" label="&permAllow;"/>
-              <radio id="fullscreen#2" command="cmd_fullscreenToggle" label="&permBlock;"/>
-            </radiogroup>
-          </hbox>
-        </vbox>
-        <vbox class="permission" id="permPointerLockRow" >
-          <label class="permissionLabel" id="permPointerLockLabel"
-                 value="&permPointerLock2;" control="pointerLockRadioGroup"/>
-          <hbox id="permPointerLockBox" role="group" aria-labelledby="permPointerLockLabel">
-            <checkbox id="pointerLockDef" command="cmd_pointerLockDef" label="&permAskAlways;"/>
-            <spacer flex="1"/>
-            <radiogroup id="pointerLockRadioGroup" orient="horizontal">
-              <radio id="pointerLock#1" command="cmd_pointerLockToggle" label="&permAllow;"/>
-              <radio id="pointerLock#2" command="cmd_pointerLockToggle" label="&permBlock;"/>
             </radiogroup>
           </hbox>
         </vbox>

--- a/application/palemoon/base/content/pageinfo/permissions.js
+++ b/application/palemoon/base/content/pageinfo/permissions.js
@@ -76,20 +76,6 @@ var gPermObj = {
   {
     return UNKNOWN;
   },
-  fullscreen: function getFullscreenDefaultPermissions()
-  {
-    if (!gPrefs.getBoolPref("full-screen-api.enabled")) {
-      return DENY;
-    }
-    return UNKNOWN;  
-  },
-  pointerLock: function getPointerLockPermissions()
-  {
-    if (!gPrefs.getBoolPref("full-screen-api.pointer-lock.enabled")) {
-      return DENY;
-    }
-    return ALLOW;
-  },
 };
 
 var permissionObserver = {

--- a/application/palemoon/components/preferences/aboutPermissions.js
+++ b/application/palemoon/components/preferences/aboutPermissions.js
@@ -418,31 +418,6 @@ var PermissionDefaults = {
     Services.prefs.setBoolPref("dom.indexedDB.enabled", value);
   },
 
-  get fullscreen() {
-    if (!Services.prefs.getBoolPref("full-screen-api.enabled")) {
-      return this.DENY;
-    }
-    // We always ask for permission to fullscreen with a specific site,
-    // so there is no global ALLOW.
-    return this.UNKNOWN;
-  },
-  set fullscreen(aValue) {
-    let value = (aValue != this.DENY);
-    Services.prefs.setBoolPref("full-screen-api.enabled", value);
-  },
-
-  get pointerLock() {
-    if (!Services.prefs.getBoolPref("full-screen-api.pointer-lock.enabled")) {
-      return this.DENY;
-    }
-    // We always ask for permission to hide the mouse pointer
-    // with a specific site, so there is no global ALLOW.
-    return this.UNKNOWN;
-  },
-  set pointerLock(aValue) {
-    let value = (aValue != this.DENY);
-    Services.prefs.setBoolPref("full-screen-api.pointer-lock.enabled", value);
-  },
 }
 
 /**
@@ -489,14 +464,12 @@ var AboutPermissions = {
    * Potential future additions: "sts/use", "sts/subd"
    */
   _supportedPermissions: ["password", "image", "popup", "cookie",
-                          "desktop-notification", "install", "geo", "indexedDB",
-                          "fullscreen", "pointerLock"],
+                          "desktop-notification", "install", "geo", "indexedDB"],
 
   /**
    * Permissions that don't have a global "Allow" option.
    */
-  _noGlobalAllow: ["desktop-notification", "geo", "indexedDB", "fullscreen",
-                   "pointerLock"],
+  _noGlobalAllow: ["desktop-notification", "geo", "indexedDB"],
 
   /**
    * Permissions that don't have a global "Deny" option.
@@ -543,8 +516,6 @@ var AboutPermissions = {
     Services.prefs.addObserver("geo.enabled", this, false);
     Services.prefs.addObserver("dom.indexedDB.enabled", this, false);
     Services.prefs.addObserver("plugins.click_to_play", this, false);
-    Services.prefs.addObserver("full-screen-api.enabled", this, false);
-    Services.prefs.addObserver("full-screen-api.pointer-lock.enabled", this, false);
     Services.prefs.addObserver("permissions.places-sites-limit", this, false);
 
     Services.obs.addObserver(this, "perm-changed", false);
@@ -695,8 +666,6 @@ var AboutPermissions = {
       Services.prefs.removeObserver("geo.enabled", this, false);
       Services.prefs.removeObserver("dom.indexedDB.enabled", this, false);
       Services.prefs.removeObserver("plugins.click_to_play", this, false);
-      Services.prefs.removeObserver("full-screen-api.enabled", this, false);
-      Services.prefs.removeObserver("full-screen-api.pointer-lock.enabled", this, false);
       Services.prefs.removeObserver("permissions.places-sites-limit", this, false);
 
       Services.obs.removeObserver(this, "perm-changed");

--- a/application/palemoon/components/preferences/aboutPermissions.xul
+++ b/application/palemoon/components/preferences/aboutPermissions.xul
@@ -336,64 +336,6 @@
           <vbox id="plugins-box"/>
         </vbox>
       </hbox>
-
-      <!-- Fullscreen -->
-      <hbox id="fullscreen-pref-item"
-            class="pref-item" align="top">
-        <image class="pref-icon" type="fullscreen"/>
-        <vbox>
-          <hbox>
-            <label class="pref-title" value="&fullscreen.label;"/>
-            <label id="fullscreen-default" class="pref-default" value="*"/>
-          </hbox>
-          <hbox align="center">
-            <menulist id="fullscreen-menulist"
-                      class="pref-menulist"
-                      type="fullscreen"
-                      oncommand="AboutPermissions.onPermissionCommand(event, false);">
-              <menupopup>
-                <menuitem id="fullscreen-0" value="0" label="&permission.alwaysAsk;"/>
-                <menuitem id="fullscreen-1" value="1" label="&permission.allow;"/>
-                <menuitem id="fullscreen-2" value="2" label="&permission.block;"/>
-              </menupopup>
-            </menulist>
-            <button id="fullscreen-set-default"
-                    class="pref-set-default"
-                    label="&permission.default;"
-                    type="fullscreen"
-                    oncommand="AboutPermissions.onPermissionCommand(event, true);"/>
-          </hbox>
-        </vbox>
-      </hbox>      
-      
-      <!-- PointerLock -->
-      <hbox id="pointerLock-pref-item"
-            class="pref-item" align="top">
-        <image class="pref-icon" type="pointerLock"/>
-        <vbox>
-          <hbox>
-            <label class="pref-title" value="&pointerLock.label;"/>
-            <label id="pointerLock-default" class="pref-default" value="*"/>
-          </hbox>
-          <hbox>
-            <menulist id="pointerLock-menulist"
-                      class="pref-menulist"
-                      type="pointerLock"
-                      oncommand="AboutPermissions.onPermissionCommand(event, false);">
-              <menupopup>
-                <menuitem id="pointerLock-0" value="0" label="&permission.alwaysAsk;"/>
-                <menuitem id="pointerLock-1" value="1" label="&permission.allow;"/>
-                <menuitem id="pointerLock-2" value="2" label="&permission.block;"/>
-              </menupopup>
-            </menulist>
-            <button id="pointerLock-set-default"
-                    class="pref-set-default"
-                    label="&permission.default;"
-                    type="pointerLock"
-                    oncommand="AboutPermissions.onPermissionCommand(event, true);"/>
-          </hbox>
-        </vbox>
-      </hbox>
     </vbox>
   </hbox>
 

--- a/application/palemoon/locales/en-US/chrome/browser/browser.dtd
+++ b/application/palemoon/locales/en-US/chrome/browser/browser.dtd
@@ -107,9 +107,6 @@ These should match what Safari and other Apple applications use on OS X Lion. --
 <!ENTITY fullScreenAutohide.accesskey "H">
 <!ENTITY fullScreenExit.label "Exit Full Screen Mode">
 <!ENTITY fullScreenExit.accesskey "F">
-<!ENTITY fullscreenAllowButton.label "Allow">
-<!ENTITY fullscreenExitButton.label "Deny">
-<!ENTITY fullscreenApproval.value "Allow fullscreen?">
 
 <!ENTITY fullscreenExitHint.value "Press ESC at any time to exit fullscreen.">
 <!ENTITY leaveDOMFullScreen.label "Exit Full Screen">

--- a/application/palemoon/locales/en-US/chrome/browser/browser.properties
+++ b/application/palemoon/locales/en-US/chrome/browser/browser.properties
@@ -377,8 +377,6 @@ dataReportingNotification.button.accessKey  = C
 
 # LOCALIZATION NOTE (fullscreen.entered): displayed when we enter HTML5 fullscreen mode, %S is the domain name of the focused website (e.g. mozilla.com).
 fullscreen.entered=%S is now fullscreen.
-# LOCALIZATION NOTE (fullscreen.rememberDecision): displayed when we enter HTML5 fullscreen mode, %S is the domain name of the focused website (e.g. mozilla.com).
-fullscreen.rememberDecision=Remember decision for %S
 
 # LOCALIZATION NOTE (getUserMedia.shareCamera.message, getUserMedia.shareMicrophone.message, getUserMedia.shareCameraAndMicrophone.message): %S is the website origin (e.g. www.mozilla.org)
 # LOCALIZATION NOTE (getUserMedia.shareSelectedDevices.label):

--- a/application/palemoon/locales/en-US/chrome/browser/pageInfo.dtd
+++ b/application/palemoon/locales/en-US/chrome/browser/pageInfo.dtd
@@ -66,8 +66,6 @@
 <!ENTITY  permInstall             "Install Extensions or Themes">
 <!ENTITY  permGeo                 "Share Location">
 <!ENTITY  permPlugins             "Activate Plugins">
-<!ENTITY  permFullscreen          "Enter Fullscreen">
-<!ENTITY  permPointerLock2        "Hide the Mouse Pointer">
 
 <!ENTITY  permIndexedDB              "Maintain Offline Storage">
 <!ENTITY  permClearStorage           "Clear Storage">

--- a/application/palemoon/locales/en-US/chrome/browser/preferences/aboutPermissions.dtd
+++ b/application/palemoon/locales/en-US/chrome/browser/preferences/aboutPermissions.dtd
@@ -51,8 +51,4 @@
 
 <!ENTITY popup.label                     "Open Pop-up Windows">
 
-<!ENTITY fullscreen.label                "Fullscreen">
-
-<!ENTITY pointerLock.label               "Hide the Mouse Pointer">
-
 <!ENTITY focusSearch.key                 "f">

--- a/application/palemoon/themes/linux/browser.css
+++ b/application/palemoon/themes/linux/browser.css
@@ -2067,21 +2067,12 @@ toolbar[mode="text"] toolbarbutton.chevron > .toolbarbutton-icon {
   box-shadow: 0 0 2px white;
 }
 
-#full-screen-warning-container[obscure-browser] {
-  background-color: rgba(0,0,0,0.3);
-}
-
 .full-screen-description {
   font-size: 150%;
 }
 
 #full-screen-domain-text {
   font-size: 300%;
-}
-
-.full-screen-approval-button,
-#full-screen-remember-decision {
-  font-size: 120%;
 }
 
 %ifdef MOZ_DEVTOOLS

--- a/application/palemoon/themes/linux/preferences/aboutPermissions.css
+++ b/application/palemoon/themes/linux/preferences/aboutPermissions.css
@@ -104,12 +104,6 @@
 .pref-icon[type="plugins"] {
   list-style-image: url(chrome://mozapps/skin/plugins/pluginGeneric.png);
 }
-.pref-icon[type="fullscreen"] {
-  list-style-image: url(chrome://global/skin/icons/question-64.png);
-}
-.pref-icon[type="pointerLock"] {
-  list-style-image: url(chrome://global/skin/icons/question-64.png);
-}
 
 .pref-title {
   font-size: 125%;

--- a/application/palemoon/themes/osx/browser.css
+++ b/application/palemoon/themes/osx/browser.css
@@ -2346,21 +2346,12 @@ toolbar[brighttext] #addonbar-closebutton {
     box-shadow: 0 0 2px white;
 }
 
-#full-screen-warning-container[obscure-browser] {
-    background-color: rgba(0,0,0,0.3);
-}
-
 .full-screen-description {
     font-size: 150%;
 }
 
 #full-screen-domain-text {
     font-size: 300%;
-}
-
-.full-screen-approval-button,
-#full-screen-remember-decision {
-    font-size: 120%;
 }
 
 %ifdef MOZ_DEVTOOLS

--- a/application/palemoon/themes/osx/preferences/aboutPermissions.css
+++ b/application/palemoon/themes/osx/preferences/aboutPermissions.css
@@ -107,12 +107,6 @@
 .pref-icon[type="plugins"] {
   list-style-image: url(chrome://mozapps/skin/plugins/pluginGeneric.png);
 }
-.pref-icon[type="fullscreen"] {
-  list-style-image: url(chrome://global/skin/icons/question-64.png);
-}
-.pref-icon[type="pointerLock"] {
-  list-style-image: url(chrome://global/skin/icons/question-64.png);
-}
 
 .pref-title {
   font-size: 125%;

--- a/application/palemoon/themes/windows/browser.css
+++ b/application/palemoon/themes/windows/browser.css
@@ -2820,21 +2820,12 @@ toolbar[brighttext] #addonbar-closebutton {
   box-shadow: 0 0 2px white;
 }
 
-#full-screen-warning-container[obscure-browser] {
-  background-color: rgba(0,0,0,0.3);
-}
-
 .full-screen-description {
   font-size: 150%;
 }
 
 #full-screen-domain-text {
   font-size: 300%;
-}
-
-.full-screen-approval-button,
-#full-screen-remember-decision {
-  font-size: 120%;
 }
 
 %ifdef MOZ_DEVTOOLS

--- a/application/palemoon/themes/windows/preferences/aboutPermissions.css
+++ b/application/palemoon/themes/windows/preferences/aboutPermissions.css
@@ -107,12 +107,6 @@
 .pref-icon[type="plugins"] {
   list-style-image: url(chrome://mozapps/skin/plugins/pluginGeneric-48.png);
 }
-.pref-icon[type="fullscreen"] {
-  list-style-image: url(chrome://global/skin/icons/question-48.png);
-}
-.pref-icon[type="pointerLock"] {
-  list-style-image: url(chrome://global/skin/icons/question-48.png);
-}
 
 .pref-title {
   font-size: 125%;


### PR DESCRIPTION
This changes the following:

* Update fullscreen activation event to match UXP
* Replace fullscreen permission dialog with a warning
* Remove fullscreen and pointer-lock from permission managing (not available in UXP)

Based on:

* https://bugzilla.mozilla.org/show_bug.cgi?id=1053413
* https://bugzilla.mozilla.org/show_bug.cgi?id=1160017

Since this removes `full-screen-api.approval-required`, I provided a way to achieve the same effect by setting `full-screen-api.warning.timeout=0` (improvement over Mozilla).

Tag #270.
