### PR TITLE
Don't hide caption buttons with a lw theme, either

### DIFF
--- a/application/palemoon/themes/osx/browser.css
+++ b/application/palemoon/themes/osx/browser.css
@@ -127,7 +127,7 @@
 }
 
 /* ensure extra titlebar doesn't appear on normal (e.g. non-privacy) windows */
-#main-window:not([privatebrowsingmode=temporary]) > #titlebar > #titlebar-content > #titlebar-buttonbox-container,
+#main-window:not([privatebrowsingmode=temporary]):not(-moz-lwtheme) > #titlebar > #titlebar-content > #titlebar-buttonbox-container,
 #main-window:not([drawintitlebar=true]):not(:-moz-lwtheme) > #titlebar {
     display: none;
 }


### PR DESCRIPTION
Follow-up to #585. I removed this from the PR, but it's actually needed, otherwise the caption buttons are hidden with a lightweight theme!

Tag #491, https://github.com/MoonchildProductions/Pale-Moon/issues/623