### PR TITLE
about:profiles - fix "Launch profile in new browser" (added "-no-remote" for Windows)

### DIFF
--- a/toolkit/components/startup/nsAppStartup.cpp
+++ b/toolkit/components/startup/nsAppStartup.cpp
@@ -1020,8 +1020,13 @@ nsAppStartup::CreateInstanceWithProfile(nsIToolkitProfile* aProfile)
     return rv;
   }
 
+#if defined(XP_WIN)
+  const char *args[] = { "-no-remote", "-P", profileName.get() };
+  rv = process->Run(false, args, 3);
+#else
   const char *args[] = { "-P", profileName.get() };
   rv = process->Run(false, args, 2);
+#endif
   if (NS_WARN_IF(NS_FAILED(rv))) {
     return rv;
   }


### PR DESCRIPTION
This resolves #673 

---

I've created the new build (x32, Windows) - `Pale Moon` - and tested,
