### PR TITLE
Get rid of AppConstants in `application/palemoon`

### DIFF
--- a/application/palemoon/base/content/autocomplete.xml
+++ b/application/palemoon/base/content/autocomplete.xml
@@ -449,13 +449,15 @@
 
           var cancel = false;
 
-          let { AppConstants } =
-              Components.utils.import("resource://gre/modules/AppConstants.jsm", {});
           // Catch any keys that could potentially move the caret. Ctrl can be
           // used in combination with these keys on Windows and Linux; and Alt
           // can be used on OS X, so make sure the unused one isn't used.
-          let metaKey = AppConstants.platform == "macosx" ? aEvent.ctrlKey : aEvent.altKey;
-          if (!this.disableKeyNavigation && !metaKey) {
+          if (!this.disableKeyNavigation &&
+#ifdef XP_MACOSX
+              !aEvent.ctrlKey) {
+#else
+              !aEvent.altKey) {
+#endif
             switch (aEvent.keyCode) {
               case KeyEvent.DOM_VK_LEFT:
               case KeyEvent.DOM_VK_RIGHT:
@@ -492,11 +494,11 @@
               cancel = this.mController.handleEscape();
               break;
             case KeyEvent.DOM_VK_RETURN:
-              if (AppConstants.platform == "macosx") {
-                // Prevent the default action, since it will beep on Mac
-                if (aEvent.metaKey)
-                  aEvent.preventDefault();
-              }
+#ifdef XP_MACOSX
+              // Prevent the default action, since it will beep on Mac
+              if (aEvent.metaKey)
+                aEvent.preventDefault();
+#endif
               this.mEnterEvent = aEvent;
               if (this.mController.selection) {
                 this._selectionDetails = {
@@ -507,26 +509,30 @@
               cancel = this.handleEnter();
               break;
             case KeyEvent.DOM_VK_DELETE:
-              if (AppConstants.platform == "macosx" && !aEvent.shiftKey) {
+#ifdef XP_MACOSX
+              if (!aEvent.shiftKey) {
                 break;
               }
+#endif
               cancel = this.handleDelete();
               break;
+#ifdef XP_MACOSX
             case KeyEvent.DOM_VK_BACK_SPACE:
-              if (AppConstants.platform == "macosx" && aEvent.shiftKey) {
+              if (aEvent.shiftKey) {
                 cancel = this.handleDelete();
               }
               break;
+#endif
             case KeyEvent.DOM_VK_DOWN:
             case KeyEvent.DOM_VK_UP:
               if (aEvent.altKey)
                 this.toggleHistoryPopup();
               break;
+#ifndef XP_MACOSX
             case KeyEvent.DOM_VK_F4:
-              if (AppConstants.platform != "macosx") {
-                this.toggleHistoryPopup();
-              }
+              this.toggleHistoryPopup();
               break;
+#endif
           }
 
           if (cancel) {

--- a/application/palemoon/components/shell/ShellService.jsm
+++ b/application/palemoon/components/shell/ShellService.jsm
@@ -8,7 +8,6 @@ this.EXPORTED_SYMBOLS = ["ShellService"];
 
 const { classes: Cc, interfaces: Ci, utils: Cu, results: Cr } = Components;
 
-Cu.import("resource://gre/modules/AppConstants.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "WindowsRegistry",
@@ -26,20 +25,18 @@ var ShellServiceInternal = {
    * environments.
    */
   get canSetDesktopBackground() {
-    if (AppConstants.platform == "win" ||
-        AppConstants.platform == "macosx") {
-      return true;
+#if defined(XP_WIN) || defined(XP_MACOSX)
+    return true;
+#elif XP_LINUX
+    if (this.shellService) {
+      let linuxShellService = this.shellService
+                                  .QueryInterface(Ci.nsIGNOMEShellService);
+      return linuxShellService.canSetDesktopBackground;
     }
-
-    if (AppConstants.platform == "linux") {
-      if (this.shellService) {
-        let linuxShellService = this.shellService
-                                    .QueryInterface(Ci.nsIGNOMEShellService);
-        return linuxShellService.canSetDesktopBackground;
-      }
-    }
-
     return false;
+#else
+    return false;
+#endif
   },
 
   /**
@@ -60,18 +57,18 @@ var ShellServiceInternal = {
       return false;
     }
 
-    if (AppConstants.platform == "win") {
-      let optOutValue = WindowsRegistry.readRegKey(Ci.nsIWindowsRegKey.ROOT_KEY_CURRENT_USER,
-                                                   "Software\\Mozilla\\PaleMoon",
-                                                   "DefaultBrowserOptOut");
-      WindowsRegistry.removeRegKey(Ci.nsIWindowsRegKey.ROOT_KEY_CURRENT_USER,
-                                   "Software\\Mozilla\\PaleMoon",
-                                   "DefaultBrowserOptOut");
-      if (optOutValue == "True") {
-        Services.prefs.setBoolPref("browser.shell.checkDefaultBrowser", false);
-        return false;
-      }
+#ifdef XP_WIN
+    let optOutValue = WindowsRegistry.readRegKey(Ci.nsIWindowsRegKey.ROOT_KEY_CURRENT_USER,
+                                                 "Software\\Mozilla\\PaleMoon",
+                                                 "DefaultBrowserOptOut");
+    WindowsRegistry.removeRegKey(Ci.nsIWindowsRegKey.ROOT_KEY_CURRENT_USER,
+                                 "Software\\Mozilla\\PaleMoon",
+                                 "DefaultBrowserOptOut");
+    if (optOutValue == "True") {
+      Services.prefs.setBoolPref("browser.shell.checkDefaultBrowser", false);
+      return false;
     }
+#endif
 
     return true;
   },

--- a/application/palemoon/components/shell/content/setDesktopBackground.js
+++ b/application/palemoon/components/shell/content/setDesktopBackground.js
@@ -2,13 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-Components.utils.import("resource://gre/modules/AppConstants.jsm");
-
 var Ci = Components.interfaces;
 
 var gSetBackground = {
-  _position        : AppConstants.platform == "macosx" ? "STRETCH" : "",
-  _backgroundColor : AppConstants.platform != "macosx" ? 0 : undefined,
+#ifdef XP_MACOSX
+  _position        : "STRETCH",
+  _backgroundColor : undefined,
+#else
+  _position        : "",
+  _backgroundColor : 0,
+#endif
   _screenWidth     : 0,
   _screenHeight    : 0,
   _image           : null,
@@ -25,23 +28,23 @@ var gSetBackground = {
     this._canvas = document.getElementById("screen");
     this._screenWidth = screen.width;
     this._screenHeight = screen.height;
-    if (AppConstants.platform == "macosx") {
-      document.documentElement.getButton("accept").hidden = true;
-    }
+#ifdef XP_MACOSX
+    document.documentElement.getButton("accept").hidden = true;
+#endif
     if (this._screenWidth / this._screenHeight >= 1.6)
       document.getElementById("monitor").setAttribute("aspectratio", "16:10");
 
-    if (AppConstants.platform == "win") {
-      // Hide fill + fit options if < Win7 since they don't work.
-      var version = Components.classes["@mozilla.org/system-info;1"]
-                    .getService(Ci.nsIPropertyBag2)
-                    .getProperty("version");
-      var isWindows7OrHigher = (parseFloat(version) >= 6.1);
-      if (!isWindows7OrHigher) {
-        document.getElementById("fillPosition").hidden = true;
-        document.getElementById("fitPosition").hidden = true;
-      }
+#ifdef XP_WIN
+    // Hide fill + fit options if < Win7 since they don't work.
+    var version = Components.classes["@mozilla.org/system-info;1"]
+                  .getService(Ci.nsIPropertyBag2)
+                  .getProperty("version");
+    var isWindows7OrHigher = (parseFloat(version) >= 6.1);
+    if (!isWindows7OrHigher) {
+      document.getElementById("fillPosition").hidden = true;
+      document.getElementById("fitPosition").hidden = true;
     }
+#endif
 
     // make sure that the correct dimensions will be used
     setTimeout(function(self) {
@@ -60,37 +63,37 @@ var gSetBackground = {
     var ctx = this._canvas.getContext("2d");
     ctx.scale(this._canvas.clientWidth / this._screenWidth, this._canvas.clientHeight / this._screenHeight);
 
-    if (AppConstants.platform != "macosx") {
-      this._initColor();
-    } else {
-      // Make sure to reset the button state in case the user has already
-      // set an image as their desktop background.
-      var setDesktopBackground = document.getElementById("setDesktopBackground");
-      setDesktopBackground.hidden = false;
-      var bundle = document.getElementById("backgroundBundle");
-      setDesktopBackground.label = bundle.getString("DesktopBackgroundSet");
-      setDesktopBackground.disabled = false;
+#ifndef XP_MACOSX
+    this._initColor();
+#else
+    // Make sure to reset the button state in case the user has already
+    // set an image as their desktop background.
+    var setDesktopBackground = document.getElementById("setDesktopBackground");
+    setDesktopBackground.hidden = false;
+    var bundle = document.getElementById("backgroundBundle");
+    setDesktopBackground.label = bundle.getString("DesktopBackgroundSet");
+    setDesktopBackground.disabled = false;
 
-      document.getElementById("showDesktopPreferences").hidden = true;
-    }
+    document.getElementById("showDesktopPreferences").hidden = true;
+#endif
     this.updatePosition();
   },
 
   setDesktopBackground: function ()
   {
-    if (AppConstants.platform != "macosx") {
-      document.persist("menuPosition", "value");
-      this._shell.desktopBackgroundColor = this._hexStringToLong(this._backgroundColor);
-    } else {
-      Components.classes["@mozilla.org/observer-service;1"]
-                .getService(Ci.nsIObserverService)
-                .addObserver(this, "shell:desktop-background-changed", false);
+#ifndef XP_MACOSX
+    document.persist("menuPosition", "value");
+    this._shell.desktopBackgroundColor = this._hexStringToLong(this._backgroundColor);
+#else
+    Components.classes["@mozilla.org/observer-service;1"]
+              .getService(Ci.nsIObserverService)
+              .addObserver(this, "shell:desktop-background-changed", false);
 
-      var bundle = document.getElementById("backgroundBundle");
-      var setDesktopBackground = document.getElementById("setDesktopBackground");
-      setDesktopBackground.disabled = true;
-      setDesktopBackground.label = bundle.getString("DesktopBackgroundDownloading");
-    }
+    var bundle = document.getElementById("backgroundBundle");
+    var setDesktopBackground = document.getElementById("setDesktopBackground");
+    setDesktopBackground.disabled = true;
+    setDesktopBackground.label = bundle.getString("DesktopBackgroundDownloading");
+#endif
     this._shell.setDesktopBackground(this._image,
                                      Ci.nsIShellService["BACKGROUND_" + this._position]);
   },
@@ -100,9 +103,9 @@ var gSetBackground = {
     var ctx = this._canvas.getContext("2d");
     ctx.clearRect(0, 0, this._screenWidth, this._screenHeight);
 
-    if (AppConstants.platform != "macosx") {
-      this._position = document.getElementById("menuPosition").value;
-    }
+#ifndef XP_MACOSX
+    this._position = document.getElementById("menuPosition").value;
+#endif
 
     switch (this._position) {
       case "TILE":
@@ -158,57 +161,57 @@ var gSetBackground = {
   }
 };
 
-if (AppConstants.platform != "macosx") {
-  gSetBackground["_initColor"] = function ()
-  {
-    var color = this._shell.desktopBackgroundColor;
+#ifndef XP_MACOSX
+gSetBackground["_initColor"] = function ()
+{
+  var color = this._shell.desktopBackgroundColor;
 
-    const rMask = 4294901760;
-    const gMask = 65280;
-    const bMask = 255;
-    var r = (color & rMask) >> 16;
-    var g = (color & gMask) >> 8;
-    var b = (color & bMask);
-    this.updateColor(this._rgbToHex(r, g, b));
+  const rMask = 4294901760;
+  const gMask = 65280;
+  const bMask = 255;
+  var r = (color & rMask) >> 16;
+  var g = (color & gMask) >> 8;
+  var b = (color & bMask);
+  this.updateColor(this._rgbToHex(r, g, b));
 
-    var colorpicker = document.getElementById("desktopColor");
-    colorpicker.color = this._backgroundColor;
-  };
+  var colorpicker = document.getElementById("desktopColor");
+  colorpicker.color = this._backgroundColor;
+};
 
-  gSetBackground["updateColor"] = function (aColor)
-  {
-    this._backgroundColor = aColor;
-    this._canvas.style.backgroundColor = aColor;
-  };
+gSetBackground["updateColor"] = function (aColor)
+{
+  this._backgroundColor = aColor;
+  this._canvas.style.backgroundColor = aColor;
+};
 
-  // Converts a color string in the format "#RRGGBB" to an integer.
-  gSetBackground["_hexStringToLong"] = function (aString)
-  {
-    return parseInt(aString.substring(1, 3), 16) << 16 |
-           parseInt(aString.substring(3, 5), 16) << 8 |
-           parseInt(aString.substring(5, 7), 16);
-  };
+// Converts a color string in the format "#RRGGBB" to an integer.
+gSetBackground["_hexStringToLong"] = function (aString)
+{
+  return parseInt(aString.substring(1, 3), 16) << 16 |
+         parseInt(aString.substring(3, 5), 16) << 8 |
+         parseInt(aString.substring(5, 7), 16);
+};
 
-  gSetBackground["_rgbToHex"] = function (aR, aG, aB)
-  {
-    return "#" + [aR, aG, aB].map(aInt => aInt.toString(16).replace(/^(.)$/, "0$1"))
-                             .join("").toUpperCase();
-  };
-} else {
-  gSetBackground["observe"] = function (aSubject, aTopic, aData)
-  {
-    if (aTopic == "shell:desktop-background-changed") {
-      document.getElementById("setDesktopBackground").hidden = true;
-      document.getElementById("showDesktopPreferences").hidden = false;
+gSetBackground["_rgbToHex"] = function (aR, aG, aB)
+{
+  return "#" + [aR, aG, aB].map(aInt => aInt.toString(16).replace(/^(.)$/, "0$1"))
+                           .join("").toUpperCase();
+};
+#else
+gSetBackground["observe"] = function (aSubject, aTopic, aData)
+{
+  if (aTopic == "shell:desktop-background-changed") {
+    document.getElementById("setDesktopBackground").hidden = true;
+    document.getElementById("showDesktopPreferences").hidden = false;
 
-      Components.classes["@mozilla.org/observer-service;1"]
-                .getService(Ci.nsIObserverService)
-                .removeObserver(this, "shell:desktop-background-changed");
-    }
-  };
+    Components.classes["@mozilla.org/observer-service;1"]
+              .getService(Ci.nsIObserverService)
+              .removeObserver(this, "shell:desktop-background-changed");
+  }
+};
 
-  gSetBackground["showDesktopPrefs"] = function()
-  {
-    this._shell.openApplication(Ci.nsIMacShellService.APPLICATION_DESKTOP);
-  };
-}
+gSetBackground["showDesktopPrefs"] = function()
+{
+  this._shell.openApplication(Ci.nsIMacShellService.APPLICATION_DESKTOP);
+};
+#endif

--- a/application/palemoon/components/shell/jar.mn
+++ b/application/palemoon/components/shell/jar.mn
@@ -4,4 +4,4 @@
 
 browser.jar:
 *       content/browser/setDesktopBackground.xul              (content/setDesktopBackground.xul)
-        content/browser/setDesktopBackground.js               (content/setDesktopBackground.js)
+*       content/browser/setDesktopBackground.js               (content/setDesktopBackground.js)

--- a/application/palemoon/components/shell/moz.build
+++ b/application/palemoon/components/shell/moz.build
@@ -46,7 +46,7 @@ EXTRA_COMPONENTS += [
     'nsSetDefaultBrowser.manifest',
 ]
 
-EXTRA_JS_MODULES += [
+EXTRA_PP_JS_MODULES += [
     'ShellService.jsm',
 ]
 


### PR DESCRIPTION
`AppConstants.jsm` is used in the following two places in `application/palemoon`:

* shell component
* autocomplete.xml

This PR uses preprocessing to get rid of it.

Tag #65.