### PR TITLE
Check if there are any unpreprocessed files in '@MOZ_OBJDIR@/dist/bin'

### DIFF
--- a/python/mozbuild/mozbuild/mach_commands.py
+++ b/python/mozbuild/mozbuild/mach_commands.py
@@ -541,9 +541,11 @@ class Build(MachCommandBase):
                 # as when doing OSX Universal builds)
                 pass
 
-        # Check if there are any unpreprocessed files
-        grepcmd = 'grep -E -r "^(#|%)ifdef" --include=\*.{js\*,css,x\*,h\*,manifest,dtd,properties} '\
-                  + self.topobjdir + '/dist/bin'
+        # Check if there are any unpreprocessed files in '@MOZ_OBJDIR@/dist/bin'
+        # See python/mozbuild/mozbuild/preprocessor.py#L293-L309 for the list of directives
+        grepcmd = 'grep -E -r "^(#|%)(define|el|endif|error|expand|filter|if|include|literal|undef|unfilter)" '\
+                  + '--include=\*.{css,dtd,h\*,js\*,x\*,manifest,properties,rdf} '\
+                  + self.topobjdir + '/dist/bin | grep -v ".css:#"'
         grepresult = subprocess.Popen(grepcmd, stdout=subprocess.PIPE, shell=True).communicate()[0]
         if grepresult:
             print('\nERROR: preprocessor was not applied to the following files:\n\n' + grepresult)

--- a/python/mozbuild/mozbuild/mach_commands.py
+++ b/python/mozbuild/mozbuild/mach_commands.py
@@ -543,7 +543,8 @@ class Build(MachCommandBase):
 
         # Check if there are any unpreprocessed files in '@MOZ_OBJDIR@/dist/bin'
         # See python/mozbuild/mozbuild/preprocessor.py#L293-L309 for the list of directives
-        grepcmd = 'grep -E -r "^(#|%)(define|el|endif|error|expand|filter|if|include|literal|undef|unfilter)" '\
+        # We skip if, ifdef, ifndef, else, elif, elifdef and elifndef, because they are never used alone
+        grepcmd = 'grep -E -r "^(#|%)(define|endif|error|expand|filter|include|literal|undef|unfilter)" '\
                   + '--include=\*.{css,dtd,html,js,jsm,xhtml,xml,xul,manifest,properties,rdf} '\
                   + self.topobjdir + '/dist/bin | grep -v ".css:#"'
         grepresult = subprocess.Popen(grepcmd, stdout=subprocess.PIPE, shell=True).communicate()[0]

--- a/python/mozbuild/mozbuild/mach_commands.py
+++ b/python/mozbuild/mozbuild/mach_commands.py
@@ -541,6 +541,13 @@ class Build(MachCommandBase):
                 # as when doing OSX Universal builds)
                 pass
 
+        # Check if there are any unpreprocessed files
+        grepcmd = 'grep -E -r "^(#|%)ifdef" --include=\*.{js\*,css,x\*,h\*,manifest,dtd,properties} '\
+                  + self.topobjdir + '/dist/bin'
+        grepresult = subprocess.Popen(grepcmd, stdout=subprocess.PIPE, shell=True).communicate()[0]
+        if grepresult:
+            print('\nERROR: preprocessor was not applied to the following files:\n\n' + grepresult)
+
         return status
 
     @Command('configure', category='build',

--- a/python/mozbuild/mozbuild/mach_commands.py
+++ b/python/mozbuild/mozbuild/mach_commands.py
@@ -544,7 +544,7 @@ class Build(MachCommandBase):
         # Check if there are any unpreprocessed files in '@MOZ_OBJDIR@/dist/bin'
         # See python/mozbuild/mozbuild/preprocessor.py#L293-L309 for the list of directives
         grepcmd = 'grep -E -r "^(#|%)(define|el|endif|error|expand|filter|if|include|literal|undef|unfilter)" '\
-                  + '--include=\*.{css,dtd,h\*,js\*,x\*,manifest,properties,rdf} '\
+                  + '--include=\*.{css,dtd,html,js,jsm,xhtml,xml,xul,manifest,properties,rdf} '\
                   + self.topobjdir + '/dist/bin | grep -v ".css:#"'
         grepresult = subprocess.Popen(grepcmd, stdout=subprocess.PIPE, shell=True).communicate()[0]
         if grepresult:


### PR DESCRIPTION
This is intended to reduce the number of errors in case not all the necessary files are added to the preprocessing.

The check is performed automatically after each `mach build`.

Resolves #428.