### PR TITLE
Add UTF-8 as a default fallback encoding for unknown encodings

### DIFF
--- a/browser/components/preferences/fonts.xul
+++ b/browser/components/preferences/fonts.xul
@@ -255,7 +255,8 @@
                control="DefaultCharsetList"/>
         <menulist id="DefaultCharsetList" preference="intl.charset.fallback.override">
           <menupopup>
-            <menuitem label="&languages.customize.Fallback.auto;"        value=""/>
+            <menuitem label="&languages.customize.Fallback.auto;"        value="*"/>
+            <menuitem label="&languages.customize.Fallback.utf8;"        value="UTF-8"/>
             <menuitem label="&languages.customize.Fallback.arabic;"      value="windows-1256"/>
             <menuitem label="&languages.customize.Fallback.baltic;"      value="windows-1257"/>
             <menuitem label="&languages.customize.Fallback.ceiso;"       value="ISO-8859-2"/>

--- a/browser/locales/en-US/chrome/browser/preferences/fonts.dtd
+++ b/browser/locales/en-US/chrome/browser/preferences/fonts.dtd
@@ -70,6 +70,7 @@
 <!ENTITY languages.customize.Fallback2.desc       "This text encoding is used for legacy content that fails to declare its encoding.">
 
 <!ENTITY languages.customize.Fallback.auto        "Default for Current Locale">
+<!ENTITY languages.customize.Fallback.utf8        "UTF-8">
 <!-- LOCALIZATION NOTE (languages.customize.Fallback.arabic):
      Translate "Arabic" as an adjective for an encoding, not as the name of the language. -->
 <!ENTITY languages.customize.Fallback.arabic      "Arabic">

--- a/dom/encoding/FallbackEncoding.cpp
+++ b/dom/encoding/FallbackEncoding.cpp
@@ -55,8 +55,7 @@ FallbackEncoding::Get(nsACString& aFallback)
   // Don't let the user break things by setting the override to unreasonable
   // values via about:config
   if (!EncodingUtils::FindEncodingForLabel(override, mFallback) ||
-      !EncodingUtils::IsAsciiCompatible(mFallback) ||
-      mFallback.EqualsLiteral("UTF-8")) {
+      !EncodingUtils::IsAsciiCompatible(mFallback)) {
     mFallback.Truncate();
   }
 

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -2046,7 +2046,7 @@ pref("intl.accept_languages",               "chrome://global/locale/intl.propert
 pref("intl.menuitems.alwaysappendaccesskeys","chrome://global/locale/intl.properties");
 pref("intl.menuitems.insertseparatorbeforeaccesskeys","chrome://global/locale/intl.properties");
 pref("intl.charset.detector",               "chrome://global/locale/intl.properties");
-pref("intl.charset.fallback.override",      "");
+pref("intl.charset.fallback.override",      "*"); // '*' to make sure the UI selects the proper entry for 'auto'
 pref("intl.charset.fallback.tld",           true);
 pref("intl.ellipsis",                       "chrome://global-platform/locale/intl.properties");
 pref("intl.locale.matchOS",                 false);


### PR DESCRIPTION
This resolves #315

---

I've created the new build (x32, Windows) - `Basilisk` / `Pale Moon UXP` - and tested.
