### PR TITLE
Revert "Only display SSE2 error dialog on 32-bit Linux"

### DIFF
--- a/application/palemoon/confvars.sh
+++ b/application/palemoon/confvars.sh
@@ -98,11 +98,9 @@ if test "$OS_ARCH" = "WINNT" -o \
   MOZ_BUNDLED_FONTS=1
 fi
 
-# Display an error on non-SSE2 32-bit Linux systems
-if ! test "$HAVE_64BIT_BUILD"; then
-  if test "$OS_ARCH" = "Linux"; then
-    MOZ_LINUX_SSE2_STARTUP_ERROR=1
-  fi
+# Display an error on non-SSE2 Linux systems
+if test "$OS_ARCH" = "Linux"; then
+  MOZ_LINUX_SSE2_STARTUP_ERROR=1
 fi
 
 # Short-circuit a few services to be removed

--- a/browser/confvars.sh
+++ b/browser/confvars.sh
@@ -18,11 +18,9 @@ if test "$OS_ARCH" = "WINNT"; then
   MOZ_MAINTENANCE_SERVICE=
 fi
 
-# Display an error on non-SSE2 32-bit Linux systems
-if ! test "$HAVE_64BIT_BUILD"; then
-  if test "$OS_ARCH" = "Linux"; then
-    MOZ_LINUX_SSE2_STARTUP_ERROR=1
-  fi
+# Display an error on non-SSE2 Linux systems
+if test "$OS_ARCH" = "Linux"; then
+  MOZ_LINUX_SSE2_STARTUP_ERROR=1
 fi
 
 # For Basilisk we want to use 52.9.YYYY.MM.DD as MOZ_APP_VERSION in release


### PR DESCRIPTION
Reverts MoonchildProductions/UXP#397