### PR TITLE
Shell quote environment variable values when dumping them in dump_env.py

### DIFF
--- a/python/mozbuild/mozbuild/action/dump_env.py
+++ b/python/mozbuild/mozbuild/action/dump_env.py
@@ -6,5 +6,11 @@
 # native paths printed on Windows so that these paths can be incorporated
 # into Python configure's environment.
 import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from shellutil import quote
+
 for key, value in os.environ.items():
-    print('%s=%s' % (key, value))
+    print('%s=%s' % (key, quote(value)))


### PR DESCRIPTION
The mozconfig output parsing code already (mostly) handles shell quoted strings, because that's what `set` outputs. By quoting environment variable values, we avoid a bunch of problems with "weird" values.

On some newer distros (Fedora 28 being the primary culprit here) all mach commands fail because the environment variables are incorrectly parsed. This patch changes how the build system takes values from the environment to feed build options to configure (there is no affect on the application being built).

Tested and verified that the build completes successfully on Fedora 28 without busting building on CentOS 7.