### PR TITLE
[PALEMOON] Places - remove unused @param from controller.js

### DIFF
--- a/application/palemoon/components/places/content/controller.js
+++ b/application/palemoon/components/places/content/controller.js
@@ -300,9 +300,6 @@ PlacesController.prototype = {
    * are non-removable. We don't need to worry about recursion here since it
    * is a policy decision that a removable item not be placed inside a non-
    * removable item.
-   * @param aIsMoveCommand
-   *        True if the command for which this method is called only moves the
-   *        selected items to another container, false otherwise.
    * @returns true if all nodes in the selection can be removed,
    *          false otherwise.
    */


### PR DESCRIPTION
`_hasRemovableSelection()` does not use parameters.
