### PR TITLE
Explicitly specify the AccessPoint interface name

### DIFF
--- a/netwerk/wifi/nsWifiScannerDBus.cpp
+++ b/netwerk/wifi/nsWifiScannerDBus.cpp
@@ -62,7 +62,7 @@ nsWifiScannerDBus::SendMessage(const char* aInterface,
       return NS_ERROR_FAILURE;
     }
   } else if (!strcmp(aFuncCall, "GetAll")) {
-    const char* param = "";
+    const char* param = "org.freedesktop.NetworkManager.AccessPoint";
     if (!dbus_message_iter_append_basic(&argsIter, DBUS_TYPE_STRING, &param)) {
       return NS_ERROR_FAILURE;
     }


### PR DESCRIPTION
Fixes [Bug 1314968](https://bugzilla.mozilla.org/show_bug.cgi?id=1314968). This fixes wifi-based location for UXP for platform that provides the NetworkManager DBus interface.