### PR TITLE
Remove dead Help Viewer skin mapping from Toolkit

### DIFF
--- a/toolkit/themes/shared/jar.inc.mn
+++ b/toolkit/themes/shared/jar.inc.mn
@@ -9,7 +9,6 @@
 
 toolkit.jar:
 % skin global classic/1.0 %skin/classic/global/
-% skin help classic/1.0 %skin/classic/help/
 % skin mozapps classic/1.0 %skin/classic/mozapps/
   skin/classic/global/about.css                            (../../shared/about.css)
   skin/classic/global/aboutCache.css                       (../../shared/aboutCache.css)


### PR DESCRIPTION
This removes dead skin mapping, left after [Help Viewer was removed from Toolkit](https://bugzilla.mozilla.org/show_bug.cgi?id=1290756).