### PR TITLE
Make fetch() use "same-origin" credentials by default

### DIFF
--- a/dom/fetch/Request.cpp
+++ b/dom/fetch/Request.cpp
@@ -327,7 +327,7 @@ Request::Constructor(const GlobalObject& aGlobal,
   RequestCache fallbackCache = RequestCache::EndGuard_;
   if (aInput.IsUSVString()) {
     fallbackMode = RequestMode::Cors;
-    fallbackCredentials = RequestCredentials::Omit;
+    fallbackCredentials = RequestCredentials::Same_origin;
     fallbackCache = RequestCache::Default;
   }
 

--- a/dom/tests/mochitest/fetch/test_fetch_cors.js
+++ b/dom/tests/mochitest/fetch/test_fetch_cors.js
@@ -64,9 +64,9 @@ function testSameOriginCredentials() {
                 withCred: "same-origin",
               },
               {
-                // Default mode is "omit".
+                // Default mode is "same-origin".
                 pass: 1,
-                noCookie: 1,
+                cookie: cookieStr,
               },
               {
                 pass: 1,

--- a/dom/tests/mochitest/fetch/test_request.js
+++ b/dom/tests/mochitest/fetch/test_request.js
@@ -6,7 +6,7 @@ function testDefaultCtor() {
   is(req.context, "fetch", "Default context is fetch.");
   is(req.referrer, "about:client", "Default referrer is `client` which serializes to about:client.");
   is(req.mode, "cors", "Request mode for string input is cors");
-  is(req.credentials, "omit", "Default Request credentials is omit");
+  is(req.credentials, "same-origin", "Default Request credentials is same-origin");
   is(req.cache, "default", "Default Request cache is default");
 
   var req = new Request(req);
@@ -16,7 +16,7 @@ function testDefaultCtor() {
   is(req.context, "fetch", "Default context is fetch.");
   is(req.referrer, "about:client", "Default referrer is `client` which serializes to about:client.");
   is(req.mode, "cors", "Request mode string input is cors");
-  is(req.credentials, "omit", "Default Request credentials is omit");
+  is(req.credentials, "same-origin", "Default Request credentials is same-origin");
   is(req.cache, "default", "Default Request cache is default");
 }
 

--- a/testing/web-platform/tests/fetch/api/request/request-init-003.sub.html
+++ b/testing/web-platform/tests/fetch/api/request/request-init-003.sub.html
@@ -44,7 +44,7 @@
                              "referrer" : "http://{{host}}:{{ports[http][0]}}/",
                              "referrerPolicy" : "",
                              "mode" : "cors",
-                             "credentials" : "omit",
+                             "credentials" : "same-origin",
                              "cache" : "default",
                              "redirect" : "follow",
                              "integrity" : "",

--- a/testing/web-platform/tests/fetch/api/request/request-structure.html
+++ b/testing/web-platform/tests/fetch/api/request/request-structure.html
@@ -82,7 +82,7 @@
             break;
 
           case "credentials":
-            defaultValue = "omit";
+            defaultValue = "same-origin";
             newValue = "cors";
             break;
 


### PR DESCRIPTION
This resolves #389

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
