### PR TITLE
Added "nsIContentPolicy::TYPE_SAVEAS_DOWNLOAD": The context menu - "Save Link As" feature should use the loading principal instead of the system principal

### DIFF
--- a/application/basilisk/base/content/nsContextMenu.js
+++ b/application/basilisk/base/content/nsContextMenu.js
@@ -1348,11 +1348,6 @@ nsContextMenu.prototype = {
     }
 
     // setting up a new channel for 'right click - save link as ...'
-    // ideally we should use:
-    // * doc            - as the loadingNode, and/or
-    // * this.principal - as the loadingPrincipal
-    // for now lets use systemPrincipal to bypass mixedContentBlocker
-    // checks after redirects, see bug: 1136055
     var channel = NetUtil.newChannel({
                     uri: makeURI(linkURL),
                     loadingPrincipal: this.principal,

--- a/application/basilisk/base/content/nsContextMenu.js
+++ b/application/basilisk/base/content/nsContextMenu.js
@@ -1355,7 +1355,9 @@ nsContextMenu.prototype = {
     // checks after redirects, see bug: 1136055
     var channel = NetUtil.newChannel({
                     uri: makeURI(linkURL),
-                    loadUsingSystemPrincipal: true
+                    loadingPrincipal: this.principal,
+                    contentPolicyType: Ci.nsIContentPolicy.TYPE_SAVEAS_DOWNLOAD,
+                    securityFlags: Ci.nsILoadInfo.SEC_ALLOW_CROSS_ORIGIN_DATA_INHERITS,
                   });
 
     if (linkDownload)

--- a/application/palemoon/base/content/nsContextMenu.js
+++ b/application/palemoon/base/content/nsContextMenu.js
@@ -1124,11 +1124,6 @@ nsContextMenu.prototype = {
     }
 
     // setting up a new channel for 'right click - save link as ...'
-    // ideally we should use:
-    // * doc            - as the loadingNode, and/or
-    // * this.principal - as the loadingPrincipal
-    // for now lets use systemPrincipal to bypass mixedContentBlocker
-    // checks after redirects, see bug: 1136055
     var channel = NetUtil.newChannel({
                     uri: makeURI(linkURL),
                     loadingPrincipal: this.principal,

--- a/application/palemoon/base/content/nsContextMenu.js
+++ b/application/palemoon/base/content/nsContextMenu.js
@@ -1131,7 +1131,9 @@ nsContextMenu.prototype = {
     // checks after redirects, see bug: 1136055
     var channel = NetUtil.newChannel({
                     uri: makeURI(linkURL),
-                    loadUsingSystemPrincipal: true
+                    loadingPrincipal: this.principal,
+                    contentPolicyType: Ci.nsIContentPolicy.TYPE_SAVEAS_DOWNLOAD,
+                    securityFlags: Ci.nsILoadInfo.SEC_ALLOW_CROSS_ORIGIN_DATA_INHERITS,
                   });
 
     if (linkDownload)

--- a/application/palemoon/base/content/nsContextMenu.js
+++ b/application/palemoon/base/content/nsContextMenu.js
@@ -1126,7 +1126,7 @@ nsContextMenu.prototype = {
     // setting up a new channel for 'right click - save link as ...'
     var channel = NetUtil.newChannel({
                     uri: makeURI(linkURL),
-                    loadingPrincipal: this.principal,
+                    loadingPrincipal: this.target.ownerDocument.nodePrincipal,
                     contentPolicyType: Ci.nsIContentPolicy.TYPE_SAVEAS_DOWNLOAD,
                     securityFlags: Ci.nsILoadInfo.SEC_ALLOW_CROSS_ORIGIN_DATA_INHERITS,
                   });

--- a/devtools/client/netmonitor/request-utils.js
+++ b/devtools/client/netmonitor/request-utils.js
@@ -177,7 +177,8 @@ const LOAD_CAUSE_STRINGS = {
   [Ci.nsIContentPolicy.TYPE_BEACON]: "beacon",
   [Ci.nsIContentPolicy.TYPE_FETCH]: "fetch",
   [Ci.nsIContentPolicy.TYPE_IMAGESET]: "imageset",
-  [Ci.nsIContentPolicy.TYPE_WEB_MANIFEST]: "webManifest"
+  [Ci.nsIContentPolicy.TYPE_WEB_MANIFEST]: "webManifest",
+  [Ci.nsIContentPolicy.TYPE_SAVEAS_DOWNLOAD]: "saveasDownload"
 };
 
 exports.loadCauseString = function (causeType) {

--- a/dom/base/nsContentPolicyUtils.h
+++ b/dom/base/nsContentPolicyUtils.h
@@ -237,7 +237,7 @@ NS_CheckContentLoadPolicy(uint32_t          contentType,
     CHECK_PRINCIPAL_AND_DATA(ShouldLoad);
     if (policyService) {
         CHECK_CONTENT_POLICY_WITH_SERVICE(ShouldLoad, policyService);
-y   ?
+    }
     CHECK_CONTENT_POLICY(ShouldLoad);
 }
 

--- a/dom/base/nsContentPolicyUtils.h
+++ b/dom/base/nsContentPolicyUtils.h
@@ -115,6 +115,7 @@ NS_CP_ContentTypeName(uint32_t contentType)
     CASE_RETURN( TYPE_FETCH                       );
     CASE_RETURN( TYPE_IMAGESET                    );
     CASE_RETURN( TYPE_WEB_MANIFEST                );
+    CASE_RETURN( TYPE_SAVEAS_DOWNLOAD             );
     CASE_RETURN( TYPE_INTERNAL_SCRIPT             );
     CASE_RETURN( TYPE_INTERNAL_WORKER             );
     CASE_RETURN( TYPE_INTERNAL_SHARED_WORKER      );
@@ -236,7 +237,7 @@ NS_CheckContentLoadPolicy(uint32_t          contentType,
     CHECK_PRINCIPAL_AND_DATA(ShouldLoad);
     if (policyService) {
         CHECK_CONTENT_POLICY_WITH_SERVICE(ShouldLoad, policyService);
-    }
+y   ?
     CHECK_CONTENT_POLICY(ShouldLoad);
 }
 

--- a/dom/base/nsIContentPolicy.idl
+++ b/dom/base/nsIContentPolicy.idl
@@ -20,7 +20,7 @@ interface nsIPrincipal;
  * by launching a dialog to prompt the user for something).
  */
 
-[scriptable,uuid(caad4f1f-d047-46ac-ae9d-dc598e4fb91b)]
+[scriptable,uuid(d472863b-adb2-4448-aa8f-6c33c0c4c633)]
 interface nsIContentPolicy : nsIContentPolicyBase
 {
   /**

--- a/dom/base/nsIContentPolicyBase.idl
+++ b/dom/base/nsIContentPolicyBase.idl
@@ -24,7 +24,7 @@ typedef unsigned long nsContentPolicyType;
  * by launching a dialog to prompt the user for something).
  */
 
-[scriptable,uuid(17418187-d86f-48dd-92d1-238838df0a4e)]
+[scriptable,uuid(e8046cd0-3b32-4065-ad78-4099a9bb2e35)]
 interface nsIContentPolicyBase : nsISupports
 {
   /**

--- a/dom/base/nsIContentPolicyBase.idl
+++ b/dom/base/nsIContentPolicyBase.idl
@@ -182,6 +182,11 @@ interface nsIContentPolicyBase : nsISupports
   const nsContentPolicyType TYPE_WEB_MANIFEST = 22;
 
   /**
+   * Indicates an save-as link download from the front-end code.
+   */
+  const nsContentPolicyType TYPE_SAVEAS_DOWNLOAD = 43;
+
+  /**
    * Indicates an internal constant for scripts loaded through script
    * elements.
    *

--- a/dom/base/nsISimpleContentPolicy.idl
+++ b/dom/base/nsISimpleContentPolicy.idl
@@ -28,7 +28,7 @@ interface nsIDOMElement;
  * by launching a dialog to prompt the user for something).
  */
 
-[scriptable,uuid(b9df71e3-a9b3-4706-b2d5-e6c0d3d68ec7)]
+[scriptable,uuid(2215d135-df0d-445b-bb49-f11a4855f2a1)]
 interface nsISimpleContentPolicy : nsIContentPolicyBase
 {
   /**

--- a/dom/cache/DBSchema.cpp
+++ b/dom/cache/DBSchema.cpp
@@ -269,6 +269,7 @@ static_assert(nsIContentPolicy::TYPE_INVALID == 0 &&
               nsIContentPolicy::TYPE_FETCH == 20 &&
               nsIContentPolicy::TYPE_IMAGESET == 21 &&
               nsIContentPolicy::TYPE_WEB_MANIFEST == 22 &&
+              nsIContentPolicy::TYPE_SAVEAS_DOWNLOAD == 43 &&
               nsIContentPolicy::TYPE_INTERNAL_SCRIPT == 23 &&
               nsIContentPolicy::TYPE_INTERNAL_WORKER == 24 &&
               nsIContentPolicy::TYPE_INTERNAL_SHARED_WORKER == 25 &&

--- a/dom/fetch/InternalRequest.cpp
+++ b/dom/fetch/InternalRequest.cpp
@@ -320,6 +320,9 @@ InternalRequest::MapContentPolicyTypeToRequestContext(nsContentPolicyType aConte
   case nsIContentPolicy::TYPE_WEB_MANIFEST:
     context = RequestContext::Manifest;
     break;
+  case nsIContentPolicy::TYPE_SAVEAS_DOWNLOAD:
+    context = RequestContext::Internal;
+    break;
   default:
     MOZ_ASSERT(false, "Unhandled nsContentPolicyType value");
     break;

--- a/dom/fetch/InternalRequest.h
+++ b/dom/fetch/InternalRequest.h
@@ -53,7 +53,7 @@ namespace dom {
  * image             | TYPE_INTERNAL_IMAGE, TYPE_INTERNAL_IMAGE_PRELOAD, TYPE_INTERNAL_IMAGE_FAVICON
  * imageset          | TYPE_IMAGESET
  * import            | Not supported by Gecko
- * internal          | TYPE_DOCUMENT, TYPE_XBL, TYPE_OTHER
+ * internal          | TYPE_DOCUMENT, TYPE_XBL, TYPE_OTHER, TYPE_SAVEAS_DOWNLOAD
  * location          |
  * manifest          | TYPE_WEB_MANIFEST
  * object            | TYPE_INTERNAL_OBJECT

--- a/dom/security/nsCSPUtils.cpp
+++ b/dom/security/nsCSPUtils.cpp
@@ -258,6 +258,9 @@ CSP_ContentTypeToDirective(nsContentPolicyType aType)
     case nsIContentPolicy::TYPE_CSP_REPORT:
       return nsIContentSecurityPolicy::NO_DIRECTIVE;
 
+    case nsIContentPolicy::TYPE_SAVEAS_DOWNLOAD:
+      return nsIContentSecurityPolicy::NO_DIRECTIVE;
+
     // Fall through to error for all other directives
     default:
       MOZ_ASSERT(false, "Can not map nsContentPolicyType to CSPDirective");

--- a/dom/security/nsContentSecurityManager.cpp
+++ b/dom/security/nsContentSecurityManager.cpp
@@ -471,6 +471,12 @@ DoContentSecurityChecks(nsIChannel* aChannel, nsILoadInfo* aLoadInfo)
       break;
     }
 
+    case nsIContentPolicy::TYPE_SAVEAS_DOWNLOAD: {
+      mimeTypeGuess = EmptyCString();
+      requestingContext = aLoadInfo->LoadingNode();
+      break;
+    }
+
     default:
       // nsIContentPolicy::TYPE_INVALID
       MOZ_ASSERT(false, "can not perform security check without a valid contentType");

--- a/dom/security/nsMixedContentBlocker.cpp
+++ b/dom/security/nsMixedContentBlocker.cpp
@@ -468,6 +468,13 @@ nsMixedContentBlocker::ShouldLoad(bool aHadInsecureImageRedirect,
       *aDecision = ACCEPT;
       return NS_OK;
 
+    // Creating insecure connections for a save-as link download is acceptable.
+    // This download is completely disconnected from the docShell, but still
+    // using the same loading principal.
+    case TYPE_SAVEAS_DOWNLOAD:
+      *aDecision = ACCEPT;
+      return NS_OK;
+
     // Static display content is considered moderate risk for mixed content so
     // these will be blocked according to the mixed display preference
     case TYPE_IMAGE:

--- a/extensions/permissions/nsContentBlocker.cpp
+++ b/extensions/permissions/nsContentBlocker.cpp
@@ -46,6 +46,7 @@ static const char *kTypeString[] = {
                                     "fetch",
                                     "image",
                                     "manifest",
+                                    "saveas_download",
                                     "", // TYPE_INTERNAL_SCRIPT
                                     "", // TYPE_INTERNAL_WORKER
                                     "", // TYPE_INTERNAL_SHARED_WORKER

--- a/toolkit/modules/addons/WebRequestCommon.jsm
+++ b/toolkit/modules/addons/WebRequestCommon.jsm
@@ -35,6 +35,7 @@ var WebRequestCommon = {
       case Ci.nsIContentPolicy.TYPE_CSP_REPORT: return "csp_report";
       case Ci.nsIContentPolicy.TYPE_IMAGESET: return "imageset";
       case Ci.nsIContentPolicy.TYPE_WEB_MANIFEST: return "web_manifest";
+      case Ci.nsIContentPolicy.TYPE_SAVEAS_DOWNLOAD: return "saveas_download";
       default: return "other";
     }
   },


### PR DESCRIPTION
This resolves #508 

This fix is based on:
- [Bug 1398229](https://bugzilla.mozilla.org/show_bug.cgi?id=1398229)
  - https://hg.mozilla.org/integration/mozilla-inbound/rev/e7d2101e1aa9
  - https://hg.mozilla.org/integration/mozilla-inbound/rev/6b4cebf12e3f
- [Bug 1430758](https://bugzilla.mozilla.org/show_bug.cgi?id=1430758) - `Save Link As` does not work in non-e10s

---

I've created the new build (x32, Windows) - `Pale Moon UXP / Basilisk` - and tested:
- https://www.palemoon.org/
- https://interfacelift.com/wallpaper/downloads/date/any/
(from [bug 1136055](https://bugzilla.mozilla.org/show_bug.cgi?id=1136055) - `Save Link As` does not follow HTTP 302 response / redirection)
