### PR TITLE
Revive the quickdial page (about:newtab)

### DIFF
--- a/application/palemoon/base/content/newtab/grid.js
+++ b/application/palemoon/base/content/newtab/grid.js
@@ -115,10 +115,10 @@ var gGrid = {
     // (Re-)initialize all cells.
     let cellElements = this.node.querySelectorAll(".newtab-cell");
     // Tycho: this._cells = [new Cell(this, cell) for (cell of cellElements)];
-    this.cells = [];
+    this._cells = [];
     
     for (let cellItem of cellElements) {
-      this.cells.push(new Cell(this, cellItem));
+      this._cells.push(new Cell(this, cellItem));
     }
   },
 


### PR DESCRIPTION
Correction of the typo made [here](https://github.com/MoonchildProductions/UXP/commit/2569bca9308968c778f750c3db23c08d95aa7230) restores normal operation of the quickdial page.

Tag #57.