### PR TITLE
DevTools - display newlines in some console messages

### DIFF
--- a/devtools/client/themes/webconsole.css
+++ b/devtools/client/themes/webconsole.css
@@ -148,7 +148,7 @@ a {
   display: flex;
 }
 
-.message-body > * {
+.message-body {
   white-space: pre-wrap;
   word-wrap: break-word;
 }


### PR DESCRIPTION
This resolves #614 

Based on:
[Bug 1345533](https://hg.mozilla.org/mozilla-central/rev/0c405b138c2b) - partially

---

I've created the new build (x32, Windows) - `Pale Moon` and tested.
