### PR TITLE
about:welcomeback - fix an error "invalid 'in' operand gTreeData[idx]" in aboutSessionRestore.js

### DIFF
--- a/browser/components/sessionstore/content/aboutSessionRestore.js
+++ b/browser/components/sessionstore/content/aboutSessionRestore.js
@@ -188,6 +188,9 @@ function onListClick(aEvent) {
   if (aEvent.button == 2)
     return;
 
+  if (!treeView.treeBox) {
+    return;
+  }
   var cell = treeView.treeBox.getCellAt(aEvent.clientX, aEvent.clientY);
   if (cell.col) {
     // Restore this specific tab in the same window for middle/double/accel clicking

--- a/browser/components/sessionstore/content/aboutSessionRestore.js
+++ b/browser/components/sessionstore/content/aboutSessionRestore.js
@@ -289,7 +289,9 @@ var treeView = {
   get rowCount()                     { return gTreeData.length; },
   setTree: function(treeBox)         { this.treeBox = treeBox; },
   getCellText: function(idx, column) { return gTreeData[idx].label; },
-  isContainer: function(idx)         { return "open" in gTreeData[idx]; },
+  isContainer: function(idx)         {
+    return gTreeData[idx] ? "open" in gTreeData[idx] : false;
+  },
   getCellValue: function(idx, column){ return gTreeData[idx].checked; },
   isContainerOpen: function(idx)     { return gTreeData[idx].open; },
   isContainerEmpty: function(idx)    { return false; },


### PR DESCRIPTION
__Depends on:__
#350 

---

__Steps to reproduce:__

Go to `about:welcomeback`

Go to `Restore only the ones you want`

Click into an empty tree with collumns `Restore | Windows and Tabs`

__Throws an error in Browser Console:__
```
TypeError: invalid 'in' operand gTreeData[idx]  aboutSessionRestore.js:289:40
```

---

I've created the new build (x32, Windows) - `Basilisk` - and tested:
- the above example
- a refresh profile (`about:support` - `Refresh Basilisk`: when the tree is not empty)
