### PR TITLE
Add architecture detection to "about:" and "about:support"

### DIFF
--- a/toolkit/content/about.js
+++ b/toolkit/content/about.js
@@ -33,7 +33,12 @@ var versionNum = Components.classes["@mozilla.org/xre/app-info;1"]
                            .getService(Components.interfaces.nsIXULAppInfo)
                            .version;
 var version = document.getElementById("version");
-version.textContent += " " + versionNum;
+#ifdef HAVE_64BIT_BUILD
+var versionStr = versionNum + " (64-bit)";
+#else
+var versionStr = versionNum + " (32-bit)";
+#endif
+version.textContent += " " + versionStr;
 
 // insert the buildid of the XUL application
 var BuildIDVal = Components.classes["@mozilla.org/xre/app-info;1"]

--- a/toolkit/content/aboutSupport.js
+++ b/toolkit/content/aboutSupport.js
@@ -42,6 +42,9 @@ var snapshotFormatters = {
     $("os-box").textContent = data.osVersion;
     $("supportLink").href = data.supportURL;
     let version = AppConstants.MOZ_APP_VERSION_DISPLAY;
+    if (data.versionArch) {
+      version += " (" + data.versionArch + ")";
+    }
     if (data.vendor)
       version += " (" + data.vendor + ")";
     $("version-box").textContent = version;

--- a/toolkit/content/jar.mn
+++ b/toolkit/content/jar.mn
@@ -8,7 +8,7 @@ toolkit.jar:
    content/global/textbox.css
    content/global/menulist.css
    content/global/autocomplete.css
-   content/global/about.js
+*  content/global/about.js
    content/global/about.xhtml
    content/global/aboutAbout.js
    content/global/aboutAbout.xhtml

--- a/toolkit/locales/en-US/chrome/global/about.dtd
+++ b/toolkit/locales/en-US/chrome/global/about.dtd
@@ -1,7 +1,7 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<!ENTITY about.version                "Version">
+<!ENTITY about.version                "Version:">
 
 <!-- LOCALIZATION NOTE (about.credits.beforeLink): note that there is no space between this phrase and the linked about.credits.linkTitle phrase, so if your locale needs a space between words, add it at the end of this entity. -->
 <!ENTITY about.credits.beforeLink     "See a list of ">

--- a/toolkit/modules/Troubleshoot.jsm
+++ b/toolkit/modules/Troubleshoot.jsm
@@ -188,6 +188,12 @@ var dataProviders = {
     if (AppConstants.MOZ_UPDATER)
       data.updateChannel = Cu.import("resource://gre/modules/UpdateUtils.jsm", {}).UpdateUtils.UpdateChannel;
 
+#ifdef HAVE_64BIT_BUILD
+    data.versionArch = "64-bit";
+#else
+    data.versionArch = "32-bit";
+#endif
+
     try {
       data.vendor = Services.prefs.getCharPref("app.support.vendor");
     }

--- a/toolkit/modules/moz.build
+++ b/toolkit/modules/moz.build
@@ -94,7 +94,6 @@ EXTRA_JS_MODULES += [
     'Sqlite.jsm',
     'Task.jsm',
     'Timer.jsm',
-    'Troubleshoot.jsm',
     'UpdateUtils.jsm',
     'WebChannel.jsm',
     'WindowDraggingUtils.jsm',
@@ -103,7 +102,10 @@ EXTRA_JS_MODULES += [
 EXTRA_JS_MODULES.third_party.jsesc += ['third_party/jsesc/jsesc.js']
 EXTRA_JS_MODULES.sessionstore += ['sessionstore/Utils.jsm']
 
-EXTRA_PP_JS_MODULES += ['NewTabUtils.jsm']
+EXTRA_PP_JS_MODULES += [
+    'NewTabUtils.jsm',
+    'Troubleshoot.jsm',
+]
 
 if not CONFIG['MOZ_WEBEXTENSIONS']:
   EXTRA_PP_JS_MODULES += ['UpdateChannel.jsm']


### PR DESCRIPTION
Tag #492

---

I've created the new build (x32/x64, Windows) - `Pale Moon UXP` - and tested.
