### PR TITLE
[suggestion] [PALEMOON] Unstable releases - fix some links on Linux

### DIFF
--- a/application/palemoon/branding/unstable/pref/palemoon-branding.js
+++ b/application/palemoon/branding/unstable/pref/palemoon-branding.js
@@ -26,11 +26,19 @@ pref("app.update.promptWaitTime", 86400);
 
 // URL user can browse to manually if for some reason all update installation
 // attempts fail.
+#ifndef XP_LINUX
 pref("app.update.url.manual", "http://www.palemoon.org/unstable/");
-
+#else
+pref("app.update.url.manual", "http://linux.palemoon.org/download/unstable/");
+#endif
 // A default value for the "More information about this update" link
 // supplied in the "An update is available" page of the update wizard. 
+#ifndef XP_LINUX
 pref("app.update.url.details", "http://www.palemoon.org/unstable/");
+#else
+pref("app.update.url.details", "http://linux.palemoon.org/download/unstable/");
+#endif
+
 #else
 // Updates disabled (Mac, etc.)
 pref("app.update.enabled", false);


### PR DESCRIPTION
This resolves #480

---

I've created the new build (x32, Windows) - `Pale Moon UXP` (unstable) - and tested:
`about:config`:
`app.update.url.details`
`app.update.url.manual`
