### PR TITLE
Fix incorrect preprocessor defines for safebrowsing

### DIFF
--- a/application/basilisk/components/preferences/in-content/privacy.js
+++ b/application/basilisk/components/preferences/in-content/privacy.js
@@ -22,7 +22,7 @@ var gPrivacyPane = {
    */
   _shouldPromptForRestart: true,
 
-#ifdef MOZ_SAFEBROWSING
+#ifdef MOZ_SAFE_BROWSING
   /**
    * Show the Tracking Protection UI depending on the
    * privacy.trackingprotection.ui.enabled pref, and linkify its Learn More link
@@ -131,7 +131,7 @@ var gPrivacyPane = {
     this.updateHistoryModePane();
     this.updatePrivacyMicroControls();
     this.initAutoStartPrivateBrowsingReverter();
-#ifdef MOZ_SAFEBROWSING
+#ifdef MOZ_SAFE_BROWSING
     this._initTrackingProtection();
     this._initTrackingProtectionPBM();
 #endif
@@ -160,7 +160,7 @@ var gPrivacyPane = {
       gPrivacyPane.clearPrivateDataNow(true);
       return false;
     });
-#ifdef MOZ_SAFEBROWSING
+#ifdef MOZ_SAFE_BROWSING
     setEventListener("doNotTrackSettings", "click", function () {
       gPrivacyPane.showDoNotTrackSettings();
       return false;
@@ -174,7 +174,7 @@ var gPrivacyPane = {
                      gPrivacyPane.showCookies);
     setEventListener("clearDataSettings", "command",
                      gPrivacyPane.showClearPrivateDataSettings);
-#ifdef MOZ_SAFEBROWSING
+#ifdef MOZ_SAFE_BROWSING
     setEventListener("trackingProtectionRadioGroup", "command",
                      gPrivacyPane.trackingProtectionWritePrefs);
     setEventListener("trackingProtectionExceptions", "command",
@@ -190,7 +190,7 @@ var gPrivacyPane = {
                      gPrivacyPane.showContainerSettings);
   },
 
-#ifdef MOZ_SAFEBROWSING
+#ifdef MOZ_SAFE_BROWSING
   // TRACKING PROTECTION MODE
 
   /**
@@ -472,7 +472,7 @@ var gPrivacyPane = {
       this._shouldPromptForRestart = true;
   },
 
-#ifdef MOZ_SAFEBROWSING
+#ifdef MOZ_SAFE_BROWSING
   /**
    * Displays fine-grained, per-site preferences for tracking protection.
    */
@@ -496,7 +496,7 @@ var gPrivacyPane = {
     gotoPref("containers");
   },
 
-#ifdef MOZ_SAFEBROWSING
+#ifdef MOZ_SAFE_BROWSING
   /**
    * Displays the available block lists for tracking protection.
    */

--- a/application/basilisk/components/preferences/in-content/privacy.xul
+++ b/application/basilisk/components/preferences/in-content/privacy.xul
@@ -10,7 +10,7 @@
 <preferences id="privacyPreferences" hidden="true" data-category="panePrivacy">
 
   <!-- Tracking -->
-#ifdef MOZ_SAFEBROWSING
+#ifdef MOZ_SAFE_BROWSING
   <preference id="privacy.trackingprotection.enabled"
               name="privacy.trackingprotection.enabled"
               type="bool"/>
@@ -91,7 +91,7 @@
 
 <!-- Tracking -->
 <groupbox id="trackingGroup" data-category="panePrivacy" hidden="true">
-#ifdef MOZ_SAFEBROWSING
+#ifdef MOZ_SAFE_BROWSING
   <vbox id="trackingprotectionbox" hidden="true">
     <hbox align="start">
       <vbox>

--- a/application/basilisk/components/preferences/jar.mn
+++ b/application/basilisk/components/preferences/jar.mn
@@ -5,7 +5,7 @@
 browser.jar:
     content/browser/preferences/applicationManager.xul
     content/browser/preferences/applicationManager.js
-#ifdef MOZ_SAFEBROWSING
+#ifdef MOZ_SAFE_BROWSING
     content/browser/preferences/blocklists.xul
     content/browser/preferences/blocklists.js
 #endif
@@ -14,7 +14,7 @@ browser.jar:
     content/browser/preferences/cookies.js
 *   content/browser/preferences/connection.xul
     content/browser/preferences/connection.js
-#ifdef MOZ_SAFEBROWSING
+#ifdef MOZ_SAFE_BROWSING
     content/browser/preferences/donottrack.xul
 #endif
 *   content/browser/preferences/fonts.xul


### PR DESCRIPTION
`MOZ_SAFEBROWSING -> MOZ_SAFE_BROWSING`

Follow-up to #469, resolves #488.