### PR TITLE
Fix Build Bustage - with "--enable-debug"

### DIFF
--- a/dom/html/HTMLMediaElement.cpp
+++ b/dom/html/HTMLMediaElement.cpp
@@ -5514,7 +5514,9 @@ void HTMLMediaElement::SuspendOrResumeElement(bool aPauseElement, bool aSuspendE
       }
       mEventDeliveryPaused = aSuspendEvents;
     } else {
+#ifdef MOZ_EME
       MOZ_ASSERT(!mMediaKeys);
+#endif
       if (mDecoder) {
         mDecoder->Resume();
         if (!mPaused && !mDecoder->IsEnded()) {

--- a/editor/libeditor/TextEditor.cpp
+++ b/editor/libeditor/TextEditor.cpp
@@ -836,7 +836,7 @@ TextEditor::BeginIMEComposition(WidgetCompositionEvent* aEvent)
 nsresult
 TextEditor::UpdateIMEComposition(WidgetCompositionEvent* aCompositionChangeEvent)
 {
-  MOZ_ASSERT(aCompsitionChangeEvent,
+  MOZ_ASSERT(aCompositionChangeEvent,
              "aCompositionChangeEvent must not be nullptr");
 
   if (NS_WARN_IF(!aCompositionChangeEvent)) {

--- a/js/src/vm/EnvironmentObject.h
+++ b/js/src/vm/EnvironmentObject.h
@@ -930,6 +930,9 @@ class DebugEnvironments
     void mark(JSTracer* trc);
     void sweep(JSRuntime* rt);
     void finish();
+#ifdef JSGC_HASH_TABLE_CHECKS
+    void checkHashTablesAfterMovingGC(JSRuntime* runtime);
+#endif 
 
     // If a live frame has a synthesized entry in missingEnvs, make sure it's not
     // collected.

--- a/layout/base/nsLayoutUtils.cpp
+++ b/layout/base/nsLayoutUtils.cpp
@@ -5057,7 +5057,7 @@ nsLayoutUtils::IntrinsicForAxis(PhysicalAxis              aAxis,
   NS_PRECONDITION(aFrame->GetParent(),
                   "IntrinsicForAxis called on frame not in tree");
   NS_PRECONDITION(aType == MIN_ISIZE || aType == PREF_ISIZE, "bad type");
-  MOZ_ASSERT(aFrame->GetParent()->Type() != LayoutFrameType::GridContainer ||
+  MOZ_ASSERT(aFrame->GetParent()->GetType() != nsGkAtoms::gridContainerFrame ||
              aPercentageBasis.isSome(),
              "grid layout should always pass a percentage basis");
 


### PR DESCRIPTION
This resolves #627 

---

```
[path]/UXP/editor/libeditor/TextEditor.cpp(840):
error C2065: 'aCompsitionChangeEvent': undeclared identifier
```
Follow up (fix typo):
[Issue #12 Part 1: Stop using nsIDOMEvent in UpdateIMEComposition](https://github.com/MoonchildProductions/UXP/commit/783f57d74b0caf84cec01a0ae43a2a8cb8697673#diff-5cbba76a78f12bcc4c82b77fe80f5423R839)

```
[path]/UXP/layout/base/nsLayoutUtils.cpp(5062):
error C2653: 'LayoutFrameType': is not a class or namespace name
```
Follow up:
[CSS - Grid - transferred min-size contribution of percentage size grid item with an intrinsic ratio](https://github.com/MoonchildProductions/UXP/commit/76e1c016a32cb8cee6f5a0a0012fe512570da1eb#diff-81c0a9db69d21b1dc0081929f57f4f49R5060)

```
[path]/UXP/dom/html/HTMLMediaElement.cpp(5517):
error C2065: 'mMediaKeys': undeclared identifier
```

Follow up:
[Don't build EME-specific subroutines without EME](https://github.com/MoonchildProductions/UXP/commit/46ad1199deeaf6ba2db31fb3398d3eaa9abdbb2e#diff-2e3935e4e5f0ef25207d1db3fd7c3524R1480)

```
[path]/UXP/js/src/jsgc.cpp(6523): error C2039:
'checkHashTablesAfterMovingGC': is not a member of 'js::DebugEnvironments'
```

Follow up:
[Remove remaining conditional GCZeal code](https://github.com/MoonchildProductions/UXP/commit/1cac08b9a2d2171593fc6737e1b649d81ff39784#diff-6c43cb8c3f7363745e4a864c38fb9fe4L933)
