### PR TITLE
Add UA mode for unofficial branding

### DIFF
--- a/application/palemoon/branding/unofficial/pref/palemoon-branding.js
+++ b/application/palemoon/branding/unofficial/pref/palemoon-branding.js
@@ -6,6 +6,9 @@
 pref("startup.homepage_override_url","http://www.palemoon.org/unofficial.shtml");
 pref("app.releaseNotesURL", "http://www.palemoon.org/releasenotes.shtml");
 
+// Native UA mode
+pref("general.useragent.compatMode", 0);
+
 // Updates disabled
 pref("app.update.enabled", false);
 pref("app.update.url", "");


### PR DESCRIPTION
Because of this missing pref, browser startup fails on initial launch and subsequent launches, unless UA mode is explicitly set in preferences. UI is loaded but many things are missing, most notably DevTools.

`-jsconsole` shows some error related to component failure. Observed on both Mac and Linux.