### PR TITLE
[MSE] Correct ADTS frame size calculation

### DIFF
--- a/dom/media/mediasource/ContainerParser.cpp
+++ b/dom/media/mediasource/ContainerParser.cpp
@@ -588,8 +588,8 @@ public:
       return false;
     }
     size_t header_length = have_crc ? 9 : 7;
-    size_t data_length = (((*aData)[3] & 0x03) << 11) ||
-                         (((*aData)[4] & 0xff) << 3) ||
+    size_t data_length = (((*aData)[3] & 0x03) << 11) |
+                         (((*aData)[4] & 0xff) << 3) |
                          (((*aData)[5] & 0xe0) >> 5);
     uint8_t frames = ((*aData)[6] & 0x03) + 1;
     MOZ_ASSERT(frames > 0);


### PR DESCRIPTION
This fixes yet another Mozilla-inherited typo in our MSE code.

No associated issue as this is a low-risk two-liner and has been tested on Linux.