### PR TITLE
[PALEMOON] Remove UA override for Google Fonts

### DIFF
--- a/application/palemoon/branding/shared/pref/uaoverrides.inc
+++ b/application/palemoon/branding/shared/pref/uaoverrides.inc
@@ -43,11 +43,6 @@ pref("@GUAO_PREF@.players.brightcove.net","Mozilla/5.0 (Windows NT 6.1; Trident/
 pref("@GUAO_PREF@.facebook.com","Mozilla/5.0 (@OS_SLICE@ rv:99.9) @GK_SLICE@ Firefox/99.9 (Pale Moon)");
 pref("@GUAO_PREF@.fbcdn.net","Mozilla/5.0 (@OS_SLICE@ rv:99.9) @GK_SLICE@ Firefox/99.9 (Pale Moon)");
 
-#ifdef XP_UNIX
-// Google Fonts forces unicode ranges unless it is being told the browser is Firefox 43 or below.
-// They do NOT test for unicode-ranges CSS support.
-pref("@GUAO_PREF@.fonts.googleapis.com","Mozilla/5.0 (@OS_SLICE@ rv:43.0) @GK_SLICE@ Firefox/43.0");
-#endif
 
 // UA-Sniffing domains below are pending responses from their operators - temp workaround
 pref("@GUAO_PREF@.chase.com","Mozilla/5.0 (@OS_SLICE@ rv:@GK_VERSION@) @GK_SLICE@ @FX_SLICE@");


### PR DESCRIPTION
This should no longer be necessary ([issue 749](https://github.com/MoonchildProductions/Pale-Moon/issues/749) on the PM repo is labelled "Solved by UXP").

While it shouldn't be needed anymore I have not tested this due to not currently having access to a Linux system with a GUI.

@khronosschoty @JustOff  would one of you be able to test this for me while I'm away?