### PR TITLE
Simplify HeapSlot to make it trivially copyable

### DIFF
--- a/js/src/gc/Barrier.h
+++ b/js/src/gc/Barrier.h
@@ -667,27 +667,13 @@ class HeapSlot : public WriteBarrieredBase<Value>
         Element = 1
     };
 
-    explicit HeapSlot() = delete;
-
-    explicit HeapSlot(NativeObject* obj, Kind kind, uint32_t slot, const Value& v)
-      : WriteBarrieredBase<Value>(v)
-    {
-        post(obj, kind, slot, v);
-    }
-
-    explicit HeapSlot(NativeObject* obj, Kind kind, uint32_t slot, const HeapSlot& s)
-      : WriteBarrieredBase<Value>(s.value)
-    {
-        post(obj, kind, slot, s);
-    }
-
-    ~HeapSlot() {
-        pre();
-    }
-
     void init(NativeObject* owner, Kind kind, uint32_t slot, const Value& v) {
         value = v;
         post(owner, kind, slot, v);
+    }
+
+    void destroy() {
+        pre();
     }
 
 #ifdef DEBUG
@@ -701,11 +687,6 @@ class HeapSlot : public WriteBarrieredBase<Value>
         pre();
         value = v;
         post(owner, kind, slot, v);
-    }
-
-    /* For users who need to manually barrier the raw types. */
-    static void writeBarrierPost(NativeObject* owner, Kind kind, uint32_t slot, const Value& target) {
-        reinterpret_cast<HeapSlot*>(const_cast<Value*>(&target))->post(owner, kind, slot, target);
     }
 
   private:

--- a/js/src/vm/NativeObject.h
+++ b/js/src/vm/NativeObject.h
@@ -876,7 +876,7 @@ class NativeObject : public ShapedObject
         MOZ_ASSERT(end <= getDenseInitializedLength());
         MOZ_ASSERT(!denseElementsAreCopyOnWrite());
         for (size_t i = start; i < end; i++)
-            elements_[i].HeapSlot::~HeapSlot();
+            elements_[i].destroy();
     }
 
     /*
@@ -885,7 +885,7 @@ class NativeObject : public ShapedObject
      */
     void prepareSlotRangeForOverwrite(size_t start, size_t end) {
         for (size_t i = start; i < end; i++)
-            getSlotAddressUnchecked(i)->HeapSlot::~HeapSlot();
+            getSlotAddressUnchecked(i)->destroy();
     }
 
   public:
@@ -1130,8 +1130,7 @@ class NativeObject : public ShapedObject
                     dst->set(this, HeapSlot::Element, dst - elements_, *src);
             }
         } else {
-            memmove(reinterpret_cast<Value*>(elements_ + dstStart), elements_ + srcStart,
-                    count * sizeof(Value));
+            memmove(elements_ + dstStart, elements_ + srcStart, count * sizeof(HeapSlot));
             elementsRangeWriteBarrierPost(dstStart, count);
         }
     }
@@ -1144,8 +1143,7 @@ class NativeObject : public ShapedObject
         MOZ_ASSERT(!denseElementsAreCopyOnWrite());
         MOZ_ASSERT(!denseElementsAreFrozen());
 
-        memmove(reinterpret_cast<Value*>(elements_ + dstStart), elements_ + srcStart,
-                count * sizeof(Value));
+        memmove(elements_ + dstStart, elements_ + srcStart, count * sizeof(HeapSlot));
         elementsRangeWriteBarrierPost(dstStart, count);
     }
 

--- a/js/src/vm/NativeObject.h
+++ b/js/src/vm/NativeObject.h
@@ -1085,7 +1085,8 @@ class NativeObject : public ShapedObject
             for (uint32_t i = 0; i < count; ++i)
                 elements_[dstStart + i].set(this, HeapSlot::Element, dstStart + i, src[i]);
         } else {
-            memcpy(&elements_[dstStart], src, count * sizeof(HeapSlot));
+            memcpy(reinterpret_cast<Value*>(&elements_[dstStart]), src,
+                   count * sizeof(Value));
             elementsRangeWriteBarrierPost(dstStart, count);
         }
     }
@@ -1094,7 +1095,7 @@ class NativeObject : public ShapedObject
         MOZ_ASSERT(dstStart + count <= getDenseCapacity());
         MOZ_ASSERT(!denseElementsAreCopyOnWrite());
         MOZ_ASSERT(!denseElementsAreFrozen());
-        memcpy(&elements_[dstStart], src, count * sizeof(HeapSlot));
+        memcpy(reinterpret_cast<Value*>(&elements_[dstStart]), src, count * sizeof(Value));
         elementsRangeWriteBarrierPost(dstStart, count);
     }
 
@@ -1129,7 +1130,8 @@ class NativeObject : public ShapedObject
                     dst->set(this, HeapSlot::Element, dst - elements_, *src);
             }
         } else {
-            memmove(elements_ + dstStart, elements_ + srcStart, count * sizeof(HeapSlot));
+            memmove(reinterpret_cast<Value*>(elements_ + dstStart), elements_ + srcStart,
+                    count * sizeof(Value));
             elementsRangeWriteBarrierPost(dstStart, count);
         }
     }
@@ -1142,7 +1144,8 @@ class NativeObject : public ShapedObject
         MOZ_ASSERT(!denseElementsAreCopyOnWrite());
         MOZ_ASSERT(!denseElementsAreFrozen());
 
-        memmove(elements_ + dstStart, elements_ + srcStart, count * sizeof(Value));
+        memmove(reinterpret_cast<Value*>(elements_ + dstStart), elements_ + srcStart,
+                count * sizeof(Value));
         elementsRangeWriteBarrierPost(dstStart, count);
     }
 


### PR DESCRIPTION
This PR simplifies HeapSlot and makes it trivially copyable. This removes the constructors, which were never called since we allocate arrays of HeapSlot with pod_malloc. The destructor is only ever called explicitly since we free this memory with js_free so it has been renamed to destroy(). Also removed is an unused manual barrier.

This resolves half dozen or so compiler warnings with GCC 8 and eliminates a very large amount of build warning spam.

Tested using Pale Moon built with with GCC 7 and 8. No issues seen with either build after casually browsing for a while. Requesting additionall review as I'm not very familiar with the code in js.

Tag #705 