### PR TITLE
Add some error handling when parsing MP4 files

### DIFF
--- a/media/libstagefright/binding/include/mp4_demuxer/Box.h
+++ b/media/libstagefright/binding/include/mp4_demuxer/Box.h
@@ -12,7 +12,7 @@
 #include "MediaResource.h"
 #include "mozilla/EndianUtils.h"
 #include "mp4_demuxer/AtomType.h"
-#include "mp4_demuxer/ByteReader.h"
+#include "mp4_demuxer/BufferReader.h"
 
 using namespace mozilla;
 
@@ -73,11 +73,11 @@ public:
     , mReader(mBuffer.Elements(), mBuffer.Length())
   {
   }
-  ByteReader* operator->() { return &mReader; }
+  BufferReader* operator->() { return &mReader; }
 
 private:
   nsTArray<uint8_t> mBuffer;
-  ByteReader mReader;
+  BufferReader mReader;
 };
 }
 

--- a/media/libstagefright/binding/include/mp4_demuxer/BufferReader.h
+++ b/media/libstagefright/binding/include/mp4_demuxer/BufferReader.h
@@ -1,0 +1,225 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BUFFER_READER_H_
+#define BUFFER_READER_H_
+
+#include "mozilla/EndianUtils.h"
+#include "mozilla/Vector.h"
+#include "nsTArray.h"
+#include "MediaData.h"
+
+namespace mp4_demuxer {
+
+class MOZ_RAII BufferReader
+{
+public:
+  BufferReader() : mPtr(nullptr), mRemaining(0) {}
+  explicit BufferReader(const mozilla::Vector<uint8_t>& aData)
+    : mPtr(aData.begin()), mRemaining(aData.length()), mLength(aData.length())
+  {
+  }
+  BufferReader(const uint8_t* aData, size_t aSize)
+    : mPtr(aData), mRemaining(aSize), mLength(aSize)
+  {
+  }
+  template<size_t S>
+  explicit BufferReader(const AutoTArray<uint8_t, S>& aData)
+    : mPtr(aData.Elements()), mRemaining(aData.Length()), mLength(aData.Length())
+  {
+  }
+  explicit BufferReader(const nsTArray<uint8_t>& aData)
+    : mPtr(aData.Elements()), mRemaining(aData.Length()), mLength(aData.Length())
+  {
+  }
+  explicit BufferReader(const mozilla::MediaByteBuffer* aData)
+    : mPtr(aData->Elements()), mRemaining(aData->Length()), mLength(aData->Length())
+  {
+  }
+
+  void SetData(const nsTArray<uint8_t>& aData)
+  {
+    MOZ_ASSERT(!mPtr && !mRemaining);
+    mPtr = aData.Elements();
+    mRemaining = aData.Length();
+    mLength = mRemaining;
+  }
+
+  ~BufferReader()
+  {
+  }
+
+  size_t Offset() const
+  {
+    return mLength - mRemaining;
+  }
+
+  size_t Remaining() const { return mRemaining; }
+
+  bool CanRead8() const { return mRemaining >= 1; }
+
+  bool ReadU8(uint8_t& aU8)
+  {
+    const uint8_t* ptr;
+    if (!Read(1, &ptr)) {
+      NS_WARNING("Failed to read data");
+      return false;
+    }
+    aU8 = *ptr;
+    return true;
+  }
+
+  bool CanRead16() { return mRemaining >= 2; }
+
+  bool ReadU16(uint16_t& u16)
+  {
+    const uint8_t* ptr;
+    if (!Read(2, &ptr)) {
+      NS_WARNING("Failed to read data");
+      return false;
+    }
+    u16 = mozilla::BigEndian::readUint16(ptr);
+    return true;
+  }
+
+  bool CanRead32() { return mRemaining >= 4; }
+
+  bool ReadU32(uint32_t& u32)
+  {
+    const uint8_t* ptr;
+    if (!Read(4, &ptr)) {
+      NS_WARNING("Failed to read data");
+      return false;
+    }
+    u32 = mozilla::BigEndian::readUint32(ptr);
+    return true;
+  }
+
+  bool Read32(int32_t& i32)
+  {
+    const uint8_t* ptr;
+    if (!Read(4, &ptr)) {
+      NS_WARNING("Failed to read data");
+      return 0;
+    }
+    i32 = mozilla::BigEndian::readInt32(ptr);
+    return true;
+  }
+
+  bool ReadU64(uint64_t& u64)
+  {
+    const uint8_t* ptr;
+    if (!Read(8, &ptr)) {
+      NS_WARNING("Failed to read data");
+      return false;
+    }
+    u64 = mozilla::BigEndian::readUint64(ptr);
+    return true;
+  }
+
+  bool Read64(int64_t& i64)
+  {
+    const uint8_t* ptr;
+    if (!Read(8, &ptr)) {
+      NS_WARNING("Failed to read data");
+      return false;
+    }
+    i64 = mozilla::BigEndian::readInt64(ptr);
+    return true;
+  }
+
+  bool ReadU24(uint32_t& u32)
+  {
+    const uint8_t* ptr;
+    if (!Read(3, &ptr)) {
+      NS_WARNING("Failed to read data");
+      return false;
+    }
+    u32 = ptr[0] << 16 | ptr[1] << 8 | ptr[2];
+    return true;
+  }
+
+  bool Skip(size_t aCount)
+  {
+    const uint8_t* ptr;
+    if (!Read(aCount, &ptr)) {
+      NS_WARNING("Failed to skip data");
+      return false;
+    }
+    return true;
+  }
+
+  bool Read(size_t aCount, const uint8_t** aPtr)
+  {
+    if (aCount > mRemaining) {
+      mRemaining = 0;
+      return false;
+    }
+    mRemaining -= aCount;
+
+    *aPtr = mPtr;
+    mPtr += aCount;
+
+    return true;
+  }
+
+  uint32_t Align() const
+  {
+    return 4 - ((intptr_t)mPtr & 3);
+  }
+
+  template <typename T> bool CanReadType() const { return mRemaining >= sizeof(T); }
+
+  template <typename T> T ReadType()
+  {
+    const uint8_t* ptr;
+    if (!Read(sizeof(T), &ptr)) {
+      NS_WARNING("ReadType failed");
+      return 0;
+    }
+    return *reinterpret_cast<const T*>(ptr);
+  }
+
+  template <typename T>
+  MOZ_MUST_USE bool ReadArray(nsTArray<T>& aDest, size_t aLength)
+  {
+    const uint8_t* ptr;
+    if (!Read(aLength * sizeof(T), &ptr)) {
+      NS_WARNING("ReadArray failed");
+      return false;
+    }
+
+    aDest.Clear();
+    aDest.AppendElements(reinterpret_cast<const T*>(ptr), aLength);
+    return true;
+  }
+
+  template <typename T>
+  MOZ_MUST_USE bool ReadArray(FallibleTArray<T>& aDest, size_t aLength)
+  {
+    const uint8_t* ptr;
+    if (!Read(aLength * sizeof(T), &ptr)) {
+      NS_WARNING("ReadArray failed");
+      return false;
+    }
+
+    aDest.Clear();
+    if (!aDest.SetCapacity(aLength, mozilla::fallible)) {
+      return false;
+    }
+    MOZ_ALWAYS_TRUE(aDest.AppendElements(reinterpret_cast<const T*>(ptr),
+                                         aLength,
+                                         mozilla::fallible));
+    return true;
+  }
+
+private:
+  const uint8_t* mPtr;
+  size_t mRemaining;
+  size_t mLength;
+};
+
+} // namespace mp4_demuxer
+
+#endif

