### PR TITLE
Fix "about:support"s "graphics" section when "webgl.disable-extensions" is true

### DIFF
--- a/toolkit/modules/Troubleshoot.jsm
+++ b/toolkit/modules/Troubleshoot.jsm
@@ -460,7 +460,9 @@ var dataProviders = {
 
         // Eagerly free resources.
         let loseExt = gl.getExtension("WEBGL_lose_context");
-        loseExt.loseContext();
+        if (loseExt) {
+          loseExt.loseContext();
+        }
 
 
         return contextInfo;


### PR DESCRIPTION
`about:support` `Graphics` section breaks when `webgl.disable-extensions` (in `about:config`) is true

Throws an error in Browser Console:
```
Troubleshoot data provider failed: graphics
TypeError: loseExt is null  Troubleshoot.jsm:155
TypeError: invalid 'in' operand data  aboutSupport.js:204:1
```
