### PR TITLE
[PALEMOON] Include devtools/client when building language packs

### DIFF
--- a/application/palemoon/locales/Makefile.in
+++ b/application/palemoon/locales/Makefile.in
@@ -124,7 +124,9 @@ libs-%:
 	@$(MAKE) -C ../../../services/sync/locales AB_CD=$* XPI_NAME=locale-$*
 	@$(MAKE) -C ../../../extensions/spellcheck/locales AB_CD=$* XPI_NAME=locale-$*
 	@$(MAKE) -C ../../../intl/locales AB_CD=$* XPI_NAME=locale-$*
+ifdef MOZ_DEVTOOLS
 	@$(MAKE) -C ../../../devtools/client/locales AB_CD=$* XPI_NAME=locale-$*
+endif
 	@$(MAKE) libs AB_CD=$* XPI_NAME=locale-$* PREF_DIR=$(PREF_DIR)
 	@$(MAKE) -C $(DEPTH)/$(MOZ_BRANDING_DIRECTORY)/locales AB_CD=$* XPI_NAME=locale-$*
 

--- a/application/palemoon/locales/Makefile.in
+++ b/application/palemoon/locales/Makefile.in
@@ -124,6 +124,7 @@ libs-%:
 	@$(MAKE) -C ../../../services/sync/locales AB_CD=$* XPI_NAME=locale-$*
 	@$(MAKE) -C ../../../extensions/spellcheck/locales AB_CD=$* XPI_NAME=locale-$*
 	@$(MAKE) -C ../../../intl/locales AB_CD=$* XPI_NAME=locale-$*
+	@$(MAKE) -C ../../../devtools/client/locales AB_CD=$* XPI_NAME=locale-$*
 	@$(MAKE) libs AB_CD=$* XPI_NAME=locale-$* PREF_DIR=$(PREF_DIR)
 	@$(MAKE) -C $(DEPTH)/$(MOZ_BRANDING_DIRECTORY)/locales AB_CD=$* XPI_NAME=locale-$*
 


### PR DESCRIPTION
Based on [bug 1182722](https://bugzilla.mozilla.org/show_bug.cgi?id=1182722).

This resolves #512.