--- a/media/libstagefright/binding/include/mp4_demuxer/ByteReader.h
+++ b/media/libstagefright/binding/include/mp4_demuxer/ByteReader.h
@@ -63,7 +63,7 @@ public:
   {
     auto ptr = Read(1);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to read data");
       return 0;
     }
     return *ptr;
@@ -75,7 +75,7 @@ public:
   {
     auto ptr = Read(2);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to read data");
       return 0;
     }
     return mozilla::BigEndian::readUint16(ptr);
@@ -85,7 +85,7 @@ public:
   {
     auto ptr = Read(2);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to read data");
       return 0;
     }
     return mozilla::LittleEndian::readInt16(ptr);
@@ -95,7 +95,7 @@ public:
   {
     auto ptr = Read(3);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to read data");
       return 0;
     }
     return ptr[0] << 16 | ptr[1] << 8 | ptr[2];
@@ -110,7 +110,7 @@ public:
   {
     auto ptr = Read(3);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to read data");
       return 0;
     }
     int32_t result = int32_t(ptr[2] << 16 | ptr[1] << 8 | ptr[0]);
@@ -126,7 +126,7 @@ public:
   {
     auto ptr = Read(4);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to read data");
       return 0;
     }
     return mozilla::BigEndian::readUint32(ptr);
