### PR TITLE
backport mozbug #546387: fix assert failure in gtk which prints to the console

### DIFF
--- a/widget/gtk/nsClipboard.cpp
+++ b/widget/gtk/nsClipboard.cpp
@@ -214,7 +214,8 @@ nsClipboard::SetData(nsITransferable *aTransferable,
     GtkTargetEntry *gtkTargets = gtk_target_table_new_from_list(list, &numTargets);
           
     // Set getcallback and request to store data after an application exit
-    if (gtk_clipboard_set_with_data(gtkClipboard, gtkTargets, numTargets, 
+    if (gtkTargets &&
+        gtk_clipboard_set_with_data(gtkClipboard, gtkTargets, numTargets,
                                     clipboard_get_cb, clipboard_clear_cb, this))
     {
         // We managed to set-up the clipboard so update internal state


### PR DESCRIPTION
GNU/Linux users see "Gtk-CRITICAL **: gtk_clipboard_set_with_data: assertion 'targets != NULL' failed" spammed to the console when selecting null data on the newtab page and other areas. This fixes that issue by backporting [mozbug 546387](https://hg.mozilla.org/releases/mozilla-esr52/raw-rev/d13e3fefb76e).