### PR TITLE
Make document.domain non-nullable

### DIFF
--- a/dom/html/nsHTMLDocument.cpp
+++ b/dom/html/nsHTMLDocument.cpp
@@ -886,7 +886,7 @@ nsHTMLDocument::GetDomain(nsAString& aDomain)
   nsCOMPtr<nsIURI> uri = GetDomainURI();
 
   if (!uri) {
-    SetDOMStringToNull(aDomain);
+    aDomain.Truncate();
     return NS_OK;
   }
 
@@ -896,8 +896,8 @@ nsHTMLDocument::GetDomain(nsAString& aDomain)
     CopyUTF8toUTF16(hostName, aDomain);
   } else {
     // If we can't get the host from the URI (e.g. about:, javascript:,
-    // etc), just return an null string.
-    SetDOMStringToNull(aDomain);
+    // etc), just return an empty string.
+    aDomain.Truncate();
   }
   return NS_OK;
 }

--- a/dom/webidl/HTMLDocument.webidl
+++ b/dom/webidl/HTMLDocument.webidl
@@ -7,7 +7,7 @@
 [OverrideBuiltins]
 interface HTMLDocument : Document {
            [SetterThrows]
-           attribute DOMString? domain;
+           attribute DOMString domain;
            [Throws]
            attribute DOMString cookie;
   // DOM tree accessors


### PR DESCRIPTION
Return empty string instead.

Aligns with the spec.

See: [Bug 819475](https://bugzilla.mozilla.org/show_bug.cgi?id=819475)

This resolves #647 