### PR TITLE
Only display SSE2 error dialog on 32-bit Linux

### DIFF
--- a/application/palemoon/confvars.sh
+++ b/application/palemoon/confvars.sh
@@ -98,9 +98,11 @@ if test "$OS_ARCH" = "WINNT" -o \
   MOZ_BUNDLED_FONTS=1
 fi
 
-# Display an error on non-SSE2 Linux systems
-if test "$OS_ARCH" = "Linux"; then
-  MOZ_LINUX_SSE2_STARTUP_ERROR=1
+# Display an error on non-SSE2 32-bit Linux systems
+if ! test "$HAVE_64BIT_BUILD"; then
+  if test "$OS_ARCH" = "Linux"; then
+    MOZ_LINUX_SSE2_STARTUP_ERROR=1
+  fi
 fi
 
 # Short-circuit a few services to be removed

--- a/browser/confvars.sh
+++ b/browser/confvars.sh
@@ -18,9 +18,11 @@ if test "$OS_ARCH" = "WINNT"; then
   MOZ_MAINTENANCE_SERVICE=
 fi
 
-# Display an error on non-SSE2 Linux systems
-if test "$OS_ARCH" = "Linux"; then
-  MOZ_LINUX_SSE2_STARTUP_ERROR=1
+# Display an error on non-SSE2 32-bit Linux systems
+if ! test "$HAVE_64BIT_BUILD"; then
+  if test "$OS_ARCH" = "Linux"; then
+    MOZ_LINUX_SSE2_STARTUP_ERROR=1
+  fi
 fi
 
 # For Basilisk we want to use 52.9.YYYY.MM.DD as MOZ_APP_VERSION in release


### PR DESCRIPTION
Just what it says in the tin. All 64-bit CPU's support SSE2 so there's no reason to have this code on 64-bit builds.

Tested on both 32 and 64-bit environments and works as intended.