### PR TITLE
Fix typos in comments - scratchpad.properties

### DIFF
--- a/devtools/client/locales/en-US/scratchpad.properties
+++ b/devtools/client/locales/en-US/scratchpad.properties
@@ -64,12 +64,12 @@ confirmRevert=Do you want to revert the changes you made to this scratchpad?
 # you try to revert unsaved content of scratchpad.
 confirmRevert.title=Revert Changes
 
-# LOCALIZATION NOTE  (scratchpadIntro): This is a multi-line comment explaining
+# LOCALIZATION NOTE  (scratchpadIntro1): This is a multi-line comment explaining
 # how to use the Scratchpad. Note that this should be a valid JavaScript
 # comment inside /* and */.
 scratchpadIntro1=/*\n * This is a JavaScript Scratchpad.\n *\n * Enter some JavaScript, then Right Click or choose from the Execute Menu:\n * 1. Run to evaluate the selected text (%1$S),\n * 2. Inspect to bring up an Object Inspector on the result (%2$S), or,\n * 3. Display to insert the result in a comment after the selection. (%3$S)\n */\n\n
 
-# LOCALIZATION NOTE  (notification.browserContext): This is the message displayed
+# LOCALIZATION NOTE  (browserContext.notification): This is the message displayed
 # over the top of the editor when the user has switched to browser context.
 browserContext.notification=This scratchpad executes in the Browser context.
 
@@ -82,7 +82,7 @@ help.openDocumentationPage=https://developer.mozilla.org/en/Tools/Scratchpad
 # Scratchpad.
 scratchpad.statusBarLineCol  = Line %1$S, Col %2$S
 
-# LOCALIZATION NOTE (fileExists.notification): This is the message displayed
+# LOCALIZATION NOTE (fileNoLongerExists.notification): This is the message displayed
 # over the top of the the editor when a file does not exist.
 fileNoLongerExists.notification=This file no longer exists.
 
@@ -99,7 +99,7 @@ connectionTimeout=Connection timeout. Check the Error Console on both ends for p
 # %1 is the text of selfxss.okstring
 selfxss.msg=Scam Warning: Take care when pasting things you don’t understand. This could allow attackers to steal your identity or take control of your computer. Please type ‘%S’ in the scratchpad below to allow pasting.
 
-# LOCALIZATION NOTE (selfxss.msg): the string to be typed
+# LOCALIZATION NOTE (selfxss.okstring): the string to be typed
 # in by a new user of the developer tools when they receive the sefxss.msg prompt.
 # Please avoid using non-keyboard characters here
 selfxss.okstring=allow pasting


### PR DESCRIPTION
Align `Name values` with `names in comments`.
