### PR TITLE
nsIContentPolicy::TYPE_DOCUMENT - Use "aLoadInfo->ContextForTopLevelLoad()" instead of "aLoadInfo->LoadingNode()"

### DIFF
--- a/dom/security/nsContentSecurityManager.cpp
+++ b/dom/security/nsContentSecurityManager.cpp
@@ -303,7 +303,7 @@ DoContentSecurityChecks(nsIChannel* aChannel, nsILoadInfo* aLoadInfo)
 
     case nsIContentPolicy::TYPE_DOCUMENT: {
       mimeTypeGuess = EmptyCString();
-      requestingContext = aLoadInfo->LoadingNode();
+      requestingContext = aLoadInfo->ContextForTopLevelLoad();
       break;
     }
 


### PR DESCRIPTION
This (maybe) resolves #600   

---

I've created the new build (x32, Windows) - `Pale Moon`.
