### PR TITLE
Don't link against crmf while building --with-system-nss

### DIFF
--- a/old-configure.in
+++ b/old-configure.in
@@ -2058,9 +2058,7 @@ if test -n "$_USE_SYSTEM_NSS"; then
     AM_PATH_NSS(3.28.6, [MOZ_SYSTEM_NSS=1], [AC_MSG_ERROR([you don't have NSS installed or your version is too old])])
 fi
 
-if test -n "$MOZ_SYSTEM_NSS"; then
-   NSS_LIBS="$NSS_LIBS -lcrmf"
-else
+if test -z "$MOZ_SYSTEM_NSS"; then
    NSS_CFLAGS="-I${DIST}/include/nss"
 fi
 


### PR DESCRIPTION
Bug: [1371991](https://bugzilla.mozilla.org/show_bug.cgi?id=1371991)

Since mozilla34, the crypto functions that make use of `libcrmf` has been [removed][0], so it's no longer necessary to link with `libcrmf`. Given our fork point, it's certain that we do not carry the functions that make use of `libcrmf` (test builds confirms this fact).

This patch removes `-lcrmf` from `NSS_LIBS`, which would allows building UXP with `--with-system-nss` on system where `libcrmf` is not available (eg. Arch Linux).

[0]: https://bugzilla.mozilla.org/show_bug.cgi?id=1030963