### PR TITLE
[PALEMOON] Fix "Permissions Manager" and "Remove All Cookies"

### DIFF
--- a/application/palemoon/components/permissions/aboutPermissions.js
+++ b/application/palemoon/components/permissions/aboutPermissions.js
@@ -254,7 +254,7 @@ Site.prototype = {
     while (enumerator.hasMoreElements()) {
       let cookie = enumerator.getNext().QueryInterface(Ci.nsICookie2);
       if (cookie.host.hasRootDomain(
-          AboutPermissions.domainFromHost(this.host))) {
+          AboutPermissions.domainFromHost(this.principal.URI.host))) {
         cookies.push(cookie);
       }
     }

--- a/application/palemoon/components/permissions/aboutPermissions.js
+++ b/application/palemoon/components/permissions/aboutPermissions.js
@@ -266,7 +266,8 @@ Site.prototype = {
    */
   clearCookies: function Site_clearCookies() {
     this.cookies.forEach(function(aCookie) {
-      Services.cookies.remove(aCookie.host, aCookie.name, aCookie.path, false);
+      Services.cookies.remove(aCookie.host, aCookie.name, aCookie.path, false,
+                              aCookie.originAttributes);
     });
   },
 


### PR DESCRIPTION
Follow up #273 

Depends on:
#518 

`Remove All Cookies` throws a warning in Browser Console:
```
“nsICookieManager.remove()” is changed.
Update your code and pass the correct originAttributes.
Read more on MDN:
https://developer.mozilla.org/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsICookieManager
```
