### PR TITLE
Rename some remaining strings "firefox[-branding].js" to "basilisk[-branding].js" (or [application name].js)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -57,7 +57,7 @@ b2g/locales/en-US/b2g-l10n.js
 
 # browser/ exclusions
 browser/app/**
-browser/branding/**/firefox-branding.js
+browser/branding/**/basilisk-branding.js
 browser/base/content/browser-social.js
 browser/base/content/nsContextMenu.js
 browser/base/content/sanitizeDialog.js

--- a/services/sync/services-sync.js
+++ b/services/sync/services-sync.js
@@ -81,7 +81,7 @@ pref("services.sync.fxa.privacyURL", "https://accounts.firefox.com/legal/privacy
 pref("services.sync.telemetry.submissionInterval", 43200); // 12 hours in seconds
 pref("services.sync.telemetry.maxPayloadCount", 500);
 
-// Note that services.sync.validation.enabled is located in browser/app/profile/firefox.js
+// Note that services.sync.validation.enabled is located in application/[application name]/app/profile/[application name].js
 
 // We consider validation this frequently. After considering validation, even
 // if we don't end up validating, we won't try again unless this much time has passed.


### PR DESCRIPTION
Ad:
https://github.com/MoonchildProductions/UXP/commit/30cc819b77891ec4c097156670ecb5ce10b5d9c7

---

I've created the new build (x32, Windows) - `Basilisk`.
