### PR TITLE
[MSE] Add a missing comma in validBoxes

### DIFF
--- a/dom/media/mediasource/ContainerParser.cpp
+++ b/dom/media/mediasource/ContainerParser.cpp
@@ -390,7 +390,7 @@ private:
         "ftyp", "moov", // init segment
         "pdin", "free", "sidx", // optional prior moov box
         "styp", "moof", "mdat", // media segment
-        "mfra", "skip", "meta", "meco", "ssix", "prft" // others.
+        "mfra", "skip", "meta", "meco", "ssix", "prft", // others.
         "pssh", // optional with encrypted EME, though ignored.
         "emsg", // ISO23009-1:2014 Section 5.10.3.3
         "bloc", "uuid" // boxes accepted by chrome.


### PR DESCRIPTION
This fixes a small typo that we inherited from Mozilla that would prevent MSE playback from working in some instances.

No associated issue as this is a low-risk one-liner that has been tested on Linux..