### PR TITLE
[PALEMOON] Fix "Always ask" for Plugins (in Preferences - Applications)

### DIFF
--- a/application/palemoon/components/preferences/applications.js
+++ b/application/palemoon/components/preferences/applications.js
@@ -288,6 +288,14 @@ HandlerInfoWrapper.prototype = {
   },
 
   set preferredAction(aNewValue) {
+    // If the action is to use the plugin,
+    // we must set the preferred action to "save to disk".
+    // But only if it's not currently the preferred action.
+    if ((aNewValue == kActionUsePlugin) &&
+        (this.preferredAction != Ci.nsIHandlerInfo.saveToDisk)) {
+      aNewValue = Ci.nsIHandlerInfo.saveToDisk;
+    }
+
     // We don't modify the preferred action if the new action is to use a plugin
     // because handler info objects don't understand our custom "use plugin"
     // value.  Also, leaving it untouched means that we can automatically revert
@@ -1616,33 +1624,31 @@ var gApplicationsPane = {
     var typeItem = this._list.selectedItem;
     var handlerInfo = this._handledTypes[typeItem.type];
 
-    if (aActionItem.hasAttribute("alwaysAsk")) {
+    let action = parseInt(aActionItem.getAttribute("action"));
+
+    // Set the plugin state if we're enabling or disabling a plugin.
+    if (action == kActionUsePlugin)
+      handlerInfo.enablePluginType();
+    else if (handlerInfo.pluginName && !handlerInfo.isDisabledPluginType)
+      handlerInfo.disablePluginType();
+
+    // Set the preferred application handler.
+    // We leave the existing preferred app in the list when we set
+    // the preferred action to something other than useHelperApp so that
+    // legacy datastores that don't have the preferred app in the list
+    // of possible apps still include the preferred app in the list of apps
+    // the user can choose to handle the type.
+    if (action == Ci.nsIHandlerInfo.useHelperApp)
+      handlerInfo.preferredApplicationHandler = aActionItem.handlerApp;
+
+    // Set the "always ask" flag.
+    if (action == Ci.nsIHandlerInfo.alwaysAsk)
       handlerInfo.alwaysAskBeforeHandling = true;
-    }
-    else if (aActionItem.hasAttribute("action")) {
-      let action = parseInt(aActionItem.getAttribute("action"));
-
-      // Set the plugin state if we're enabling or disabling a plugin.
-      if (action == kActionUsePlugin)
-        handlerInfo.enablePluginType();
-      else if (handlerInfo.pluginName && !handlerInfo.isDisabledPluginType)
-        handlerInfo.disablePluginType();
-
-      // Set the preferred application handler.
-      // We leave the existing preferred app in the list when we set
-      // the preferred action to something other than useHelperApp so that
-      // legacy datastores that don't have the preferred app in the list
-      // of possible apps still include the preferred app in the list of apps
-      // the user can choose to handle the type.
-      if (action == Ci.nsIHandlerInfo.useHelperApp)
-        handlerInfo.preferredApplicationHandler = aActionItem.handlerApp;
-
-      // Set the "always ask" flag.
+    else
       handlerInfo.alwaysAskBeforeHandling = false;
 
-      // Set the preferred action.
-      handlerInfo.preferredAction = action;
-    }
+    // Set the preferred action.
+    handlerInfo.preferredAction = action;
 
     handlerInfo.store();
 

--- a/application/palemoon/components/preferences/applications.js
+++ b/application/palemoon/components/preferences/applications.js
@@ -1069,29 +1069,20 @@ var gApplicationsPane = {
   _loadPluginHandlers: function() {
     "use strict";
 
-    let pluginHost = Cc["@mozilla.org/plugin/host;1"].getService(Ci.nsIPluginHost);
-    let pluginTags = pluginHost.getPluginTags();
+    let mimeTypes = navigator.mimeTypes;
 
-    for (let i = 0; i < pluginTags.length; ++i) {
-      let pluginTag = pluginTags[i];
-
-      let mimeTypes = pluginTag.getMimeTypes();
-      for (let j = 0; j < mimeTypes.length; ++j) {
-        let type = mimeTypes[j];
-
-        let handlerInfoWrapper;
-        if (type in this._handledTypes)
-          handlerInfoWrapper = this._handledTypes[type];
-        else {
-          let wrappedHandlerInfo =
-            this._mimeSvc.getFromTypeAndExtension(type, null);
-          handlerInfoWrapper = new HandlerInfoWrapper(type, wrappedHandlerInfo);
-          handlerInfoWrapper.handledOnlyByPlugin = true;
-          this._handledTypes[type] = handlerInfoWrapper;
-        }
-
-        handlerInfoWrapper.pluginName = pluginTag.name;
+    for (let mimeType of mimeTypes) {
+      let handlerInfoWrapper;
+      if (mimeType.type in this._handledTypes) {
+        handlerInfoWrapper = this._handledTypes[mimeType.type];
+      } else {
+        let wrappedHandlerInfo =
+              this._mimeSvc.getFromTypeAndExtension(mimeType.type, null);
+        handlerInfoWrapper = new HandlerInfoWrapper(mimeType.type, wrappedHandlerInfo);
+        handlerInfoWrapper.handledOnlyByPlugin = true;
+        this._handledTypes[mimeType.type] = handlerInfoWrapper;
       }
+      handlerInfoWrapper.pluginName = mimeType.enabledPlugin.name;
     }
   },
 

--- a/application/palemoon/components/preferences/applications.js
+++ b/application/palemoon/components/preferences/applications.js
@@ -8,15 +8,10 @@
 //****************************************************************************//
 // Constants & Enumeration Values
 
-/*
-#ifndef XP_MACOSX
-*/
 var Cc = Components.classes;
 var Ci = Components.interfaces;
 var Cr = Components.results;
-/*
-#endif
-*/
+
 Components.utils.import('resource://gre/modules/Services.jsm');
 
 const TYPE_MAYBE_FEED = "application/vnd.mozilla.maybe.feed";
@@ -158,7 +153,7 @@ function isFeedType(t) {
  * 
  * We create an instance of this wrapper for each entry we might display
  * in the prefpane, and we compose the instances from various sources,
- * including navigator.plugins and the handler service.
+ * including plugins and the handler service.
  *
  * We don't implement all the original nsIHandlerInfo functionality,
  * just the stuff that the prefpane needs.
@@ -272,7 +267,7 @@ HandlerInfoWrapper.prototype = {
   // What to do with content of this type.
   get preferredAction() {
     // If we have an enabled plugin, then the action is to use that plugin.
-    if (this.plugin && !this.isDisabledPluginType)
+    if (this.pluginName && !this.isDisabledPluginType)
       return kActionUsePlugin;
 
     // If the action is to use a helper app, but we don't have a preferred
@@ -308,7 +303,7 @@ HandlerInfoWrapper.prototype = {
     // of any user configuration, and the default in that case is to always ask,
     // even though we never ask for content handled by a plugin, so special case
     // plugin-handled types by returning false here.
-    if (this.plugin && this.handledOnlyByPlugin)
+    if (this.pluginName && this.handledOnlyByPlugin)
       return false;
 
     // If this is a protocol type and the preferred action is "save to disk",
@@ -1064,10 +1059,17 @@ var gApplicationsPane = {
    * check the pref ourselves to find out if it's enabled.
    */
   _loadPluginHandlers: function() {
-    for (let i = 0; i < navigator.plugins.length; ++i) {
-      let plugin = navigator.plugins[i];
-      for (let j = 0; j < plugin.length; ++j) {
-        let type = plugin[j].type;
+    "use strict";
+
+    let pluginHost = Cc["@mozilla.org/plugin/host;1"].getService(Ci.nsIPluginHost);
+    let pluginTags = pluginHost.getPluginTags();
+
+    for (let i = 0; i < pluginTags.length; ++i) {
+      let pluginTag = pluginTags[i];
+
+      let mimeTypes = pluginTag.getMimeTypes();
+      for (let j = 0; j < mimeTypes.length; ++j) {
+        let type = mimeTypes[j];
 
         let handlerInfoWrapper;
         if (type in this._handledTypes)
@@ -1080,7 +1082,7 @@ var gApplicationsPane = {
           this._handledTypes[type] = handlerInfoWrapper;
         }
 
-        handlerInfoWrapper.plugin = plugin;
+        handlerInfoWrapper.pluginName = pluginTag.name;
       }
     }
   },
@@ -1274,7 +1276,7 @@ var gApplicationsPane = {
 
       case kActionUsePlugin:
         return this._prefsBundle.getFormattedString("usePluginIn",
-                                                    [aHandlerInfo.plugin.name,
+                                                    [aHandlerInfo.pluginName,
                                                      this._brandShortName]);
     }
   },
@@ -1456,11 +1458,11 @@ var gApplicationsPane = {
     }
 
     // Create a menu item for the plugin.
-    if (handlerInfo.plugin) {
+    if (handlerInfo.pluginName) {
       var pluginMenuItem = document.createElement("menuitem");
       pluginMenuItem.setAttribute("action", kActionUsePlugin);
       let label = this._prefsBundle.getFormattedString("usePluginIn",
-                                                       [handlerInfo.plugin.name,
+                                                       [handlerInfo.pluginName,
                                                         this._brandShortName]);
       pluginMenuItem.setAttribute("label", label);
       pluginMenuItem.setAttribute("tooltiptext", label);
@@ -1623,7 +1625,7 @@ var gApplicationsPane = {
       // Set the plugin state if we're enabling or disabling a plugin.
       if (action == kActionUsePlugin)
         handlerInfo.enablePluginType();
-      else if (handlerInfo.plugin && !handlerInfo.isDisabledPluginType)
+      else if (handlerInfo.pluginName && !handlerInfo.isDisabledPluginType)
         handlerInfo.disablePluginType();
 
       // Set the preferred application handler.

--- a/application/palemoon/components/preferences/applications.js
+++ b/application/palemoon/components/preferences/applications.js
@@ -1378,7 +1378,7 @@ var gApplicationsPane = {
 
     {
       var askMenuItem = document.createElement("menuitem");
-      askMenuItem.setAttribute("alwaysAsk", "true");
+      askMenuItem.setAttribute("action", Ci.nsIHandlerInfo.alwaysAsk);
       let label;
       if (isFeedType(handlerInfo.type))
         label = this._prefsBundle.getFormattedString("previewInApp",


### PR DESCRIPTION
This resolves #675 

- Set the default value
- Use of the attribute `action` (only)
- Use `navigator.mimeTypes` instead of `navigator.plugins` (and types)

---

I've created the new build (x32, Windows) - `Pale Moon` - and tested.
