### PR TITLE
[PALEMOON] Use ShellService.jsm to get the shell service in utilityOverlay.js

### DIFF
--- a/application/palemoon/base/content/utilityOverlay.js
+++ b/application/palemoon/base/content/utilityOverlay.js
@@ -9,6 +9,9 @@ Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
 Components.utils.import("resource://gre/modules/PrivateBrowsingUtils.jsm");
 Components.utils.import("resource:///modules/RecentWindow.jsm");
 
+XPCOMUtils.defineLazyModuleGetter(this, "ShellService",
+                                  "resource:///modules/ShellService.jsm");
+
 XPCOMUtils.defineLazyGetter(this, "BROWSER_NEW_TAB_URL", function () {
   const PREF = "browser.newtab.url";
 
@@ -448,15 +451,10 @@ function gatherTextUnder ( root )
   return text;
 }
 
+// This function exists for legacy reasons.
 function getShellService()
 {
-  var shell = null;
-  try {
-    shell = Components.classes["@mozilla.org/browser/shell-service;1"]
-      .getService(Components.interfaces.nsIShellService);
-  } catch (e) {
-  }
-  return shell;
+  return ShellService;
 }
 
 function isBidiEnabled() {


### PR DESCRIPTION
Access to the `canSetDesktopBackground()`, `shouldCheckDefaultBrowser()` and `isDefaultBrowser()` functions of the shell service [stolen from Basilisk](https://github.com/MoonchildProductions/UXP/commit/20cae79eb3ce238022056d104e2efcb03139f2e1) requires `ShellService.jsm` as a proxy.

Resolves #420, tag #57.