### PR TITLE
[PALEMOON] about:sessionrestore - fix an error "treeView.treeBox is null" in aboutSessionRestore.js

### DIFF
--- a/application/palemoon/components/sessionstore/content/aboutSessionRestore.js
+++ b/application/palemoon/components/sessionstore/content/aboutSessionRestore.js
@@ -134,6 +134,9 @@ function onListClick(aEvent) {
   if (aEvent.button == 2)
     return;
 
+  if (!treeView.treeBox) {
+    return;
+  }
   var cell = treeView.treeBox.getCellAt(aEvent.clientX, aEvent.clientY);
   if (cell.col) {
     // Restore this specific tab in the same window for middle/double/accel clicking


### PR DESCRIPTION
Ad #350

__Steps to reproduce:__

Go to `about:sessionrestore`

Click into an empty tree with columns `Restore | Windows and Tabs`

__Throws an error in Browser Console:__
```
TypeError: treeView.treeBox is null  aboutSessionRestore.js:191:7
```

---

I've created the new build (x32, Windows) - `Pale Moon` - and tested:
- the above example
- a restore session (when the tree is not empty)
