### PR TITLE
Remove the obsolete `media.mediasource.format-reader` control from the preferences UI

### DIFF
--- a/application/palemoon/components/preferences/content.js
+++ b/application/palemoon/components/preferences/content.js
@@ -38,33 +38,11 @@ var gContentPane = {
    */
   updateMSE: function ()
   {
-    var checkboxMSENFR = document.getElementById('videoMSENFR');
     var checkboxMSEMP4 = document.getElementById('videoMSEMP4');
     var checkboxMSEWebM = document.getElementById('videoMSEWebM');
     var preference = document.getElementById('media.mediasource.enabled');
-    checkboxMSENFR.disabled = preference.value != true;
     checkboxMSEMP4.disabled = preference.value != true;
     checkboxMSEWebM.disabled = preference.value != true;
-    // Check and disable WebM if necessary
-    if (preference.value == true) {
-      this.updateMSEWebM();
-    }
-  },
-
-  /**
-   * Utility function to enable/disable the checkbox for MSE+WebM depending
-   * on the value of media.mediasource.format-reader.
-   */
-  updateMSEWebM: function ()
-  {
-    var checkboxMSEWebM = document.getElementById('videoMSEWebM');
-    var preference = document.getElementById('media.mediasource.format-reader');
-    checkboxMSEWebM.disabled = preference.value == true;
-    if (preference.value == true) {
-      // Switch off incompatible format
-      Services.prefs.setBoolPref('media.mediasource.webm.enabled', false);
-      checkboxMSEWebM.checked = false;
-    }
   },
 
   // BEGIN UI CODE

--- a/application/palemoon/components/preferences/content.xul
+++ b/application/palemoon/components/preferences/content.xul
@@ -33,10 +33,7 @@
                   onchange="gContentPane._rebuildFonts();"/>
                   
       <!-- VIDEO -->
-      <preference id="media.mediasource.enabled"       name="media.mediasource.enabled"       type="bool"
-        onchange="gContentPane.updateMSE();" />
-      <preference id="media.mediasource.format-reader" name="media.mediasource.format-reader" type="bool"
-        onchange="gContentPane.updateMSEWebM();" />
+      <preference id="media.mediasource.enabled"       name="media.mediasource.enabled"       type="bool"/>
       <preference id="media.mediasource.mp4.enabled"   name="media.mediasource.mp4.enabled"   type="bool"/>
       <preference id="media.mediasource.webm.enabled"  name="media.mediasource.webm.enabled"  type="bool"/>
       
@@ -163,8 +160,6 @@
        <checkbox id="videoMSE" preference="media.mediasource.enabled"
                  label="&videoMSE.label;" accesskey="&videoMSE.accesskey;"
                  onsyncfrompreference="gContentPane.updateMSE();"/>
-       <checkbox class="indent" id="videoMSENFR" preference="media.mediasource.format-reader"
-                 label="&videoMSENFR.label;" accesskey="&videoMSENFR.accesskey;"/>
        <checkbox class="indent" id="videoMSEMP4" preference="media.mediasource.mp4.enabled"
                  label="&videoMSEMP4.label;" accesskey="&videoMSEMP4.accesskey;"/>
        <checkbox class="indent" id="videoMSEWebM" preference="media.mediasource.webm.enabled"

--- a/application/palemoon/locales/en-US/chrome/browser/preferences/content.dtd
+++ b/application/palemoon/locales/en-US/chrome/browser/preferences/content.dtd
@@ -33,8 +33,6 @@
 <!ENTITY  video.label                 "Video">
 <!ENTITY  videoMSE.label              "Enable Media Source Extensions (MSE)">
 <!ENTITY  videoMSE.accesskey          "M">
-<!ENTITY  videoMSENFR.label           "Use MSE asynchronously">
-<!ENTITY  videoMSENFR.accesskey       "U">
 <!ENTITY  videoMSEMP4.label           "Enable MSE for MP4 video">
 <!ENTITY  videoMSEMP4.accesskey       "4">
 <!ENTITY  videoMSEWebM.label          "Enable MSE for WebM video">


### PR DESCRIPTION
Since [all the older non-formatreader code has been removed from UXP](https://github.com/MoonchildProductions/UXP/pull/275#issuecomment-385076597), the `media.mediasource.format-reader` control became obsolete and need to be removed from the preferences UI.

This along with https://github.com/MoonchildProductions/UXP/commit/99889f4cc62ffce222be79255ff3d75a8b8ccc28 reverts https://github.com/MoonchildProductions/Pale-Moon/commit/4a463ba721cef6c9f1018597ba2cfaa21150a7ce.

Tag #57.