### PR TITLE
[BASILISK] Remove tracking protection controls from the UI if safebrowsing isn't built

### DIFF
--- a/application/basilisk/components/preferences/in-content/jar.mn
+++ b/application/basilisk/components/preferences/in-content/jar.mn
@@ -8,7 +8,7 @@ browser.jar:
    content/browser/preferences/in-content/subdialogs.js
 
    content/browser/preferences/in-content/main.js
-   content/browser/preferences/in-content/privacy.js
+*  content/browser/preferences/in-content/privacy.js
    content/browser/preferences/in-content/containers.js
    content/browser/preferences/in-content/advanced.js
    content/browser/preferences/in-content/applications.js

--- a/application/basilisk/components/preferences/in-content/privacy.js
+++ b/application/basilisk/components/preferences/in-content/privacy.js
@@ -22,6 +22,7 @@ var gPrivacyPane = {
    */
   _shouldPromptForRestart: true,
 
+#ifdef MOZ_SAFEBROWSING
   /**
    * Show the Tracking Protection UI depending on the
    * privacy.trackingprotection.ui.enabled pref, and linkify its Learn More link
@@ -50,6 +51,7 @@ var gPrivacyPane = {
     let url = Services.urlFormatter.formatURLPref("app.support.baseURL") + "tracking-protection-pbm";
     link.setAttribute("href", url);
   },
+#endif
 
   /**
    * Initialize autocomplete to ensure prefs are in sync.
@@ -129,8 +131,10 @@ var gPrivacyPane = {
     this.updateHistoryModePane();
     this.updatePrivacyMicroControls();
     this.initAutoStartPrivateBrowsingReverter();
+#ifdef MOZ_SAFEBROWSING
     this._initTrackingProtection();
     this._initTrackingProtectionPBM();
+#endif
     this._initAutocomplete();
     this._initBrowserContainers();
 
@@ -156,10 +160,12 @@ var gPrivacyPane = {
       gPrivacyPane.clearPrivateDataNow(true);
       return false;
     });
+#ifdef MOZ_SAFEBROWSING
     setEventListener("doNotTrackSettings", "click", function () {
       gPrivacyPane.showDoNotTrackSettings();
       return false;
     });
+#endif
     setEventListener("privateBrowsingAutoStart", "command",
                      gPrivacyPane.updateAutostart);
     setEventListener("cookieExceptions", "command",
@@ -168,6 +174,7 @@ var gPrivacyPane = {
                      gPrivacyPane.showCookies);
     setEventListener("clearDataSettings", "command",
                      gPrivacyPane.showClearPrivateDataSettings);
+#ifdef MOZ_SAFEBROWSING
     setEventListener("trackingProtectionRadioGroup", "command",
                      gPrivacyPane.trackingProtectionWritePrefs);
     setEventListener("trackingProtectionExceptions", "command",
@@ -176,12 +183,14 @@ var gPrivacyPane = {
                      gPrivacyPane.showBlockLists);
     setEventListener("changeBlockListPBM", "command",
                      gPrivacyPane.showBlockLists);
+#endif
     setEventListener("browserContainersCheckbox", "command",
                      gPrivacyPane._checkBrowserContainers);
     setEventListener("browserContainersSettings", "command",
                      gPrivacyPane.showContainerSettings);
   },
 
+#ifdef MOZ_SAFEBROWSING
   // TRACKING PROTECTION MODE
 
   /**
@@ -225,6 +234,7 @@ var gPrivacyPane = {
         break;
     }
   },
+#endif
 
   // HISTORY MODE
 
@@ -462,6 +472,7 @@ var gPrivacyPane = {
       this._shouldPromptForRestart = true;
   },
 
+#ifdef MOZ_SAFEBROWSING
   /**
    * Displays fine-grained, per-site preferences for tracking protection.
    */
@@ -476,6 +487,7 @@ var gPrivacyPane = {
     gSubDialog.open("chrome://browser/content/preferences/permissions.xul",
                     null, params);
   },
+#endif
 
   /**
    * Displays container panel for customising and adding containers.
@@ -484,6 +496,7 @@ var gPrivacyPane = {
     gotoPref("containers");
   },
 
+#ifdef MOZ_SAFEBROWSING
   /**
    * Displays the available block lists for tracking protection.
    */
@@ -506,6 +519,7 @@ var gPrivacyPane = {
     gSubDialog.open("chrome://browser/content/preferences/donottrack.xul",
                     "resizable=no");
   },
+#endif
 
   // HISTORY
 

--- a/application/basilisk/components/preferences/in-content/privacy.xul
+++ b/application/basilisk/components/preferences/in-content/privacy.xul
@@ -10,12 +10,18 @@
 <preferences id="privacyPreferences" hidden="true" data-category="panePrivacy">
 
   <!-- Tracking -->
+#ifdef MOZ_SAFEBROWSING
   <preference id="privacy.trackingprotection.enabled"
               name="privacy.trackingprotection.enabled"
               type="bool"/>
   <preference id="privacy.trackingprotection.pbmode.enabled"
               name="privacy.trackingprotection.pbmode.enabled"
               type="bool"/>
+#else
+  <preference id="privacy.donottrackheader.enabled"
+              name="privacy.donottrackheader.enabled"
+              type="bool"/>
+#endif
 
   <!-- XXX button prefs -->
   <preference id="pref.privacy.disable_button.cookie_exceptions"
@@ -85,6 +91,7 @@
 
 <!-- Tracking -->
 <groupbox id="trackingGroup" data-category="panePrivacy" hidden="true">
+#ifdef MOZ_SAFEBROWSING
   <vbox id="trackingprotectionbox" hidden="true">
     <hbox align="start">
       <vbox>
@@ -138,6 +145,20 @@
     class="text-link" id="doNotTrackSettings"
     >&doNotTrack.settings.label;</label>&doNotTrack.post.label;</description>
   </vbox>
+#else
+  <vbox id="donottrackbox">
+    <caption><label>&tracking.label;</label></caption>
+    <hbox align="center">
+      <checkbox id="DoNotTrack"
+                preference="privacy.donottrackheader.enabled"
+                accesskey="&doNotTrack.accesskey;"
+                label="&doNotTrack.label;" />
+      <label class="text-link"
+             value="&doNotTrackLearnMore.label;"
+             href="https://www.mozilla.org/dnt"/>
+    </hbox>
+  </vbox>
+#endif
 </groupbox>
 
 <!-- History -->

--- a/application/basilisk/components/preferences/jar.mn
+++ b/application/basilisk/components/preferences/jar.mn
@@ -5,14 +5,18 @@
 browser.jar:
     content/browser/preferences/applicationManager.xul
     content/browser/preferences/applicationManager.js
+#ifdef MOZ_SAFEBROWSING
     content/browser/preferences/blocklists.xul
     content/browser/preferences/blocklists.js
+#endif
 *   content/browser/preferences/colors.xul
 *   content/browser/preferences/cookies.xul
     content/browser/preferences/cookies.js
 *   content/browser/preferences/connection.xul
     content/browser/preferences/connection.js
+#ifdef MOZ_SAFEBROWSING
     content/browser/preferences/donottrack.xul
+#endif
 *   content/browser/preferences/fonts.xul
     content/browser/preferences/fonts.js
     content/browser/preferences/handlers.xml

--- a/application/basilisk/components/privatebrowsing/content/aboutPrivateBrowsing.js
+++ b/application/basilisk/components/privatebrowsing/content/aboutPrivateBrowsing.js
@@ -14,6 +14,7 @@ const FAVICON_PRIVACY = "chrome://browser/skin/privatebrowsing/favicon.svg";
 var stringBundle = Services.strings.createBundle(
                     "chrome://browser/locale/aboutPrivateBrowsing.properties");
 
+#ifdef MOZ_SAFE_BROWSING
 var prefBranch = Services.prefs.getBranch("privacy.trackingprotection.");
 var prefObserver = {
  QueryInterface: XPCOMUtils.generateQI([Ci.nsIObserver,
@@ -37,6 +38,7 @@ var prefObserver = {
 };
 prefBranch.addObserver("pbmode.enabled", prefObserver, true);
 prefBranch.addObserver("enabled", prefObserver, true);
+#endif
 
 function setFavIcon(url) {
  document.getElementById("favicon").setAttribute("href", url);
@@ -54,23 +56,29 @@ document.addEventListener("DOMContentLoaded", function () {
    return;
  }
 
+#ifdef MOZ_SAFE_BROWSING
  let tpToggle = document.getElementById("tpToggle");
  document.getElementById("tpButton").addEventListener('click', () => {
    tpToggle.click();
  });
+#endif
 
  document.title = stringBundle.GetStringFromName("title.head");
  document.getElementById("favicon")
          .setAttribute("href", FAVICON_PRIVACY);
+#ifdef MOZ_SAFE_BROWSING
  tpToggle.addEventListener("change", toggleTrackingProtection);
+#endif
 
  let formatURLPref = Cc["@mozilla.org/toolkit/URLFormatterService;1"]
                        .getService(Ci.nsIURLFormatter).formatURLPref;
  document.getElementById("learnMore").setAttribute("href",
                     formatURLPref("app.support.baseURL") + "private-browsing");
 
+#ifdef MOZ_SAFE_BROWSING
  // Update state that depends on preferences.
  prefObserver.observe();
+#endif
 }, false);
 
 function openPrivateWindow() {
@@ -79,9 +87,11 @@ function openPrivateWindow() {
    new CustomEvent("AboutPrivateBrowsingOpenWindow", {bubbles:true}));
 }
 
+#ifdef MOZ_SAFE_BROWSING
 function toggleTrackingProtection() {
  // Ask chrome to enable tracking protection
  document.dispatchEvent(
    new CustomEvent("AboutPrivateBrowsingToggleTrackingProtection",
                    {bubbles: true}));
 }
+#endif

--- a/application/basilisk/components/privatebrowsing/content/aboutPrivateBrowsing.xhtml
+++ b/application/basilisk/components/privatebrowsing/content/aboutPrivateBrowsing.xhtml
@@ -61,11 +61,13 @@
         </p>
       </section>
 
+#ifdef MOZ_SAFE_BROWSING
       <h2 id="tpSubHeader" class="about-subheader">
         <span class="tpTitle">&trackingProtection.title;</span>
         <input id="tpToggle" class="toggle toggle-input" type="checkbox"/>
         <span id="tpButton" class="toggle-btn"></span>
       </h2>
+#endif
 
       <section class="section-main">
         <p>&trackingProtection.description2;</p>

--- a/application/basilisk/components/privatebrowsing/content/aboutPrivateBrowsing.xhtml
+++ b/application/basilisk/components/privatebrowsing/content/aboutPrivateBrowsing.xhtml
@@ -67,11 +67,11 @@
         <input id="tpToggle" class="toggle toggle-input" type="checkbox"/>
         <span id="tpButton" class="toggle-btn"></span>
       </h2>
-#endif
 
       <section class="section-main">
         <p>&trackingProtection.description2;</p>
       </section>
+#endif
 
       <section class="section-main">
         <p class="about-info">&aboutPrivateBrowsing.learnMore2;

--- a/application/basilisk/components/privatebrowsing/content/aboutPrivateBrowsing.xhtml
+++ b/application/basilisk/components/privatebrowsing/content/aboutPrivateBrowsing.xhtml
@@ -35,7 +35,9 @@
     <div class="showPrivate about-content-container">
       <h1 class="title">
         <span id="title">&privateBrowsing.title;</span>
+#ifdef MOZ_SAFE_BROWSING
         <span id="titleTracking">&privateBrowsing.title.tracking;</span>
+#endif
       </h1>
       <section class="section-main">
         <p>&aboutPrivateBrowsing.info.notsaved.before;<strong>&aboutPrivateBrowsing.info.notsaved.emphasize;</strong>&aboutPrivateBrowsing.info.notsaved.after;</p>

--- a/application/basilisk/components/privatebrowsing/jar.mn
+++ b/application/basilisk/components/privatebrowsing/jar.mn
@@ -4,5 +4,5 @@
 
 browser.jar:
     content/browser/aboutPrivateBrowsing.css              (content/aboutPrivateBrowsing.css)
-    content/browser/aboutPrivateBrowsing.xhtml            (content/aboutPrivateBrowsing.xhtml)
-    content/browser/aboutPrivateBrowsing.js               (content/aboutPrivateBrowsing.js)
+*   content/browser/aboutPrivateBrowsing.xhtml            (content/aboutPrivateBrowsing.xhtml)
+*   content/browser/aboutPrivateBrowsing.js               (content/aboutPrivateBrowsing.js)

--- a/application/basilisk/locales/en-US/chrome/browser/preferences/privacy.dtd
+++ b/application/basilisk/locales/en-US/chrome/browser/preferences/privacy.dtd
@@ -2,6 +2,8 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
+<!ENTITY tracking.label                 "Tracking">
+#ifdef MOZ_SAFE_BROWSING
 <!ENTITY  trackingProtectionHeader.label       "Use Tracking Protection">
 <!ENTITY  trackingProtectionAlways.label       "Always">
 <!ENTITY  trackingProtectionAlways.accesskey   "y">
@@ -13,7 +15,6 @@
 <!ENTITY  trackingProtectionExceptions.label   "Exceptions…">
 <!ENTITY  trackingProtectionExceptions.accesskey "x">
 
-<!ENTITY tracking.label                 "Tracking">
 <!ENTITY trackingProtectionPBM5.label         "Use Tracking Protection in Private Windows">
 <!ENTITY trackingProtectionPBM5.accesskey     "v">
 <!ENTITY trackingProtectionPBMLearnMore.label "Learn more">
@@ -25,6 +26,11 @@
 <!ENTITY  doNotTrack.pre.label          "You can also ">
 <!ENTITY  doNotTrack.settings.label     "manage your Do Not Track settings">
 <!ENTITY  doNotTrack.post.label         ".">
+#else
+<!ENTITY doNotTrack.label               "Send a signal that you don’t want to be tracked">
+<!ENTITY doNotTrack.accesskey           "T">
+<!ENTITY doNotTrackLearnMore.label      "Learn More">
+#endif
 
 <!ENTITY  history.label                 "History">
 

--- a/application/basilisk/locales/jar.mn
+++ b/application/basilisk/locales/jar.mn
@@ -64,12 +64,16 @@
     locale/browser/preferences/advanced.dtd           (%chrome/browser/preferences/advanced.dtd)
     locale/browser/preferences/applicationManager.dtd        (%chrome/browser/preferences/applicationManager.dtd)
     locale/browser/preferences/applicationManager.properties (%chrome/browser/preferences/applicationManager.properties)
+#ifdef MOZ_SAFE_BROWSING
     locale/browser/preferences/blocklists.dtd         (%chrome/browser/preferences/blocklists.dtd)
+#endif
     locale/browser/preferences/colors.dtd             (%chrome/browser/preferences/colors.dtd)
     locale/browser/preferences/cookies.dtd            (%chrome/browser/preferences/cookies.dtd)
     locale/browser/preferences/content.dtd            (%chrome/browser/preferences/content.dtd)
     locale/browser/preferences/connection.dtd         (%chrome/browser/preferences/connection.dtd)
+#ifdef MOZ_SAFE_BROWSING
     locale/browser/preferences/donottrack.dtd         (%chrome/browser/preferences/donottrack.dtd)
+#endif
     locale/browser/preferences/applications.dtd       (%chrome/browser/preferences/applications.dtd)
     locale/browser/preferences/fonts.dtd              (%chrome/browser/preferences/fonts.dtd)
     locale/browser/preferences/main.dtd               (%chrome/browser/preferences/main.dtd)
@@ -78,7 +82,7 @@
     locale/browser/preferences/preferences.dtd        (%chrome/browser/preferences/preferences.dtd)
     locale/browser/preferences/preferences.properties (%chrome/browser/preferences/preferences.properties)
     locale/browser/preferences/containers.properties  (%chrome/browser/preferences/containers.properties)
-    locale/browser/preferences/privacy.dtd            (%chrome/browser/preferences/privacy.dtd)
+*   locale/browser/preferences/privacy.dtd            (%chrome/browser/preferences/privacy.dtd)
     locale/browser/preferences/security.dtd           (%chrome/browser/preferences/security.dtd)
     locale/browser/preferences/containers.dtd         (%chrome/browser/preferences/containers.dtd)
     locale/browser/preferences/sync.dtd               (%chrome/browser/preferences/sync.dtd)

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -1217,7 +1217,11 @@ pref("privacy.donottrackheader.enabled",    false);
 // Enforce tracking protection in all modes
 pref("privacy.trackingprotection.enabled",  false);
 // Enforce tracking protection in Private Browsing mode
+#ifdef MOZ_SAFE_BROWSING
 pref("privacy.trackingprotection.pbmode.enabled",  true);
+#else
+pref("privacy.trackingprotection.pbmode.enabled",  false);
+#endif
 
 pref("dom.event.contextmenu.enabled",       true);
 pref("dom.event.clipboardevents.enabled",   true);


### PR DESCRIPTION
If safebrowsing isn't built:

* By default disable tracking protection in Private Browsing mode 
* [BASILISK] Remove tracking protection controls from the UI
* [BASILISK] Remove tracking protection title, controls and description from aboutPrivateBrowsing

Tag #230, resolves #425.