@@ -136,7 +136,7 @@ public:
   {
     auto ptr = Read(4);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to read data");
       return 0;
     }
     return mozilla::BigEndian::readInt32(ptr);
@@ -146,7 +146,7 @@ public:
   {
     auto ptr = Read(8);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to read data");
       return 0;
     }
     return mozilla::BigEndian::readUint64(ptr);
@@ -156,7 +156,7 @@ public:
   {
     auto ptr = Read(8);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to read data");
       return 0;
     }
     return mozilla::BigEndian::readInt64(ptr);
@@ -192,7 +192,7 @@ public:
   {
     auto ptr = Peek(1);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to peek data");
       return 0;
     }
     return *ptr;
@@ -202,7 +202,7 @@ public:
   {
     auto ptr = Peek(2);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to peek data");
       return 0;
     }
     return mozilla::BigEndian::readUint16(ptr);
@@ -212,7 +212,7 @@ public:
   {
     auto ptr = Peek(3);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to peek data");
       return 0;
     }
     return ptr[0] << 16 | ptr[1] << 8 | ptr[2];
@@ -227,7 +227,7 @@ public:
   {
     auto ptr = Peek(4);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to peek data");
       return 0;
     }
     return mozilla::BigEndian::readUint32(ptr);
@@ -237,7 +237,7 @@ public:
   {
     auto ptr = Peek(4);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to peek data");
       return 0;
     }
     return mozilla::BigEndian::readInt32(ptr);
@@ -247,7 +247,7 @@ public:
   {
     auto ptr = Peek(8);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to peek data");
       return 0;
     }
     return mozilla::BigEndian::readUint64(ptr);
@@ -257,7 +257,7 @@ public:
   {
     auto ptr = Peek(8);
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Failed to peek data");
       return 0;
     }
     return mozilla::BigEndian::readInt64(ptr);
@@ -274,7 +274,7 @@ public:
   const uint8_t* Seek(size_t aOffset)
   {
     if (aOffset >= mLength) {
-      MOZ_ASSERT(false);
+      NS_WARNING("Seek failed");
       return nullptr;
     }
 
@@ -301,7 +301,7 @@ public:
   {
     auto ptr = Read(sizeof(T));
     if (!ptr) {
-      MOZ_ASSERT(false);
+      NS_WARNING("ReadType failed");
       return 0;
     }
     return *reinterpret_cast<const T*>(ptr);
@@ -312,6 +312,7 @@ public:
   {
     auto ptr = Read(aLength * sizeof(T));
     if (!ptr) {
+      NS_WARNING("ReadArray failed");
       return false;
     }
 
@@ -325,6 +326,7 @@ public:
   {
     auto ptr = Read(aLength * sizeof(T));
     if (!ptr) {
+      NS_WARNING("ReadArray failed");
       return false;
     }
 

--- a/media/libstagefright/moz.build
+++ b/media/libstagefright/moz.build
@@ -53,6 +53,7 @@ EXPORTS.mp4_demuxer += [
     'binding/include/mp4_demuxer/Atom.h',
     'binding/include/mp4_demuxer/AtomType.h',
     'binding/include/mp4_demuxer/BitReader.h',
+    'binding/include/mp4_demuxer/BufferReader.h',
     'binding/include/mp4_demuxer/BufferStream.h',
     'binding/include/mp4_demuxer/ByteReader.h',
     'binding/include/mp4_demuxer/ByteWriter.h',


### PR DESCRIPTION
This PR makes the following changes:

- If the SPS value of a stream is incorrect, throw a warning instead of a hard assert.
- Create a copy of ByteReader (named BufferReader) and add some error handling to it.
- Use BufferReader when parsing MP4 files (while ByteReader remains used by other formats).
- Rework the MoofParser to return an error when the underlying BufferReader also does (instead of getting stuck in a never ending loop).

From the user perspective there should be no visible changes in behavior. I've tested this (MP4, MSE+MP4, EME+MP4, and WebM/VP9 just in case) a bit on Linux (with more testing to happen today), but this needs verification that nothing broke on Windows and Mac.

Resolves #654.

