### PR TITLE
Rewrite assert in alsa_refill_stream to pass back a cubeb error instead.

### DIFF
--- a/media/libcubeb/src/cubeb_alsa.c
+++ b/media/libcubeb/src/cubeb_alsa.c
@@ -317,7 +317,12 @@ alsa_refill_stream(cubeb_stream * stm)
       snd_pcm_recover(stm->pcm, wrote, 1);
       wrote = snd_pcm_writei(stm->pcm, p, got);
     }
-    assert(wrote >= 0 && wrote == got);
+    if (wrote < 0 || wrote != got) {
+      /* Recovery failed, somehow. */
+      pthread_mutex_unlock(&stm->mutex);
+      stm->state_callback(stm, stm->user_ptr, CUBEB_STATE_ERROR);
+      return ERROR;
+    }
     stm->write_position += wrote;
     gettimeofday(&stm->last_activity, NULL);
   }


### PR DESCRIPTION
Rewrite assert in cubeb_alsa.c: alsa_refill_stream to pass back a cubeb error instead.

This fixes #548