### PR TITLE
[regression] DevTools - Web and Browser console - Added "Log request and response bodies" preference

### DIFF
--- a/devtools/client/locales/en-US/webConsole.dtd
+++ b/devtools/client/locales/en-US/webConsole.dtd
@@ -11,6 +11,11 @@
 <!ENTITY window.title "Web Console">
 <!ENTITY browserConsole.title "Browser Console">
 
+<!-- LOCALIZATION NOTE (saveBodies.label): You can see this string in
+   - the Browser Console context menu. -->
+<!ENTITY saveBodies.label     "Log Request and Response Bodies">
+<!ENTITY saveBodies.accesskey "L">
+
 <!-- LOCALIZATION NOTE (openURL.label): You can see this string in the Web
    - Console context menu. -->
 <!ENTITY openURL.label     "Open URL in New Tab">

--- a/devtools/client/preferences/devtools.js
+++ b/devtools/client/preferences/devtools.js
@@ -248,6 +248,7 @@ pref("devtools.webconsole.filter.log", true);
 pref("devtools.webconsole.filter.debug", true);
 pref("devtools.webconsole.filter.net", false);
 pref("devtools.webconsole.filter.netxhr", false);
+pref("devtools.webconsole.filter.saveBodies", true);
 // Deprecated - old console frontend
 pref("devtools.webconsole.filter.network", true);
 pref("devtools.webconsole.filter.networkinfo", false);
@@ -273,6 +274,7 @@ pref("devtools.browserconsole.filter.network", true);
 pref("devtools.browserconsole.filter.networkinfo", false);
 pref("devtools.browserconsole.filter.netwarn", true);
 pref("devtools.browserconsole.filter.netxhr", false);
+pref("devtools.browserconsole.filter.saveBodies", false);
 pref("devtools.browserconsole.filter.csserror", true);
 pref("devtools.browserconsole.filter.cssparser", false);
 pref("devtools.browserconsole.filter.csslog", false);

--- a/devtools/client/webconsole/webconsole.xul
+++ b/devtools/client/webconsole/webconsole.xul
@@ -96,6 +96,10 @@ function goUpdateConsoleCommands() {
                         prefKey="netxhr"/>
               <menuitem label="&btnConsoleLog;" type="checkbox" autocheck="false"
                         prefKey="networkinfo"/>
+              <menuseparator id="saveBodiesSeparator" />
+              <menuitem id="saveBodies" type="checkbox" label="&saveBodies.label;"
+                        accesskey="&saveBodies.accesskey;" autocheck="false"
+                        prefKey="saveBodies"/>
             </menupopup>
           </toolbarbutton>
           <toolbarbutton label="&btnPageCSS.label;" type="menu-button"


### PR DESCRIPTION
Tag #102 

IMHO: Debugging add-ons is an important thing.

__I suggest putting it into preferences:__
`devtools.webconsole.filter.saveBodies` (default = `true`)
`devtools.browserconsole.filter.saveBodies` (default = `false`)

__Implemented:__
- To simplify switches: the context menu isn't used
- `Log Request and Response Bodies` is a separate switch - after clicking on the menu category `Net` does not change

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.

But you add the label `Verification Needed`, please.
