### PR TITLE
Fix/silence some warnings with GCC 8

### DIFF
--- a/build/moz.configure/warnings.configure
+++ b/build/moz.configure/warnings.configure
@@ -101,6 +101,9 @@ check_and_add_gcc_warning('-Wno-error=coverage-mismatch', when='MOZ_PGO')
 # false positives during PGO
 check_and_add_gcc_warning('-Wno-error=free-nonheap-object', when='MOZ_PGO')
 
+# Would be a pain to fix all occurrences, for very little gain
+check_and_add_gcc_warning('-Wno-error=multistatement-macros')
+
 # We use mix of both POSIX and Win32 printf format across the tree, so format
 # warnings are useless on mingw.
 check_and_add_gcc_warning('-Wno-format',

--- a/dom/bindings/BindingUtils.cpp
+++ b/dom/bindings/BindingUtils.cpp
@@ -119,7 +119,7 @@ ThrowInvalidThis(JSContext* aCx, const JS::CallArgs& aArgs,
                              MSG_METHOD_THIS_DOES_NOT_IMPLEMENT_INTERFACE;
   MOZ_RELEASE_ASSERT(GetErrorArgCount(errorNumber) <= 2);
   JS_ReportErrorNumberUC(aCx, GetErrorMessage, nullptr,
-                         static_cast<const unsigned>(errorNumber),
+                         static_cast<unsigned>(errorNumber),
                          funcNameStr.get(), ifaceName.get());
   return false;
 }
@@ -226,7 +226,7 @@ TErrorResult<CleanupPolicy>::SetPendingExceptionWithMessage(JSContext* aCx)
   args[argCount] = nullptr;
 
   JS_ReportErrorNumberUCArray(aCx, dom::GetErrorMessage, nullptr,
-                              static_cast<const unsigned>(message->mErrorNumber),
+                              static_cast<unsigned>(message->mErrorNumber),
                               argCount > 0 ? args : nullptr);
 
   ClearMessage();

--- a/dom/bindings/ErrorResult.h
+++ b/dom/bindings/ErrorResult.h
@@ -75,7 +75,7 @@ template<typename... Ts>
 inline bool
 ThrowErrorMessage(JSContext* aCx, const ErrNum aErrorNumber, Ts&&... aArgs)
 {
-  binding_detail::ThrowErrorMessage(aCx, static_cast<const unsigned>(aErrorNumber),
+  binding_detail::ThrowErrorMessage(aCx, static_cast<unsigned>(aErrorNumber),
                                     mozilla::Forward<Ts>(aArgs)...);
   return false;
 }

--- a/embedding/components/find/nsFind.cpp
+++ b/embedding/components/find/nsFind.cpp
@@ -33,7 +33,7 @@
 using namespace mozilla;
 
 // Yikes!  Casting a char to unichar can fill with ones!
-#define CHAR_TO_UNICHAR(c) ((char16_t)(const unsigned char)c)
+#define CHAR_TO_UNICHAR(c) ((char16_t)(unsigned char)c)
 
 static NS_DEFINE_CID(kCContentIteratorCID, NS_CONTENTITERATOR_CID);
 static NS_DEFINE_CID(kCPreContentIteratorCID, NS_PRECONTENTITERATOR_CID);

--- a/js/src/builtin/AtomicsObject.cpp
+++ b/js/src/builtin/AtomicsObject.cpp
@@ -789,7 +789,7 @@ js::atomics_wait(JSContext* cx, unsigned argc, Value* vp)
     // and it provides the necessary memory fence.
     AutoLockFutexAPI lock;
 
-    SharedMem<int32_t*>(addr) = view->viewDataShared().cast<int32_t*>() + offset;
+    SharedMem<int32_t*> addr = view->viewDataShared().cast<int32_t*>() + offset;
     if (jit::AtomicOperations::loadSafeWhenRacy(addr) != value) {
         r.setString(cx->names().futexNotEqual);
         return true;

--- a/mfbt/EnumSet.h
+++ b/mfbt/EnumSet.h
@@ -335,7 +335,7 @@ private:
   uint32_t mBitField;
 
 #ifdef DEBUG
-  uint64_t mVersion;
+  uint64_t mVersion = 0;
 #endif
 };
 

--- a/mfbt/tests/TestTypeTraits.cpp
+++ b/mfbt/tests/TestTypeTraits.cpp
@@ -70,8 +70,8 @@ static_assert(!IsPointer<IsPointerTest>::value,
               "IsPointerTest not a pointer");
 static_assert(IsPointer<IsPointerTest*>::value,
               "IsPointerTest* is a pointer");
-static_assert(!IsPointer<bool(IsPointerTest::*)>::value,
-              "bool(IsPointerTest::*) not a pointer");
+static_assert(!IsPointer<bool(IsPointerTest::*)()>::value,
+              "bool(IsPointerTest::*)() not a pointer");
 static_assert(!IsPointer<void(IsPointerTest::*)(void)>::value,
               "void(IsPointerTest::*)(void) not a pointer");
 

--- a/netwerk/cache/nsDiskCacheEntry.h
+++ b/netwerk/cache/nsDiskCacheEntry.h
@@ -32,7 +32,7 @@ struct nsDiskCacheEntry {
                                     mKeySize + mMetaDataSize;
                               }
 
-    char*           Key()     { return reinterpret_cast<char*const>(this) + 
+    char*           Key()     { return reinterpret_cast<char*>(this) +
                                     sizeof(nsDiskCacheEntry);
                               }
 

--- a/toolkit/components/downloads/ApplicationReputation.cpp
+++ b/toolkit/components/downloads/ApplicationReputation.cpp
@@ -1000,7 +1000,7 @@ PendingLookup::GetSpecHash(nsACString& aSpec, nsACString& hexEncodedHash)
   static const char* const hex = "0123456789ABCDEF";
   hexEncodedHash.SetCapacity(2 * binaryHash.Length());
   for (size_t i = 0; i < binaryHash.Length(); ++i) {
-    auto c = static_cast<const unsigned char>(binaryHash[i]);
+    auto c = static_cast<unsigned char>(binaryHash[i]);
     hexEncodedHash.Append(hex[(c >> 4) & 0x0F]);
     hexEncodedHash.Append(hex[c & 0x0F]);
   }

--- a/toolkit/components/url-classifier/Entries.h
+++ b/toolkit/components/url-classifier/Entries.h
@@ -100,7 +100,7 @@ struct SafebrowsingHash
 
     aStr.SetCapacity(2 * len);
     for (size_t i = 0; i < len; ++i) {
-      const char c = static_cast<const char>(buf[i]);
+      const char c = static_cast<char>(buf[i]);
       aStr.Append(lut[(c >> 4) & 0x0F]);
       aStr.Append(lut[c & 15]);
     }

--- a/xpcom/glue/nsTHashtable.h
+++ b/xpcom/glue/nsTHashtable.h
@@ -372,7 +372,7 @@ template<class EntryType>
 PLDHashNumber
 nsTHashtable<EntryType>::s_HashKey(const void* aKey)
 {
-  return EntryType::HashKey(static_cast<const KeyTypePointer>(aKey));
+  return EntryType::HashKey(static_cast<KeyTypePointer>(aKey));
 }
 
 template<class EntryType>
@@ -381,7 +381,7 @@ nsTHashtable<EntryType>::s_MatchEntry(const PLDHashEntryHdr* aEntry,
                                       const void* aKey)
 {
   return ((const EntryType*)aEntry)->KeyEquals(
-    static_cast<const KeyTypePointer>(aKey));
+    static_cast<KeyTypePointer>(aKey));
 }
 
 template<class EntryType>

--- a/xpcom/string/nsReadableUtilsImpl.h
+++ b/xpcom/string/nsReadableUtilsImpl.h
@@ -18,7 +18,7 @@ inline bool IsASCII(char16_t aChar) {
 inline const char16_t* aligned(const char16_t* aPtr, const uintptr_t aMask)
 {
   return reinterpret_cast<const char16_t*>(
-      reinterpret_cast<const uintptr_t>(aPtr) & ~aMask);
+      reinterpret_cast<uintptr_t>(aPtr) & ~aMask);
 }
 
 /**


### PR DESCRIPTION
This PR fixes and/or silences several compiler warnings output by GCC 8. With this patch set, about 35 compiler warnings are fixed or silenced when building Pale Moon.

In addition to testing GCC 8 I also built Basilisk using GCC 7 and Pale Moon using GCC 7 and 4.9. I saw no issues in either the build process or the resulting binary using any of these compiler versions.

Tag #705

