### PR TITLE
[PALEMOON] Fix the Findbar - open when you press "/" or "'" keys

### DIFF
--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -64,7 +64,7 @@ XPCOMUtils.defineLazyGetter(window, "gFindBar", function() {
 
   // Force a style flush to ensure that our binding is attached.
   findbar.clientTop;
-  findbar.browser = gBrowser;
+  findbar.browser = gBrowser.mCurrentBrowser;
   window.gFindBarInitialized = true;
   return findbar;
 });

--- a/application/palemoon/base/content/tabbrowser.xml
+++ b/application/palemoon/base/content/tabbrowser.xml
@@ -3096,13 +3096,25 @@
               break;
             }
             case "Findbar:Keypress":
-              if (!gFindBarInitialized) {
-                // If the find bar for this tab is not yet alive, change that,
-                // and make sure we return the result:
-                return gFindBar.receiveMessage(aMessage);
+              // If the find bar for this tab is not yet alive, only initialize
+              // it if there's a possibility FindAsYouType will be used.
+              // There's no point in doing it for most random keypresses.
+              if (!gFindBarInitialized && aMessage.data.shouldFastFind) {
+                let shouldFastFind = this._findAsYouType;
+                if (!shouldFastFind) {
+                  // Please keep in sync with toolkit/content/widgets/findbar.xml
+                  const FAYT_LINKS_KEY = "'";
+                  const FAYT_TEXT_KEY = "/";
+                  let charCode = aMessage.data.fakeEvent.charCode;
+                  let key = charCode ? String.fromCharCode(charCode) : null;
+                  shouldFastFind = key == FAYT_LINKS_KEY || key == FAYT_TEXT_KEY;
+                }
+                if (shouldFastFind) {
+                  // Make sure we return the result.
+                  return gFindBar.receiveMessage(aMessage);
+                }
               }
               break;
-
           }
         ]]></body>
       </method>
@@ -3169,6 +3181,10 @@
                                               this.mCurrentBrowser);
           }
           messageManager.addMessageListener("DOMWebNotificationClicked", this);
+
+          // To correctly handle keypresses for potential FindAsYouType, while
+          // the tab's find bar is not yet initialized.
+          this._findAsYouType = Services.prefs.getBoolPref("accessibility.typeaheadfind");
           messageManager.addMessageListener("Findbar:Keypress", this);
         ]]>
       </constructor>
@@ -3429,6 +3445,7 @@
           tab.setAttribute("onerror", "this.removeAttribute('image');");
           this.adjustTabstrip();
 
+          Services.prefs.addObserver("accessibility.typeaheadfind", this._prefObserver, false);
           Services.prefs.addObserver("browser.tabs.", this._prefObserver, false);
           window.addEventListener("resize", this, false);
           window.addEventListener("load", this, false);
@@ -3444,6 +3461,7 @@
 
       <destructor>
         <![CDATA[
+          Services.prefs.removeObserver("accessibility.typeaheadfind", this._prefObserver);
           Services.prefs.removeObserver("browser.tabs.", this._prefObserver);
         ]]>
       </destructor>
@@ -3509,6 +3527,9 @@
 
         observe: function (subject, topic, data) {
           switch (data) {
+            case "accessibility.typeaheadfind":
+              this._findAsYouType = Services.prefs.getBoolPref(data);
+              break;
             case "browser.tabs.closeButtons":
               this.tabContainer.mCloseButtons = Services.prefs.getIntPref(data);
               this.tabContainer.adjustTabstrip();

--- a/toolkit/content/browser-content.js
+++ b/toolkit/content/browser-content.js
@@ -841,6 +841,36 @@ var FindBar = {
         fakeEvent[k] = event[k];
       }
     }
+#ifdef MC_PALEMOON
+    let findBarId = "FindToolbar";
+    // The FindBar is in the chrome window's context, not in tabbrowser
+    // - see also bug 537013
+    let chromeWin = null;
+    try {
+       chromeWin = content
+         .QueryInterface(Ci.nsIInterfaceRequestor)
+         .getInterface(Ci.nsIWebNavigation)
+         .QueryInterface(Ci.nsIDocShellTreeItem)
+         .rootTreeItem
+         .QueryInterface(Ci.nsIInterfaceRequestor)
+         .getInterface(Ci.nsIDOMWindow)
+         .QueryInterface(Ci.nsIDOMChromeWindow);
+    } catch (e) {
+      Cu.reportError(
+          "The FindBar - the chrome window's context was not detected:\n" + e);
+    }
+    if (chromeWin && chromeWin.document.getElementById(findBarId)) {
+      try {
+        chromeWin.document.getElementById(findBarId)
+            .browser = Services.wm.getMostRecentWindow("navigator:browser")
+                .gBrowser.mCurrentBrowser;
+      } catch (e) {
+        Cu.reportError(
+            "The FindBar - cannot set the property 'browser':\n" + e);
+      }
+    }
+#endif
+
     // sendSyncMessage returns an array of the responses from all listeners
     let rv = sendSyncMessage("Findbar:Keypress", {
       fakeEvent: fakeEvent,

--- a/toolkit/content/jar.mn
+++ b/toolkit/content/jar.mn
@@ -37,8 +37,8 @@ toolkit.jar:
    content/global/plugins.html
    content/global/plugins.css
    content/global/browser-child.js
-   content/global/browser-content.js
-*   content/global/buildconfig.html
+*  content/global/browser-content.js
+*  content/global/buildconfig.html
    content/global/contentAreaUtils.js
 #ifndef MOZ_FENNEC
    content/global/customizeToolbar.css
@@ -56,7 +56,7 @@ toolkit.jar:
    content/global/filepicker.properties
    content/global/globalOverlay.js
    content/global/memoriam.xhtml
-*   content/global/mozilla.css
+*  content/global/mozilla.css
    content/global/mozilla.xhtml
 #ifdef MOZ_PHOENIX
    content/global/logopage.xhtml


### PR DESCRIPTION
This resolves #430

Tag #276 (follow up)

Based on:
https://bugzilla.mozilla.org/show_bug.cgi?id=1218351

...and the FindBar (in Pale Moon) is in the chrome window's context, not in tabs - see also:
https://bugzilla.mozilla.org/show_bug.cgi?id=537013

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
