### PR TITLE
Build - Fix throws a warning: 'rv': unreferenced local variable

### DIFF
--- a/netwerk/protocol/http/HttpChannelParent.cpp
+++ b/netwerk/protocol/http/HttpChannelParent.cpp
@@ -737,7 +737,6 @@ HttpChannelParent::RecvRedirect2Verify(const nsresult& result,
 {
   LOG(("HttpChannelParent::RecvRedirect2Verify [this=%p result=%x]\n",
        this, result));
-  nsresult rv;
   if (NS_SUCCEEDED(result)) {
     nsCOMPtr<nsIHttpChannel> newHttpChannel =
         do_QueryInterface(mRedirectChannel);


### PR DESCRIPTION
Tag #412 

Build - throws a warning:
```
 "[drive]:\\[path]\\netwerk\\protocol\\http\\HttpChannelParent.cpp": {
      "warnings": [
        {
          "column": null, 
          "line": 740, 
          "flag": "C4101", 
          "message": "'rv': unreferenced local variable", 
        }
      ]
    },
```

---

I've created the new build (x32, Windows) - `Pale Moon UXP`.
