### PR TITLE
Hide tracking protection controls from preferences UI

### DIFF
--- a/application/basilisk/components/preferences/in-content/privacy.xul
+++ b/application/basilisk/components/preferences/in-content/privacy.xul
@@ -117,8 +117,7 @@
       </vbox>
     </hbox>
   </vbox>
-  <vbox id="trackingprotectionpbmbox">
-    <caption><label>&tracking.label;</label></caption>
+  <vbox id="trackingprotectionpbmbox" hidden="true">
     <hbox align="center">
       <checkbox id="trackingProtectionPBM"
                 preference="privacy.trackingprotection.pbmode.enabled"
@@ -134,7 +133,8 @@
     </hbox>
   </vbox>
   <vbox>
-    <description>&doNotTrack.pre.label;<label
+    <caption><label>&tracking.label;</label></caption>
+    <description><label
     class="text-link" id="doNotTrackSettings"
     >&doNotTrack.settings.label;</label>&doNotTrack.post.label;</description>
   </vbox>

--- a/application/basilisk/locales/en-US/chrome/browser/preferences/donottrack.dtd
+++ b/application/basilisk/locales/en-US/chrome/browser/preferences/donottrack.dtd
@@ -9,5 +9,5 @@
 <!ENTITY doNotTrackCheckbox2.label    "Always apply Do Not Track">
 <!ENTITY doNotTrackCheckbox2.accesskey "A">
 
-<!ENTITY doNotTrackTPInfo.description "&brandShortName; will send a signal that you don’t want to be tracked whenever Tracking Protection is on.">
+<!ENTITY doNotTrackTPInfo.description "&brandShortName; will send a signal that you don’t want to be tracked.">
 <!ENTITY doNotTrackLearnMore.label    "Learn More">

--- a/application/basilisk/locales/en-US/chrome/browser/preferences/privacy.dtd
+++ b/application/basilisk/locales/en-US/chrome/browser/preferences/privacy.dtd
@@ -20,10 +20,8 @@
 <!ENTITY changeBlockList.label          "Change Block List">
 <!ENTITY changeBlockList.accesskey      "C">
 
-<!-- LOCALIZATION NOTE (doNotTrack.pre.label): include a trailing space as needed -->
 <!-- LOCALIZATION NOTE (doNotTrack.post.label): include a starting space as needed -->
-<!ENTITY  doNotTrack.pre.label          "You can also ">
-<!ENTITY  doNotTrack.settings.label     "manage your Do Not Track settings">
+<!ENTITY  doNotTrack.settings.label     "Manage your Do Not Track settings">
 <!ENTITY  doNotTrack.post.label         ".">
 
 <!ENTITY  history.label                 "History">


### PR DESCRIPTION
This commit hides the tracking protection controls from the UI (while leaving the Do Not Track option there). I also removed the mention of tracking protection from the Do Not Track comment in preferences as Do Not Track still works even without tracking protection enabled.

Resolves #425.