### PR TITLE
Revert incorrect UAO optimization that broke SSUAO

### DIFF
--- a/netwerk/base/nsILoadGroup.idl
+++ b/netwerk/base/nsILoadGroup.idl
@@ -95,10 +95,4 @@ interface nsILoadGroup : nsIRequest
      * the docShell has created the default request.)
      */
     attribute nsLoadFlags defaultLoadFlags;
-
-    /**
-     * The cached user agent override created by UserAgentOverrides.jsm. Used
-     * for all sub-resource requests in the loadgroup.
-     */
-    attribute ACString userAgentOverrideCache;
 };

--- a/netwerk/base/nsLoadGroup.cpp
+++ b/netwerk/base/nsLoadGroup.cpp
@@ -809,20 +809,6 @@ nsLoadGroup::SetDefaultLoadFlags(uint32_t aFlags)
     return NS_OK;
 }
 
-NS_IMETHODIMP
-nsLoadGroup::GetUserAgentOverrideCache(nsACString & aUserAgentOverrideCache)
-{
-  aUserAgentOverrideCache = mUserAgentOverrideCache;
-  return NS_OK;
-}
-
-NS_IMETHODIMP
-nsLoadGroup::SetUserAgentOverrideCache(const nsACString & aUserAgentOverrideCache)
-{
-  mUserAgentOverrideCache = aUserAgentOverrideCache;
-  return NS_OK;
-}
-
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/netwerk/base/nsLoadGroup.h
+++ b/netwerk/base/nsLoadGroup.h
@@ -95,8 +95,6 @@ protected:
 
     /* For nsPILoadGroupInternal */
     uint32_t                        mTimedNonCachedRequestsUntilOnEndPageLoad;
-
-    nsCString                       mUserAgentOverrideCache;
 };
 
 } // namespace net

