### PR TITLE
Fix typos in comments - memory.properties

### DIFF
--- a/devtools/client/locales/en-US/memory.properties
+++ b/devtools/client/locales/en-US/memory.properties
@@ -96,7 +96,7 @@ censusDisplays.internalType.tooltip=Group items by their internal C++ type
 # options of the label options.
 toolbar.labelBy=Label by:
 
-# LOCALIZATION NOTE (toolbar.labelBy): The tooltip for the label describing the
+# LOCALIZATION NOTE (toolbar.labelBy.tooltip): The tooltip for the label describing the
 # select menu options of the label options.
 toolbar.labelBy.tooltip=Change how objects are labeled
 
@@ -250,7 +250,7 @@ diffing.state.selecting.full=Select two snapshots to compare
 # dominator tree state COMPUTING.
 dominatorTree.state.computing=Generating dominators report…
 
-# LOCALIZATION NOTE (dominatorTree.state.computing): The label describing the
+# LOCALIZATION NOTE (dominatorTree.state.computing.full): The label describing the
 # dominator tree state COMPUTING, used in the dominator tree view.
 dominatorTree.state.computing.full=Generating dominators report…
 
@@ -258,7 +258,7 @@ dominatorTree.state.computing.full=Generating dominators report…
 # dominator tree state FETCHING.
 dominatorTree.state.fetching=Computing sizes…
 
-# LOCALIZATION NOTE (dominatorTree.state.fetching): The label describing the
+# LOCALIZATION NOTE (dominatorTree.state.fetching.full): The label describing the
 # dominator tree state FETCHING, used in the dominator tree view.
 dominatorTree.state.fetching.full=Computing dominator’s retained sizes…
 
@@ -266,7 +266,7 @@ dominatorTree.state.fetching.full=Computing dominator’s retained sizes…
 # describing the dominator tree state INCREMENTAL_FETCHING.
 dominatorTree.state.incrementalFetching=Fetching…
 
-# LOCALIZATION NOTE (dominatorTree.state.incrementalFetching): The label describing the
+# LOCALIZATION NOTE (dominatorTree.state.incrementalFetching.full): The label describing the
 # dominator tree state INCREMENTAL_FETCHING, used in the dominator tree view.
 dominatorTree.state.incrementalFetching.full=Fetching more…
 
@@ -274,7 +274,7 @@ dominatorTree.state.incrementalFetching.full=Fetching more…
 # dominator tree state ERROR.
 dominatorTree.state.error=Error
 
-# LOCALIZATION NOTE (dominatorTree.state.error): The label describing the
+# LOCALIZATION NOTE (dominatorTree.state.error.full): The label describing the
 # dominator tree state ERROR, used in the dominator tree view.
 dominatorTree.state.error.full=There was an error while processing the dominator tree
 


### PR DESCRIPTION
Align `Name values` with `names in comments`.

@JustOff - FYI (for a context).
