### PR TITLE
Unify strings for "Restart in Safe Mode" - in Basilisk and Toolkit: "about:profiles" and "about:support"

### DIFF
--- a/application/basilisk/locales/en-US/chrome/browser/baseMenuOverlay.dtd
+++ b/application/basilisk/locales/en-US/chrome/browser/baseMenuOverlay.dtd
@@ -23,7 +23,7 @@
 <!ENTITY helpKeyboardShortcuts.label     "Keyboard Shortcuts">
 <!ENTITY helpKeyboardShortcuts.accesskey "K">
 
-<!ENTITY helpSafeMode.label       "Restart with Add-ons Disabled…">
+<!ENTITY helpSafeMode.label       "Restart in Safe Mode…">
 <!ENTITY helpSafeMode.accesskey   "R">
 <!ENTITY helpSafeMode.stop.label       "Restart with Add-ons Enabled">
 <!ENTITY helpSafeMode.stop.accesskey   "R">

--- a/application/basilisk/locales/en-US/chrome/browser/browser.properties
+++ b/application/basilisk/locales/en-US/chrome/browser/browser.properties
@@ -413,8 +413,8 @@ extensions.{972ce4c6-7e08-4474-a285-3208198ce6fd}.name=Default
 extensions.{972ce4c6-7e08-4474-a285-3208198ce6fd}.description=The default theme.
 
 # safeModeRestart
-safeModeRestartPromptTitle=Restart with Add-ons Disabled
-safeModeRestartPromptMessage=Are you sure you want to disable all add-ons and restart?
+safeModeRestartPromptTitle=Restart in Safe Mode
+safeModeRestartPromptMessage=Are you sure you want to restart in Safe Mode?
 safeModeRestartButton=Restart
 
 # LOCALIZATION NOTE (browser.menu.showCharacterEncoding): Set to the string

--- a/toolkit/locales/en-US/chrome/global/aboutProfiles.dtd
+++ b/toolkit/locales/en-US/chrome/global/aboutProfiles.dtd
@@ -6,5 +6,5 @@
 <!ENTITY aboutProfiles.subtitle "This page helps you to manage your profiles. Each profile is a separate world which contains separate history, bookmarks, settings and add-ons.">
 <!ENTITY aboutProfiles.create "Create a New Profile">
 <!ENTITY aboutProfiles.restart.title "Restart">
-<!ENTITY aboutProfiles.restart.inSafeMode "Restart with Add-ons Disabled…">
+<!ENTITY aboutProfiles.restart.inSafeMode "Restart in Safe Mode…">
 <!ENTITY aboutProfiles.restart.normal "Restart normally…">

--- a/toolkit/locales/en-US/chrome/global/aboutSupport.dtd
+++ b/toolkit/locales/en-US/chrome/global/aboutSupport.dtd
@@ -110,7 +110,7 @@ variant of aboutSupport.showDir.label. -->
 <!ENTITY aboutSupport.copyRawDataToClipboard.label "Copy raw data to clipboard">
 
 <!ENTITY aboutSupport.safeModeTitle "Try Safe Mode">
-<!ENTITY aboutSupport.restartInSafeMode.label "Restart with Add-ons Disabled…">
+<!ENTITY aboutSupport.restartInSafeMode.label "Restart in Safe Mode…">
 
 <!ENTITY aboutSupport.graphicsFeaturesTitle "Features">
 <!ENTITY aboutSupport.graphicsDiagnosticsTitle "Diagnostics">


### PR DESCRIPTION
Ad
https://github.com/MoonchildProductions/Pale-Moon/issues/1563 - Rename "Restart with addons disabled" to "Restart in Safe Mode"
and
https://forum.palemoon.org/viewtopic.php?f=63&t=19506

