### PR TITLE
[BASILISK] "about:privatebrowsing" - use "Basilisk" instead of "Firefox"

### DIFF
--- a/application/basilisk/locales/en-US/chrome/browser/aboutPrivateBrowsing.dtd
+++ b/application/basilisk/locales/en-US/chrome/browser/aboutPrivateBrowsing.dtd
@@ -8,14 +8,14 @@
 
 <!ENTITY privateBrowsing.title                           "Private Browsing">
 <!ENTITY privateBrowsing.title.tracking                  "Private Browsing with Tracking Protection">
-<!ENTITY aboutPrivateBrowsing.info.notsaved.before       "When you browse in a Private Window, Firefox ">
+<!ENTITY aboutPrivateBrowsing.info.notsaved.before       "When you browse in a Private Window, &brandShortName; ">
 <!ENTITY aboutPrivateBrowsing.info.notsaved.emphasize    "does not save">
 <!ENTITY aboutPrivateBrowsing.info.notsaved.after        ":">
 <!ENTITY aboutPrivateBrowsing.info.visited               "visited pages">
 <!ENTITY aboutPrivateBrowsing.info.searches              "searches">
 <!ENTITY aboutPrivateBrowsing.info.cookies               "cookies">
 <!ENTITY aboutPrivateBrowsing.info.temporaryFiles        "temporary files">
-<!ENTITY aboutPrivateBrowsing.info.saved.before          "Firefox ">
+<!ENTITY aboutPrivateBrowsing.info.saved.before          "&brandShortName; ">
 <!ENTITY aboutPrivateBrowsing.info.saved.emphasize       "will save">
 <!ENTITY aboutPrivateBrowsing.info.saved.after2          " your:">
 <!ENTITY aboutPrivateBrowsing.info.downloads             "downloads">
@@ -27,5 +27,5 @@
 <!ENTITY aboutPrivateBrowsing.learnMore2.title           "Private Browsing">
 
 <!ENTITY trackingProtection.title                        "Tracking Protection">
-<!ENTITY trackingProtection.description2                 "Some websites use trackers that can monitor your activity across the Internet. With Tracking Protection Firefox will block many trackers that can collect information about your browsing behavior.">
+<!ENTITY trackingProtection.description2                 "Some websites use trackers that can monitor your activity across the Internet. With Tracking Protection &brandShortName; will block many trackers that can collect information about your browsing behavior.">
 <!ENTITY trackingProtection.startTour1                   "See how it works">


### PR DESCRIPTION
This resolves #610 

It uses some (other) parts from: [_testBranch_firefox_name](https://github.com/MoonchildProductions/UXP/compare/master...janekptacijarabaci:_testBranch_firefox_name)

---

I've created the new build (x32, Windows) - `Basilisk` and tested.
