### PR TITLE
external/nss: Don't link with libcrmf on --with-system-nss builds

### DIFF
--- a/config/external/nss/crmf/moz.build
+++ b/config/external/nss/crmf/moz.build
@@ -8,7 +8,6 @@ Library('crmf')
 
 if CONFIG['MOZ_SYSTEM_NSS']:
     OS_LIBS += [l for l in CONFIG['NSS_LIBS'] if l.startswith('-L')]
-    OS_LIBS += ['-lcrmf']
 else:
     USE_LIBS += [
         # The dependency on nss is not real, but is required to force the


### PR DESCRIPTION
Follow-up: #364 

This commit completely removes the `-lcrmf` for `--with-system-nss` builds, as libcrmf is not available on all systems (eg. Arch Linux).

This was meant to be a part of #364, but I forgot to push the commit to that PR. Sorry for the inconvenience.