### PR TITLE
[PALEMOON] Sync - fix quota.js (SyntaxError: missing ] after element list)

### DIFF
--- a/application/palemoon/base/content/sync/quota.js
+++ b/application/palemoon/base/content/sync/quota.js
@@ -213,7 +213,14 @@ var gUsageTreeView = {
    * disabled.
    */
   getEnginesToDisable: function getEnginesToDisable() {
-    return [coll.name for each (coll in this._collections) if (!coll.enabled)];
+    // Tycho: return [coll.name for each (coll in this._collections) if (!coll.enabled)];
+    let engines = [];
+    for each (let coll in this._collections) {
+      if (!coll.enabled) {
+        engines.push(coll.name);
+      }
+    }
+    return engines;
   },
 
   // nsITreeView


### PR DESCRIPTION
Tag #308

The main menu: `Tools` - `Preferences` - `Sync` - `Manage Account` - `View Quota`
throws an error in Browser Console:
```
SyntaxError: missing ] after element list  quota.js:216:22
```
