### PR TITLE
[PALEMOON] Use "w.gBrowser.selectedBrowser" instead of "aCurrentBrowser"

### DIFF
--- a/application/palemoon/base/content/utilityOverlay.js
+++ b/application/palemoon/base/content/utilityOverlay.js
@@ -347,7 +347,7 @@ function openLinkIn(url, where, params) {
                                 referrerPolicy: aReferrerPolicy,
                                 postData: aPostData,
                                 }); 
-    browserUsedForLoad = aCurrentBrowser;
+    browserUsedForLoad = w.gBrowser.selectedBrowser;
     break;
   case "tabshifted":
     loadInBackground = !loadInBackground;


### PR DESCRIPTION
Follow up #525 

__Steps to reproduce:__
Open browser, go to `Search bar`, click on `Search`

Throws an error in Browser Console:
```
ReferenceError: aCurrentBrowser is not defined  utilityOverlay.js:345:
```

Please review (@JustOff , @wolfbeast).

See also (creating a variable named `aCurrentBrowser`):
https://bugzilla.mozilla.org/show_bug.cgi?id=1000458
(`enter in location bar (URL bar) for bookmark keyword immediately followed by opening new tab sometimes loads url in new tab instead of old, particularly under high load`)
