### PR TITLE
Mac: Do not hide caption buttons or titlebar

### DIFF
--- a/application/palemoon/themes/osx/browser.css
+++ b/application/palemoon/themes/osx/browser.css
@@ -127,8 +127,8 @@
 }
 
 /* ensure extra titlebar doesn't appear on normal (e.g. non-privacy) windows */
-#titlebar-buttonbox-container,
-#main-window:not([drawintitlebar=true]) > #titlebar {
+#main-window:not([privatebrowsingmode=temporary]) > #titlebar > #titlebar-content > #titlebar-buttonbox-container,
+#main-window:not([drawintitlebar=true]):not(:-moz-lwtheme) > #titlebar {
     display: none;
 }
 


### PR DESCRIPTION
on private browsing windows or with a lightweight theme installed.

This resolves #491. This resolves #584.
Tag https://github.com/MoonchildProductions/Pale-Moon/issues/623