### PR TITLE
remove "learnMoreContainer" leftovers

### DIFF
--- a/application/basilisk/base/content/aboutNetError.xhtml
+++ b/application/basilisk/base/content/aboutNetError.xhtml
@@ -224,9 +224,6 @@
         }
 
         if (err == "sslv3Used") {
-          document.getElementById("learnMoreContainer").style.display = "block";
-          var learnMoreLink = document.getElementById("learnMoreLink");
-          learnMoreLink.href = "https://support.mozilla.org/kb/how-resolve-sslv3-error-messages-firefox";
           document.body.className = "certerror";
         }
 
@@ -270,17 +267,6 @@
         window.addEventListener("AboutNetErrorOptions", function(evt) {
         // Pinning errors are of type nssFailure2
           if (getErrorCode() == "nssFailure2" || getErrorCode() == "weakCryptoUsed") {
-            document.getElementById("learnMoreContainer").style.display = "block";
-            var learnMoreLink = document.getElementById("learnMoreLink");
-            // nssFailure2 also gets us other non-overrideable errors. Choose
-            // a "learn more" link based on description:
-            if (getDescription().includes("mozilla_pkix_error_key_pinning_failure")) {
-              learnMoreLink.href = "https://support.mozilla.org/kb/certificate-pinning-reports";
-            }
-            if (getErrorCode() == "weakCryptoUsed") {
-              learnMoreLink.href = "https://support.mozilla.org/kb/how-resolve-weak-crypto-error-messages-firefox";
-            }
-
             const hasPrefStyleError = [
               "interrupted", // This happens with subresources that are above the max tls
               "SSL_ERROR_PROTOCOL_VERSION_ALERT",
@@ -347,8 +333,6 @@
 
         addAutofocus("returnButton");
         setupAdvancedButton(true);
-
-        document.getElementById("learnMoreContainer").style.display = "block";
 
         let event = new CustomEvent("AboutNetErrorLoad", {bubbles:true});
         document.getElementById("advancedButton").dispatchEvent(event);

--- a/application/basilisk/base/content/content.js
+++ b/application/basilisk/base/content/content.js
@@ -298,12 +298,10 @@ var AboutNetAndCertErrorListener = {
   onCertErrorDetails(msg) {
     let div = content.document.getElementById("certificateErrorText");
     div.textContent = msg.data.info;
-    let learnMoreLink = content.document.getElementById("learnMoreLink");
     let baseURL = Services.urlFormatter.formatURLPref("app.support.baseURL");
 
     switch (msg.data.code) {
       case SEC_ERROR_UNKNOWN_ISSUER:
-        learnMoreLink.href = baseURL  + "security-error";
         break;
 
       // in case the certificate expired we make sure the system clock
@@ -336,7 +334,6 @@ var AboutNetAndCertErrorListener = {
           content.document.getElementById("wrongSystemTimePanel")
             .style.display = "block";
         }
-        learnMoreLink.href = baseURL  + "time-errors";
         break;
     }
   },

--- a/application/basilisk/themes/shared/aboutNetError.css
+++ b/application/basilisk/themes/shared/aboutNetError.css
@@ -39,10 +39,6 @@ button:disabled {
   display: none;
 }
 
-#learnMoreContainer {
-  display: none;
-}
-
 #certErrorAndCaptivePortalButtonContainer {
   display: none;
 }


### PR DESCRIPTION
This PR removes leftover code that once supported creation of "Learn More..." links on about:certerror page.
This resolves #667.