--- a/netwerk/protocol/http/UserAgentOverrides.jsm
+++ b/netwerk/protocol/http/UserAgentOverrides.jsm
@@ -46,9 +46,9 @@ this.UserAgentOverrides = {
     Services.prefs.addObserver(PREF_OVERRIDES_ENABLED, buildOverrides, false);
 
     try {
-      Services.obs.addObserver(HTTP_on_useragent_request, "http-on-useragent-request", false);
+      Services.obs.addObserver(HTTP_on_modify_request, "http-on-modify-request", false);
     } catch (x) {
-      // The http-on-useragent-request notification is disallowed in content processes.
+      // The http-on-modify-request notification is disallowed in content processes.
     }
 
     UserAgentUpdates.init(function(overrides) {
@@ -118,7 +118,7 @@ this.UserAgentOverrides = {
 
     Services.prefs.removeObserver(PREF_OVERRIDES_ENABLED, buildOverrides);
 
-    Services.obs.removeObserver(HTTP_on_useragent_request, "http-on-useragent-request");
+    Services.obs.removeObserver(HTTP_on_modify_request, "http-on-modify-request");
   },
 
   receiveMessage: function(aMessage) {
@@ -169,7 +169,7 @@ function buildOverrides() {
   }
 }
 
-function HTTP_on_useragent_request(aSubject, aTopic, aData) {
+function HTTP_on_modify_request(aSubject, aTopic, aData) {
   let channel = aSubject.QueryInterface(Ci.nsIHttpChannel);
 
   for (let callback of gOverrideFunctions) {

--- a/netwerk/protocol/http/nsHttpChannel.cpp
+++ b/netwerk/protocol/http/nsHttpChannel.cpp
@@ -6031,8 +6031,6 @@ nsHttpChannel::BeginConnect()
     // notify "http-on-modify-request" observers
     CallOnModifyRequestObservers();
 
-    SetLoadGroupUserAgentOverride();
-
     // Check if request was cancelled during on-modify-request or on-useragent.
     if (mCanceled) {
         return mStatus;
@@ -8396,50 +8394,6 @@ nsHttpChannel::MaybeWarnAboutAppCache()
     GetCallback(warner);
     if (warner) {
         warner->IssueWarning(nsIDocument::eAppCache, false);
-    }
-}
-
-void
-nsHttpChannel::SetLoadGroupUserAgentOverride()
-{
-    nsCOMPtr<nsIURI> uri;
-    GetURI(getter_AddRefs(uri));
-    nsAutoCString uriScheme;
-    if (uri) {
-        uri->GetScheme(uriScheme);
-    }
-
-    // We don't need a UA for file: protocols.
-    if (uriScheme.EqualsLiteral("file")) {
-        gHttpHandler->OnUserAgentRequest(this);
-        return;
-    }
-
-    nsIRequestContextService* rcsvc = gHttpHandler->GetRequestContextService();
-    nsCOMPtr<nsIRequestContext> rc;
-    if (rcsvc) {
-        rcsvc->GetRequestContext(mRequestContextID,
-                                    getter_AddRefs(rc));
-    }
-
-    nsAutoCString ua;
-    if (nsContentUtils::IsNonSubresourceRequest(this)) {
-        gHttpHandler->OnUserAgentRequest(this);
-        if (rc) {
-            GetRequestHeader(NS_LITERAL_CSTRING("User-Agent"), ua);
-            rc->SetUserAgentOverride(ua);
-        }
-    } else {
-        GetRequestHeader(NS_LITERAL_CSTRING("User-Agent"), ua);
-        // Don't overwrite the UA if it is already set (eg by an XHR with explicit UA).
-        if (ua.IsEmpty()) {
-            if (rc) {
-                rc->GetUserAgentOverride(ua);
-                SetRequestHeader(NS_LITERAL_CSTRING("User-Agent"), ua, false);
-            } else {
-                gHttpHandler->OnUserAgentRequest(this);
-            }
-        }
     }
 }
 

--- a/netwerk/protocol/http/nsHttpChannel.h
+++ b/netwerk/protocol/http/nsHttpChannel.h
@@ -460,8 +460,6 @@ private:
 
     void MaybeWarnAboutAppCache();
 
-    void SetLoadGroupUserAgentOverride();
-
     void SetDoNotTrack();
 
 private:

--- a/netwerk/protocol/http/nsHttpHandler.h
+++ b/netwerk/protocol/http/nsHttpHandler.h
@@ -280,12 +280,6 @@ public:
         NotifyObservers(chan, NS_HTTP_ON_MODIFY_REQUEST_TOPIC);
     }
 
-    // Called by the channel and cached in the loadGroup
-    void OnUserAgentRequest(nsIHttpChannel *chan)
-    {
-      NotifyObservers(chan, NS_HTTP_ON_USERAGENT_REQUEST_TOPIC);
-    }
-
     // Called by the channel once headers are available
     void OnExamineResponse(nsIHttpChannel *chan)
     {

--- a/netwerk/protocol/http/nsIHttpProtocolHandler.idl
+++ b/netwerk/protocol/http/nsIHttpProtocolHandler.idl
@@ -113,14 +113,5 @@ interface nsIHttpProtocolHandler : nsIProxiedProtocolHandler
  */
 #define NS_HTTP_ON_EXAMINE_CACHED_RESPONSE_TOPIC "http-on-examine-cached-response"
 
-/**
- * Before an HTTP request corresponding to a channel with the LOAD_DOCUMENT_URI
- * flag is sent to the server, this observer topic is notified. The observer of
- * this topic can then choose to modify the user agent for this request before
- * the request is actually sent to the server. Additionally, the modified user
- * agent will be propagated to sub-resource requests from the same load group.
- */
-#define NS_HTTP_ON_USERAGENT_REQUEST_TOPIC "http-on-useragent-request"
-
 
 %}


### PR DESCRIPTION
This reverts https://bugzilla.mozilla.org/show_bug.cgi?id=1148544, which implemented cached UAO once per LoadGroup, rather than once per channel, that broke SSUAO.

Resolves #355.