### PR TITLE
Add new close icons and make current icons Basilisk-specific

### DIFF
--- a/application/palemoon/themes/windows/browser.css
+++ b/application/palemoon/themes/windows/browser.css
@@ -2015,7 +2015,7 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 }
 
 .tab-close-button:-moz-lwtheme-brighttext {
-  list-style-image: url("chrome://global/skin/icons/close-inverted.png");
+  list-style-image: url("chrome://global/skin/icons/close-inverted.svg");
 }
 
 /* Tab scrollbox arrow, tabstrip new tab and all-tabs buttons */
@@ -2163,7 +2163,7 @@ toolbar[brighttext] #alltabs-button[type="menu"] {
 }
 
 toolbar[brighttext] .tabs-closebutton {
-  list-style-image: url("chrome://global/skin/icons/close-inverted.png");
+  list-style-image: url("chrome://global/skin/icons/close-inverted.svg");
 }
 
 .tabs-closebutton > .toolbarbutton-icon {
@@ -2697,7 +2697,7 @@ toolbarbutton.bookmark-item[dragover="true"][open="true"] {
 
 /* Make sure the allTab previews always have regular close buttons */
 #allTabs-tab-close-button:-moz-lwtheme-brighttext {
-  list-style-image: url("chrome://global/skin/icons/close.png");
+  list-style-image: url("chrome://global/skin/icons/close.svg");
 }
 
 .allTabs-favicon[src] {
@@ -2770,7 +2770,7 @@ toolbarbutton.bookmark-item[dragover="true"][open="true"] {
 }
 
 toolbar[brighttext] #addonbar-closebutton {
-  list-style-image: url("chrome://global/skin/icons/close-inverted.png");
+  list-style-image: url("chrome://global/skin/icons/close-inverted.svg");
 }
 
 /* Status panel */

--- a/toolkit/themes/linux/global/global.css
+++ b/toolkit/themes/linux/global/global.css
@@ -316,6 +316,7 @@ popupnotificationcontent {
 
 /* :::::: Close button icons ::::: */
 
+%ifdef MC_BASILISK
 .close-icon {
   -moz-appearance: none;
   height: 16px;
@@ -332,3 +333,8 @@ popupnotificationcontent {
 .close-icon:hover:active {
   background-image: -moz-image-rect(url("chrome://global/skin/icons/close.svg"), 0, 48, 16, 32);
 }
+%else
+.close-icon {
+  list-style-image: url("moz-icon://stock/gtk-close?size=menu");
+}
+%endif

--- a/toolkit/themes/linux/global/jar.mn
+++ b/toolkit/themes/linux/global/jar.mn
@@ -14,7 +14,7 @@ toolkit.jar:
    skin/classic/global/filepicker.css
    skin/classic/global/Filepicker.png                          (filepicker/Filepicker.png)
    skin/classic/global/findBar.css
-   skin/classic/global/global.css
+*  skin/classic/global/global.css
    skin/classic/global/groupbox.css
    skin/classic/global/inContentUI.css
    skin/classic/global/listbox.css

--- a/toolkit/themes/windows/global/global.css
+++ b/toolkit/themes/windows/global/global.css
@@ -331,6 +331,7 @@ popupnotificationcontent {
 
 /* :::::: Close button icons ::::: */
 
+%ifdef MC_BASILISK
 .close-icon {
   list-style-image: url("chrome://global/skin/icons/close.png");
   -moz-image-region: rect(0, 20px, 20px, 0);
@@ -398,3 +399,17 @@ popupnotificationcontent {
     }
   }
 }
+%else
+.close-icon {
+  list-style-image: url("chrome://global/skin/icons/close.svg");
+  -moz-image-region: rect(0, 16px, 16px, 0);
+}
+
+.close-icon:hover {
+  -moz-image-region: rect(0, 32px, 16px, 16px);
+}
+
+.close-icon:hover:active {
+  -moz-image-region: rect(0, 48px, 16px, 32px);
+}
+%endif

--- a/toolkit/themes/windows/global/icons/close-inverted.svg
+++ b/toolkit/themes/windows/global/icons/close-inverted.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64" height="16" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <linearGradient id="d" x1="5.5" x2="5.5" y1="1" y2="7" gradientTransform="translate(17,1)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#e35d5d" offset="0"/>
+      <stop stop-color="#e35d5d" stop-opacity="0" offset="1"/>
+    </linearGradient>
+  </defs>
+  <g>
+    <rect x="17" y="1" width="14" height="14" rx="2.5" ry="2.5" fill="#b00021" fill-rule="evenodd"/>
+    <rect id="a" x="18" y="2" width="12" height="12" rx="1.5" ry="1.5" color="#000000" color-rendering="auto" fill="url(#d)" image-rendering="auto" shape-rendering="auto" solid-color="#000000" style="isolation:auto;mix-blend-mode:normal"/>
+    <path id="c" d="m26.8 5.2-5.6 5.6m0-5.6 5.6 5.6" fill="none" stroke="#fff" stroke-linecap="square" stroke-width="1.4"/>
+    <path id="b" d="m10.8 5.2-5.6 5.6m0-5.6 5.6 5.6" fill="none" stroke="#d0d0d0" stroke-linecap="square" stroke-width="1.4"/>
+    <rect x="33" y="1" width="14" height="14" rx="2" ry="2" fill="#800018" fill-rule="evenodd"/>
+    <use transform="translate(48)" width="100%" height="100%" opacity=".5" xlink:href="#b"/>
+    <use transform="translate(16)" width="100%" height="100%" opacity=".6" xlink:href="#a"/>
+    <use transform="translate(16)" width="100%" height="100%" opacity=".6" xlink:href="#c"/>
+  </g>
+</svg>

--- a/toolkit/themes/windows/global/icons/close.svg
+++ b/toolkit/themes/windows/global/icons/close.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64" height="16" version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <linearGradient id="d" x1="5.5" x2="5.5" y1="1" y2="7" gradientTransform="translate(17,1)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#e35d5d" offset="0"/>
+      <stop stop-color="#e35d5d" stop-opacity="0" offset="1"/>
+    </linearGradient>
+  </defs>
+  <g>
+    <rect x="17" y="1" width="14" height="14" rx="2.5" ry="2.5" fill="#b00021" fill-rule="evenodd"/>
+    <rect id="a" x="18" y="2" width="12" height="12" rx="1.5" ry="1.5" color="#000000" color-rendering="auto" fill="url(#d)" image-rendering="auto" shape-rendering="auto" solid-color="#000000" style="isolation:auto;mix-blend-mode:normal"/>
+    <path id="c" d="m26.8 5.2-5.6 5.6m0-5.6 5.6 5.6" fill="none" stroke="#fff" stroke-linecap="square" stroke-width="1.4"/>
+    <path id="b" d="m10.8 5.2-5.6 5.6m0-5.6 5.6 5.6" fill="none" stroke="#303030" stroke-linecap="square" stroke-width="1.4"/>
+    <rect x="33" y="1" width="14" height="14" rx="2" ry="2" fill="#800018" fill-rule="evenodd"/>
+    <use transform="translate(48)" width="100%" height="100%" opacity=".5" xlink:href="#b"/>
+    <use transform="translate(16)" width="100%" height="100%" opacity=".6" xlink:href="#a"/>
+    <use transform="translate(16)" width="100%" height="100%" opacity=".6" xlink:href="#c"/>
+  </g>
+</svg>

--- a/toolkit/themes/windows/global/jar.mn
+++ b/toolkit/themes/windows/global/jar.mn
@@ -45,6 +45,8 @@ toolkit.jar:
   skin/classic/global/icons/autocomplete-search.svg        (icons/autocomplete-search.svg)
   skin/classic/global/icons/blacklist_favicon.png          (icons/blacklist_favicon.png)
   skin/classic/global/icons/blacklist_large.png            (icons/blacklist_large.png)
+  skin/classic/global/icons/close.svg                      (icons/close.svg)
+  skin/classic/global/icons/close-inverted.svg             (icons/close-inverted.svg)
   skin/classic/global/icons/close-win7.png                 (icons/close-win7.png)
   skin/classic/global/icons/close-win7@2x.png              (icons/close-win7@2x.png)
   skin/classic/global/icons/close-inverted-win7.png        (icons/close-inverted-win7.png)


### PR DESCRIPTION
Tag #317 

This `ifdef`'s Basilisk's icons in `global.css` and adds Pale Moon ones instead for generic platform styling (on Windows). A slightly different approach than what I'd originally planned, but hopefully a lot more minimal.

As a bonus, since Linux was also using different icons compared to previous Pale Moon releases, I've also done the same with these and just used the previous styling.

The styling itself works, but I've not been able to test the preprocessor side of things. This should probably be checked before merging.