### PR TITLE
Add event.srcElement (the alias for event.target)

### DIFF
--- a/dom/webidl/Event.webidl
+++ b/dom/webidl/Event.webidl
@@ -17,6 +17,8 @@ interface Event {
   readonly attribute DOMString type;
   [Pure]
   readonly attribute EventTarget? target;
+  [Pure, BinaryName="target"]
+  readonly attribute EventTarget? srcElement;
   [Pure]
   readonly attribute EventTarget? currentTarget;
 


### PR DESCRIPTION
This resolves #622

Based on:
https://bugzilla.mozilla.org/show_bug.cgi?id=1444004
https://bugzilla.mozilla.org/show_bug.cgi?id=453968

__An example:__
```
<html>
<body>
<script>
var ul = document.createElement("ul");
document.body.appendChild(ul);

var li1 = document.createElement("li");
var li2 = document.createElement("li");
ul.appendChild(li1);
ul.appendChild(li2);

function hide(e) {
  console.log("e.target: " + e.target);
  console.log("e.srcElement: " + e.srcElement);
  e.srcElement.style.visibility = "hidden";
}

ul.addEventListener("click", hide, false);
</script>
</body>
</html>
```

---

I've created the new build (x32, Windows) - `Pale Moon` and tested.
