### PR TITLE
[PALEMOON] Change the three-state DoNotTrack controls to a simple on/off switch

### DIFF
--- a/application/palemoon/app/profile/palemoon.js
+++ b/application/palemoon/app/profile/palemoon.js
@@ -1012,7 +1012,6 @@ pref("services.sync.prefs.sync.privacy.clearOnShutdown.sessions", true);
 pref("services.sync.prefs.sync.privacy.clearOnShutdown.siteSettings", true);
 pref("services.sync.prefs.sync.privacy.clearOnShutdown.connectivityData", true);
 pref("services.sync.prefs.sync.privacy.donottrackheader.enabled", true);
-pref("services.sync.prefs.sync.privacy.donottrackheader.value", true);
 pref("services.sync.prefs.sync.privacy.sanitize.sanitizeOnShutdown", true);
 pref("services.sync.prefs.sync.security.OCSP.enabled", true);
 pref("services.sync.prefs.sync.security.OCSP.require", true);

--- a/application/palemoon/components/nsBrowserGlue.js
+++ b/application/palemoon/components/nsBrowserGlue.js
@@ -1207,7 +1207,7 @@ BrowserGlue.prototype = {
   },
 
   _migrateUI: function BG__migrateUI() {
-    const UI_VERSION = 17;
+    const UI_VERSION = 18;
     const BROWSER_DOCURL = "chrome://browser/content/browser.xul#";
     let currentUIVersion = 0;
     try {
@@ -1411,6 +1411,20 @@ BrowserGlue.prototype = {
 
     delete this._rdf;
     delete this._dataSource;
+
+    if (currentUIVersion < 18) {
+      // Make sure the doNotTrack value conforms to the conversion from
+      // three-state to two-state. (This reverts a setting of "please track me"
+      // to the default "don't say anything").
+      try {
+        if (Services.prefs.getBoolPref("privacy.donottrackheader.enabled") &&
+            Services.prefs.getIntPref("privacy.donottrackheader.value") != 1) {
+          Services.prefs.clearUserPref("privacy.donottrackheader.enabled");
+          Services.prefs.clearUserPref("privacy.donottrackheader.value");
+        }
+      }
+      catch (ex) {}
+    }
 
     // Update the migration version.
     Services.prefs.setIntPref("browser.migration.version", UI_VERSION);

--- a/application/palemoon/components/preferences/privacy.js
+++ b/application/palemoon/components/preferences/privacy.js
@@ -151,42 +151,6 @@ var gPrivacyPane = {
   },
 
   /**
-   * Update the Tracking preferences based on controls.
-   */
-  setTrackingPrefs: function PPP_setTrackingPrefs()
-  {
-    let dntRadioGroup = document.getElementById("doNotTrackSelection"),
-        dntValuePref = document.getElementById("privacy.donottrackheader.value"),
-        dntEnabledPref = document.getElementById("privacy.donottrackheader.enabled");
-
-    // if the selected radio button says "no preference", set on/off pref to
-    // false and don't change the value pref.
-    if (dntRadioGroup.selectedItem.value == -1) {
-      dntEnabledPref.value = false;
-      return dntValuePref.value;
-    }
-
-    dntEnabledPref.value = true;
-    return dntRadioGroup.selectedItem.value;
-  },
-
-  /**
-   * Obtain the tracking preference value and reflect it in the UI.
-   */
-  getTrackingPrefs: function PPP_getTrackingPrefs()
-  {
-    let dntValuePref = document.getElementById("privacy.donottrackheader.value"),
-        dntEnabledPref = document.getElementById("privacy.donottrackheader.enabled");
-
-    // if DNT is enbaled, select the value from the selected radio
-    // button, otherwise choose the "no preference" radio button
-    if (dntEnabledPref.value)
-      return dntValuePref.value;
-
-    return document.getElementById("dntnopref").value;
-  },
-
-  /**
    * Update the private browsing auto-start pref and the history mode
    * micro-management prefs based on the history mode menulist
    */

--- a/application/palemoon/components/preferences/privacy.xul
+++ b/application/palemoon/components/preferences/privacy.xul
@@ -30,9 +30,6 @@
       <preference id="privacy.donottrackheader.enabled"
                   name="privacy.donottrackheader.enabled"
                   type="bool"/>
-      <preference id="privacy.donottrackheader.value"
-                  name="privacy.donottrackheader.value"
-                  type="int"/>
 
       <!-- XXX button prefs -->
       <preference id="pref.privacy.disable_button.cookie_exceptions"
@@ -239,17 +236,11 @@
         <!-- Tracking -->
         <tabpanel id="trackingPanel" orient="vertical">
 
-          <radiogroup id="doNotTrackSelection" orient="vertical"
-                      preference="privacy.donottrackheader.value"
-                      onsynctopreference="return gPrivacyPane.setTrackingPrefs()"
-                      onsyncfrompreference="return gPrivacyPane.getTrackingPrefs()">
-            <radio id="dntnotrack" value="1" label="&dntTrackingNotOkay.label2;"
-                    accesskey="&dntTrackingNotOkay.accesskey;" />
-            <radio id="dntdotrack" value="0" label="&dntTrackingOkay.label2;"
-                    accesskey="&dntTrackingOkay.accesskey;" />
-            <radio id="dntnopref" value="-1" label="&dntTrackingNopref.label2;"
-                    accesskey="&dntTrackingNopref.accesskey;" />
-          </radiogroup>
+          <checkbox id="privacyDoNotTrackCheckbox"
+                    label="&dntTrackingNotOkay.label2;"
+                    accesskey="&dntTrackingNotOkay.accesskey;"
+                    preference="privacy.donottrackheader.enabled"/>
+          <separator class="thin"/>
           <label class="text-link" id="doNotTrackInfo"
                  href="https://www.mozilla.org/dnt"
                  value="&doNotTrackInfo.label;"/>

--- a/application/palemoon/locales/en-US/chrome/browser/preferences/privacy.dtd
+++ b/application/palemoon/locales/en-US/chrome/browser/preferences/privacy.dtd
@@ -4,12 +4,8 @@
 
 <!ENTITY tracking.label                 "Tracking">
 
-<!ENTITY dntTrackingNopref.label2       "Do not tell sites anything about my tracking preferences">
-<!ENTITY dntTrackingNopref.accesskey    "o">
 <!ENTITY dntTrackingNotOkay.label2      "Tell sites that I do not want to be tracked">
 <!ENTITY dntTrackingNotOkay.accesskey   "n">
-<!ENTITY dntTrackingOkay.label2         "Tell sites that I want to be tracked">
-<!ENTITY dntTrackingOkay.accesskey      "t">
 <!ENTITY doNotTrackInfo.label           "Learn More">
 
 <!ENTITY  history.label                 "History">


### PR DESCRIPTION
This aligns DoNotTrack UI controls with the UXP code, which does not support the option to tell sites that you want to be tracked.

Based on [bug 1042135](https://bugzilla.mozilla.org/show_bug.cgi?id=1042135).

Tag #57, resolves #473.