### PR TITLE
"about:support" - added support for "Restart normally"

### DIFF
--- a/toolkit/content/aboutSupport.xhtml
+++ b/toolkit/content/aboutSupport.xhtml
@@ -44,6 +44,12 @@
           &aboutSupport.restartInSafeMode.label;
         </button>
       </div>
+      <div id="restart-box">
+        <h3>&aboutSupport.restartTitle;</h3>
+        <button id="restart-button">
+          &aboutSupport.restartNormal.label;
+        </button>
+      </div>
 
     </div>
     <h1>

--- a/toolkit/locales/en-US/chrome/global/aboutProfiles.dtd
+++ b/toolkit/locales/en-US/chrome/global/aboutProfiles.dtd
@@ -6,5 +6,5 @@
 <!ENTITY aboutProfiles.subtitle "This page helps you to manage your profiles. Each profile is a separate world which contains separate history, bookmarks, settings and add-ons.">
 <!ENTITY aboutProfiles.create "Create a New Profile">
 <!ENTITY aboutProfiles.restart.title "Restart">
-<!ENTITY aboutProfiles.restart.inSafeMode "Restart with Add-ons Disabled…">
+<!ENTITY aboutProfiles.restart.inSafeMode "Restart in Safe Mode…">
 <!ENTITY aboutProfiles.restart.normal "Restart normally…">

--- a/toolkit/locales/en-US/chrome/global/aboutSupport.dtd
+++ b/toolkit/locales/en-US/chrome/global/aboutSupport.dtd
@@ -110,7 +110,7 @@ variant of aboutSupport.showDir.label. -->
 <!ENTITY aboutSupport.copyRawDataToClipboard.label "Copy raw data to clipboard">
 
 <!ENTITY aboutSupport.safeModeTitle "Try Safe Mode">
-<!ENTITY aboutSupport.restartInSafeMode.label "Restart with Add-ons Disabled…">
+<!ENTITY aboutSupport.restartInSafeMode.label "Restart in Safe Mode…">
 
 <!ENTITY aboutSupport.graphicsFeaturesTitle "Features">
 <!ENTITY aboutSupport.graphicsDiagnosticsTitle "Diagnostics">

--- a/toolkit/locales/en-US/chrome/global/aboutSupport.dtd
+++ b/toolkit/locales/en-US/chrome/global/aboutSupport.dtd
@@ -112,6 +112,9 @@ variant of aboutSupport.showDir.label. -->
 <!ENTITY aboutSupport.safeModeTitle "Try Safe Mode">
 <!ENTITY aboutSupport.restartInSafeMode.label "Restart in Safe Mode…">
 
+<!ENTITY aboutSupport.restartTitle "Try Restart">
+<!ENTITY aboutSupport.restartNormal.label "Restart normally…">
+
 <!ENTITY aboutSupport.graphicsFeaturesTitle "Features">
 <!ENTITY aboutSupport.graphicsDiagnosticsTitle "Diagnostics">
 <!ENTITY aboutSupport.graphicsFailureLogTitle "Failure Log">

--- a/toolkit/themes/shared/aboutSupport.css
+++ b/toolkit/themes/shared/aboutSupport.css
@@ -99,6 +99,10 @@ td {
   width: 30%;
 }
 
+#contents {
+  clear: right;
+}
+
 #action-box,
 #reset-box,
 #safe-mode-box {


### PR DESCRIPTION
Ad
https://github.com/MoonchildProductions/Pale-Moon/pull/1093 (partially)
\- `about:support` - added support for `Restart normally...`
and
https://forum.palemoon.org/viewtopic.php?f=63&t=19506

Depends on:
#549 

---

I've created the new build (x32, Windows) - `Pale Moon UXP / Basilisk` - and tested.
