### PR TITLE
Quick fix to binary file path for Mac packaging

### DIFF
--- a/application/palemoon/installer/package-manifest.in
+++ b/application/palemoon/installer/package-manifest.in
@@ -117,7 +117,7 @@
 @BINPATH@/browser/VisualElements/VisualElements_150.png
 @BINPATH@/browser/VisualElements/VisualElements_70.png
 #else
-@BINPATH@/@MOZ_APP_NAME@-bin
+@RESPATH@/@MOZ_APP_NAME@-bin
 @BINPATH@/@MOZ_APP_NAME@
 #endif
 @RESPATH@/application.ini


### PR DESCRIPTION
We still need to investigate why the file is not being generated in the supposed location. But this fix should be good enough for the time being.

This resolves #573