### PR TITLE
Fix issue #336: Full-screen does not initialized properly when called from an empty new tab

### DIFF
--- a/application/basilisk/base/content/browser-fullScreenAndPointerLock.js
+++ b/application/basilisk/base/content/browser-fullScreenAndPointerLock.js
@@ -320,6 +320,18 @@ var FullScreen = {
       document.addEventListener("keypress", this._keyToggleCallback, false);
       document.addEventListener("popupshown", this._setPopupOpen, false);
       document.addEventListener("popuphidden", this._setPopupOpen, false);
+      // If it is not safe to collapse, add the mouse position tracker or
+      // else it won't be possible to hide the navigation toolbox again
+      if (!this._safeToCollapse()) {
+        let rect = gBrowser.mPanelContainer.getBoundingClientRect();
+        this._mouseTargetRect = {
+          top: rect.top + 50,
+          bottom: rect.bottom,
+          left: rect.left,
+          right: rect.right
+        };
+        MousePosTracker.addListener(this);
+      }
       // In DOM fullscreen mode, we hide toolbars with CSS
       if (!document.fullscreenElement)
         this.hideNavToolbox(true);

--- a/application/palemoon/base/content/browser-fullScreen.js
+++ b/application/palemoon/base/content/browser-fullScreen.js
@@ -53,6 +53,18 @@ var FullScreen = {
       document.addEventListener("popupshown", this._setPopupOpen, false);
       document.addEventListener("popuphidden", this._setPopupOpen, false);
       this._shouldAnimate = true;
+      // If it is not safe to collapse, add the mouse position tracker or
+      // else it won't be possible to hide the navigation toolbox again
+      if (!this._safeToCollapse(document.mozFullScreen)) {
+        let rect = gBrowser.mPanelContainer.getBoundingClientRect();
+        this._mouseTargetRect = {
+          top: rect.top + 50,
+          bottom: rect.bottom,
+          left: rect.left,
+          right: rect.right
+        };
+        MousePosTracker.addListener(this);
+      }
       // We don't animate the toolbar collapse if in DOM full-screen mode,
       // as the size of the content area would still be changing after the
       // mozfullscreenchange event fired, which could confuse content script.


### PR DESCRIPTION
Resolves #336.
* When a certain control is focused (i.e. URL bar) and the user enters fullscreen, the mouse position tracker doesn't get set (It only gets set if you hover over the trigger area - which can only happen if the navigation toolbox is hidden). Since nothing listens on mouse move events, this prevents the navigation toolbox from being hidden even if you navigate to other tabs.
* This sets the mouse position tracker early when the user is entering fullscreen and it's not safe to collapse.

Please add `verification needed` tag.