### PR TITLE
[PALEMOON] Sanitize - "Form and search history" sanitize also the Findbar text and history (Ctrl-Z)

### DIFF
--- a/application/palemoon/base/content/sanitize.js
+++ b/application/palemoon/base/content/sanitize.js
@@ -257,13 +257,18 @@ Sanitizer.prototype = {
                                       .getService(Components.interfaces.nsIWindowMediator);
         var windows = windowManager.getEnumerator("navigator:browser");
         while (windows.hasMoreElements()) {
-          let currentDocument = windows.getNext().document;
+          let currentWindow = windows.getNext();
+          let currentDocument = currentWindow.document;
           let searchBar = currentDocument.getElementById("searchbar");
           if (searchBar)
             searchBar.textbox.reset();
-          let findBar = currentDocument.getElementById("FindToolbar");
-          if (findBar)
-            findBar.clear();
+          let tabBrowser = currentWindow.gBrowser;
+          for (let tab of tabBrowser.tabs) {
+            if (tabBrowser.isFindBarInitialized(tab))
+              tabBrowser.getFindBar(tab).clear();
+          }
+          // Clear any saved find value
+          tabBrowser._lastFindValue = "";
         }
 
         let change = { op: "remove" };
@@ -279,7 +284,8 @@ Sanitizer.prototype = {
                                       .getService(Components.interfaces.nsIWindowMediator);
         var windows = windowManager.getEnumerator("navigator:browser");
         while (windows.hasMoreElements()) {
-          let currentDocument = windows.getNext().document;
+          let currentWindow = windows.getNext();
+          let currentDocument = currentWindow.document;
           let searchBar = currentDocument.getElementById("searchbar");
           if (searchBar) {
             let transactionMgr = searchBar.textbox.editor.transactionManager;
@@ -290,8 +296,12 @@ Sanitizer.prototype = {
               return false;
             }
           }
-          let findBar = currentDocument.getElementById("FindToolbar");
-          if (findBar && findBar.canClear) {
+          let tabBrowser = currentWindow.gBrowser;
+          let findBarCanClear = Array.some(tabBrowser.tabs, function (aTab) {
+            return tabBrowser.isFindBarInitialized(aTab) &&
+                   tabBrowser.getFindBar(aTab).canClear;
+          });
+          if (findBarCanClear) {
             aCallback("formdata", true, aArg);
             return false;
           }


### PR DESCRIPTION
This resolves #502 

Bug(s):
[409624](https://bugzilla.mozilla.org/show_bug.cgi?id=409624)
[324354](https://bugzilla.mozilla.org/show_bug.cgi?id=324354) - any mention of `Ctrl-Z`

---

I've created the new build (x32, Windows) - `Pale Moon UXP` - and tested.
