### PR TITLE
Fix typos in comments - animationinspector.properties

### DIFF
--- a/devtools/client/locales/en-US/animationinspector.properties
+++ b/devtools/client/locales/en-US/animationinspector.properties
@@ -121,12 +121,12 @@ player.somePropertiesOnCompositorTooltip=Some animation properties are optimized
 # run.
 timeline.rateSelectorTooltip=Set the animations playback rates
 
-# LOCALIZATION NOTE (timeline.pauseResumeButtonTooltip):
+# LOCALIZATION NOTE (timeline.pausedButtonTooltip):
 # This string is displayed in the timeline toolbar, as the tooltip of the
 # pause/resume button that can be used to pause or resume the animations
 timeline.pausedButtonTooltip=Resume the animations
 
-# LOCALIZATION NOTE (timeline.pauseResumeButtonTooltip):
+# LOCALIZATION NOTE (timeline.resumedButtonTooltip):
 # This string is displayed in the timeline toolbar, as the tooltip of the
 # pause/resume button that can be used to pause or resume the animations
 timeline.resumedButtonTooltip=Pause the animations


### PR DESCRIPTION
Align `Name values` with `names in comments`.
