### PR TITLE
[PALEMOON] Add missed strings required by page info

### DIFF
--- a/security/manager/locales/en-US/chrome/pippki/pippki.properties
+++ b/security/manager/locales/en-US/chrome/pippki/pippki.properties
@@ -98,7 +98,8 @@ clientAuthStoredOn=Stored on: %1$S
 # Page Info
 pageInfo_NoEncryption=Connection Not Encrypted
 pageInfo_Privacy_None1=The website %S does not support encryption for the page you are viewing.
-pageInfo_Privacy_None2=Information sent over the Internet without encryption can be seen by other people while it is in transit. 
+pageInfo_Privacy_None2=Information sent over the Internet without encryption can be seen by other people while it is in transit.
+pageInfo_Privacy_None3=The page you are viewing is not encrypted.
 pageInfo_Privacy_None4=The page you are viewing was not encrypted before being transmitted over the Internet.
 # LOCALIZATION NOTE (pageInfo_EncryptionWithBitsAndProtocol and pageInfo_BrokenEncryption):
 # %1$S is the name of the encryption standard,
@@ -110,6 +111,7 @@ pageInfo_Privacy_Encrypted1=The page you are viewing was encrypted before being 
 pageInfo_Privacy_Encrypted2=Encryption makes it difficult for unauthorized people to view information traveling between computers. It is therefore unlikely that anyone read this page as it traveled across the network.
 pageInfo_MixedContent=Connection Partially Encrypted
 pageInfo_MixedContent2=Parts of the page you are viewing were not encrypted before being transmitted over the Internet.
+pageInfo_Privacy_Broken1=Parts of the page you are viewing were not encrypted or the encryption is not strong enough before being transmitted over the Internet.
 pageInfo_WeakCipher=Your connection to this website uses weak encryption and is not private. Other people can view your information or modify the website’s behavior.
 pageInfo_CertificateTransparency_None=This website does not supply Certificate Transparency audit records.
 pageInfo_CertificateTransparency_OK=This website supplies publicly auditable Certificate Transparency records.


### PR DESCRIPTION
This fixes following error in `pageInfo.xul`:
```
NS_ERROR_FAILURE: Component returned failure code: 0x80004005 (NS_ERROR_FAILURE) [nsIStringBundle.GetStringFromName]  XStringBundle:22
	getString XStringBundle:22:22
	securityOnLoad chrome://browser/content/pageinfo/security.js:282:12
	makeGeneralTab chrome://browser/content/pageinfo/pageInfo.js:550:3
	loadPageInfo chrome://browser/content/pageinfo/pageInfo.js:356:3
	loadTab chrome://browser/content/pageinfo/pageInfo.js:441:3
	onLoadPageInfo chrome://browser/content/pageinfo/pageInfo.js:337:3
	onload chrome://browser/content/pageinfo/pageInfo.xul:1:1
```

Tag #121.