### PR TITLE
[PALEMOON] [frontend vs backend] Sync - add missed strings in sync.properties

### DIFF
--- a/services/sync/locales/en-US/sync.properties
+++ b/services/sync/locales/en-US/sync.properties
@@ -12,14 +12,33 @@ lastSync2.label = Last sync: %S
 # not configured.
 signInToSync.description = Sign In To Sync
 
+error.login.title = Error While Signing In
+error.login.description = Sync encountered an error while connecting: %1$S.  Please try again.
+error.login.prefs.label = Preferences…
+error.login.prefs.accesskey = P
+# should decide if we're going to show this
+error.logout.title = Error While Signing Out
+error.logout.description = Sync encountered an error while connecting.  It's probably ok, and you don't have to do anything about it.
 error.sync.title = Error While Syncing
 error.sync.description = Sync encountered an error while syncing: %1$S.  Sync will automatically retry this action.
+error.sync.prolonged_failure = Sync has not been able to complete during the last %1$S days. Please check your network settings.
+error.sync.serverStatusButton.label = Server Status
+error.sync.serverStatusButton.accesskey = V
+error.sync.needUpdate.description = You need to update Sync to continue syncing your data.
+error.sync.needUpdate.label = Update Sync
+error.sync.needUpdate.accesskey = U
+error.sync.tryAgainButton.label = Sync Now
+error.sync.tryAgainButton.accesskey = S
+warning.sync.quota.label = Approaching Server Quota
+warning.sync.quota.description = You are approaching the server quota. Please review which data to sync.
+error.sync.viewQuotaButton.label = View Quota
+error.sync.viewQuotaButton.accesskey = V
 warning.sync.eol.label = Service Shutting Down
-# %1: the app name (Firefox)
-warning.sync.eol.description = Your Firefox Sync service is shutting down soon. Upgrade %1$S to keep syncing.
+# %1: the app name (Basilisk)
+warning.sync.eol.description = Your Sync service is shutting down soon. Upgrade %1$S to keep syncing.
 error.sync.eol.label = Service Unavailable
-# %1: the app name (Firefox)
-error.sync.eol.description = Your Firefox Sync service is no longer available. You need to upgrade %1$S to keep syncing.
+# %1: the app name (Basilisk)
+error.sync.eol.description = Your Sync service is no longer available. You need to upgrade %1$S to keep syncing.
 sync.eol.learnMore.label = Learn more
 sync.eol.learnMore.accesskey = L
 


### PR DESCRIPTION
Tag #308

After first synchronizing - throws an error in Browser Console:
```
NS_ERROR_FAILURE: Component returned failure code:
0x80004005 (NS_ERROR_FAILURE) [nsIStringBundle.GetStringFromName]  browser.js:6450
```
