### PR TITLE
[PALEMOON] Fix the Findbar - open when you press "/" or "'" keys after start of browser

### DIFF
--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -333,14 +333,14 @@ var gFindBarSettings = {
   prefName: "accessibility.typeaheadfind",
   findAsYouType: null,
 
-  init() {
+  init: function() {
     window.messageManager.addMessageListener(this.messageName, this);
 
     gPrefService.addObserver(this.prefName, this, false);
     this.writeFindAsYouType();
   },
 
-  uninit() {
+  uninit: function() {
     window.messageManager.removeMessageListener(this.messageName, this);
 
     try {
@@ -362,7 +362,7 @@ var gFindBarSettings = {
     this.findAsYouType = gPrefService.getBoolPref(this.prefName);
   },
 
-  receiveMessage(aMessage) {
+  receiveMessage: function(aMessage) {
     switch (aMessage.name) {
       case this.messageName:
         // If the find bar for chrome window's context is not yet alive,

--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -365,8 +365,9 @@ var gFindBarSettings = {
   receiveMessage(aMessage) {
     switch (aMessage.name) {
       case this.messageName:
-        // If the find bar for this tab is not yet alive, only initialize
-        // it if there's a possibility FindAsYouType will be used.
+        // If the find bar for chrome window's context is not yet alive,
+        // only initialize it if there's a possibility FindAsYouType
+        // will be used.
         // There's no point in doing it for most random keypresses.
         if (!gFindBarInitialized && aMessage.data.shouldFastFind) {
           let shouldFastFind = this.findAsYouType;

--- a/application/palemoon/base/content/tabbrowser.xml
+++ b/application/palemoon/base/content/tabbrowser.xml
@@ -3092,26 +3092,6 @@
               window.focus();
               break;
             }
-            case "Findbar:Keypress":
-              // If the find bar for this tab is not yet alive, only initialize
-              // it if there's a possibility FindAsYouType will be used.
-              // There's no point in doing it for most random keypresses.
-              if (!gFindBarInitialized && aMessage.data.shouldFastFind) {
-                let shouldFastFind = this._findAsYouType;
-                if (!shouldFastFind) {
-                  // Please keep in sync with toolkit/content/widgets/findbar.xml
-                  const FAYT_LINKS_KEY = "'";
-                  const FAYT_TEXT_KEY = "/";
-                  let charCode = aMessage.data.fakeEvent.charCode;
-                  let key = charCode ? String.fromCharCode(charCode) : null;
-                  shouldFastFind = key == FAYT_LINKS_KEY || key == FAYT_TEXT_KEY;
-                }
-                if (shouldFastFind) {
-                  // Make sure we return the result.
-                  return gFindBar.receiveMessage(aMessage);
-                }
-              }
-              break;
           }
         ]]></body>
       </method>
@@ -3178,11 +3158,6 @@
                                               this.mCurrentBrowser);
           }
           messageManager.addMessageListener("DOMWebNotificationClicked", this);
-
-          // To correctly handle keypresses for potential FindAsYouType, while
-          // the tab's find bar is not yet initialized.
-          this._findAsYouType = Services.prefs.getBoolPref("accessibility.typeaheadfind");
-          messageManager.addMessageListener("Findbar:Keypress", this);
         ]]>
       </constructor>
 
@@ -3437,7 +3412,6 @@
           tab.setAttribute("onerror", "this.removeAttribute('image');");
           this.adjustTabstrip();
 
-          Services.prefs.addObserver("accessibility.typeaheadfind", this._prefObserver, false);
           Services.prefs.addObserver("browser.tabs.", this._prefObserver, false);
           window.addEventListener("resize", this, false);
           window.addEventListener("load", this, false);
@@ -3453,7 +3427,6 @@
 
       <destructor>
         <![CDATA[
-          Services.prefs.removeObserver("accessibility.typeaheadfind", this._prefObserver);
           Services.prefs.removeObserver("browser.tabs.", this._prefObserver);
         ]]>
       </destructor>
@@ -3519,9 +3492,6 @@
 
         observe: function (subject, topic, data) {
           switch (data) {
-            case "accessibility.typeaheadfind":
-              this._findAsYouType = Services.prefs.getBoolPref(data);
-              break;
             case "browser.tabs.closeButtons":
               this.tabContainer.mCloseButtons = Services.prefs.getIntPref(data);
               this.tabContainer.adjustTabstrip();


### PR DESCRIPTION
This resolves #430 (follow up)

Tags: #141, #441

Moving the message listener for the FindBar (in Pale Moon) to the browser's context instead of tabbrowser.

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.

But you add the label `Verification Needed`, please.
