### PR TITLE
Preferences - Cookies / Saved Passwords - "Remove..." button should not be active if there are no items; "onselect" is not fired twice

### DIFF
--- a/application/basilisk/components/preferences/cookies.js
+++ b/application/basilisk/components/preferences/cookies.js
@@ -808,7 +808,9 @@ var gCookiesWindow = {
 
     this._view._invalidateCache(0);
     this._view.selection.clearSelection();
-    this._view.selection.select(0);
+    if (this._view.rowCount > 0) {
+      this._view.selection.select(0);
+    }
     this._tree.treeBoxObject.invalidate();
     this._tree.treeBoxObject.ensureRowIsVisible(0);
 

--- a/application/basilisk/components/preferences/cookies.js
+++ b/application/basilisk/components/preferences/cookies.js
@@ -565,6 +565,8 @@ var gCookiesWindow = {
   onCookieSelected: function () {
     var item;
     var seln = this._tree.view.selection;
+    var hasRows = this._tree.view.rowCount > 0;
+    var hasSelection = seln.count > 0;
     if (!this._view._filtered)
       item = this._view._getItemAtIndex(seln.currentIndex);
     else
@@ -592,7 +594,7 @@ var gCookiesWindow = {
     removeSelectedCookies.label = PluralForm.get(selectedCookieCount, buttonLabel)
                                             .replace("#1", selectedCookieCount);
 
-    removeSelectedCookies.disabled = !(seln.count > 0);
+    removeSelectedCookies.disabled = !hasRows || !hasSelection;
   },
 
   performDeletion: function gCookiesWindow_performDeletion(deleteItems) {

--- a/application/palemoon/components/preferences/cookies.js
+++ b/application/palemoon/components/preferences/cookies.js
@@ -540,6 +540,8 @@ var gCookiesWindow = {
   onCookieSelected: function () {
     var properties, item;
     var seln = this._tree.view.selection;
+    var hasRows = this._tree.view.rowCount > 0;
+    var hasSelection = seln.count > 0;
     if (!this._view._filtered)
       item = this._view._getItemAtIndex(seln.currentIndex);
     else
@@ -570,7 +572,7 @@ var gCookiesWindow = {
     removeSelectedCookies.label = PluralForm.get(selectedCookieCount, buttonLabel)
                                             .replace("#1", selectedCookieCount);
 
-    removeSelectedCookies.disabled = !(seln.count > 0);
+    removeSelectedCookies.disabled = !hasRows || !hasSelection;
   },
 
   performDeletion: function gCookiesWindow_performDeletion(deleteItems) {

--- a/application/palemoon/components/preferences/cookies.js
+++ b/application/palemoon/components/preferences/cookies.js
@@ -788,7 +788,9 @@ var gCookiesWindow = {
 
     this._view._invalidateCache(0);
     this._view.selection.clearSelection();
-    this._view.selection.select(0);
+    if (this._view.rowCount > 0) {
+      this._view.selection.select(0);
+    }
     this._tree.treeBoxObject.invalidate();
     this._tree.treeBoxObject.ensureRowIsVisible(0);
 

--- a/toolkit/components/passwordmgr/content/passwordManager.js
+++ b/toolkit/components/passwordmgr/content/passwordManager.js
@@ -326,7 +326,7 @@ function LoadSignons() {
 function GetTreeSelections() {
   let selections = [];
   let select = signonsTree.view.selection;
-  if (select) {
+  if (select && signonsTree.view.rowCount > 0) {
     let count = select.getRangeCount();
     let min = {};
     let max = {};


### PR DESCRIPTION
This resolves #541 

---

I've created the new build (x32, Windows) - `Pale Moon UXP / Basilisk` - and tested.
