### PR TITLE
Fix null checks in dom/media

### DIFF
--- a/dom/media/ipc/VideoDecoderChild.cpp
+++ b/dom/media/ipc/VideoDecoderChild.cpp
@@ -238,6 +238,7 @@ VideoDecoderChild::Shutdown()
     SendShutdown();
   }
   mInitialized = false;
+  mCallback = nullptr;
 }
 
 bool

--- a/dom/media/ipc/VideoDecoderManagerParent.cpp
+++ b/dom/media/ipc/VideoDecoderManagerParent.cpp
@@ -194,7 +194,7 @@ VideoDecoderManagerParent::RecvReadback(const SurfaceDescriptorGPUVideo& aSD, Su
   }
 
   RefPtr<SourceSurface> source = image->GetAsSourceSurface();
-  if (!image) {
+  if (!source) {
     *aResult = null_t();
     return true;
   }

--- a/dom/media/ogg/OggCodecState.cpp
+++ b/dom/media/ogg/OggCodecState.cpp
@@ -1229,12 +1229,13 @@ already_AddRefed<MediaRawData>
 OpusState::PacketOutAsMediaRawData()
 {
   ogg_packet* packet = PacketPeek();
-  uint32_t frames = 0;
-  const int64_t endFrame = packet->granulepos;
-
   if (!packet) {
     return nullptr;
   }
+
+  uint32_t frames = 0;
+  const int64_t endFrame = packet->granulepos;
+
   if (packet->e_o_s) {
     frames = GetOpusDeltaGP(packet);
   }


### PR DESCRIPTION
This PR fixes a few null checks in our media code to prevent crashes under certain circumstances (all of these fixes were native in moebius).

Tested on Linux and works as intended.