### PR TITLE
about:sessionrestore - fix an error "treeView.treeBox is null" in aboutSessionRestore.js

### DIFF
--- a/browser/components/sessionstore/content/aboutSessionRestore.js
+++ b/browser/components/sessionstore/content/aboutSessionRestore.js
@@ -188,6 +188,9 @@ function onListClick(aEvent) {
   if (aEvent.button == 2)
     return;
 
+  if (!treeView.treeBox) {
+    return;
+  }
   var cell = treeView.treeBox.getCellAt(aEvent.clientX, aEvent.clientY);
   if (cell.col) {
     // Restore this specific tab in the same window for middle/double/accel clicking


### PR DESCRIPTION
__Steps to reproduce:__

Go to `about:sessionrestore`

Click into an empty tree with collumns "Restore | Windows and Tabs"

Throws an error in Browser Console:
```
TypeError: treeView.treeBox is null  aboutSessionRestore.js:191:7
```

---

I've created the new build (x32, Windows) - `Basilisk` - and tested:
- the above example
- a restore session (when the tree is not empty)
