### PR TITLE
Disable battery API by default

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -4718,7 +4718,8 @@ pref("dom.vibrator.max_vibrate_ms", 10000);
 pref("dom.vibrator.max_vibrate_list_len", 128);
 
 // Battery API
-pref("dom.battery.enabled", true);
+// Disabled by default to reduce private data exposure.
+pref("dom.battery.enabled", false);
 
 // Push
 


### PR DESCRIPTION
Found this while dodging dragons.

Re-land of [3c9c519](https://github.com/MoonchildProductions/Pale-Moon/commit/3c9c519d6a028967f41f2d811c39e550e1249578#diff-197990a2ed8de15d84d8f269dbd35c08) (see also [this thread](https://forum.palemoon.org/viewtopic.php?f=13&t=9375) and [this thread](https://forum.palemoon.org/viewtopic.php?f=56&t=12702)).