### PR TITLE
[PALEMOON] Fix package bustage if devtools is disabled

### DIFF
--- a/application/palemoon/installer/package-manifest.in
+++ b/application/palemoon/installer/package-manifest.in
@@ -212,6 +212,7 @@
 @RESPATH@/browser/chrome/icons/default/default48.png
 #endif
 
+#ifdef MOZ_DEVTOOLS
 ; [Webide Files]
 @RESPATH@/browser/chrome/webide@JAREXT@
 @RESPATH@/browser/chrome/webide.manifest
@@ -221,6 +222,7 @@
 @RESPATH@/browser/chrome/devtools@JAREXT@
 @RESPATH@/browser/chrome/devtools.manifest
 @RESPATH@/browser/@PREF_DIR@/devtools.js
+#endif
 
 ; shell icons
 #ifdef XP_UNIX


### PR DESCRIPTION
Ad https://forum.palemoon.org/viewtopic.php?f=63&t=19383

Package bustage:
```
application/palemoon/installer/package-manifest:101:
Missing file(s): bin/browser/chrome/webide

application/palemoon/installer/package-manifest:102:
Missing file(s): bin/browser/chrome/webide.manifest

application/palemoon/installer/package-manifest:103:
Missing file(s): bin/browser/defaults/preferences/webide-prefs.js

application/palemoon/installer/package-manifest:108:
Missing file(s): bin/browser/defaults/preferences/devtools.js
```

Tags:
#102 
https://github.com/MoonchildProductions/UXP/commit/e7e96d079c0d56822d523b6e073568cb628c8afc (follow up)

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested (disable devtools).
