### PR TITLE
Basilisk: Remove TelemetryStopwatch

### DIFF
--- a/application/basilisk/base/content/browser-fullScreenAndPointerLock.js
+++ b/application/basilisk/base/content/browser-fullScreenAndPointerLock.js
@@ -379,12 +379,10 @@ var FullScreen = {
           let topWin = event.target.ownerGlobal.top;
           browser = gBrowser.getBrowserForContentWindow(topWin);
         }
-        TelemetryStopwatch.start("FULLSCREEN_CHANGE_MS");
         this.enterDomFullscreen(browser);
         break;
       }
       case "MozDOMFullscreen:Exited":
-        TelemetryStopwatch.start("FULLSCREEN_CHANGE_MS");
         this.cleanupDomFullscreen();
         break;
     }
@@ -410,7 +408,6 @@ var FullScreen = {
       }
       case "DOMFullscreen:Painted": {
         Services.obs.notifyObservers(window, "fullscreen-painted", "");
-        TelemetryStopwatch.finish("FULLSCREEN_CHANGE_MS");
         break;
       }
     }

--- a/application/basilisk/base/content/browser-gestureSupport.js
+++ b/application/basilisk/base/content/browser-gestureSupport.js
@@ -1001,13 +1001,10 @@ var gHistorySwipeAnimation = {
                    ctx.DRAWWINDOW_ASYNC_DECODE_IMAGES |
                    ctx.DRAWWINDOW_USE_WIDGET_LAYERS);
 
-    TelemetryStopwatch.start("FX_GESTURE_INSTALL_SNAPSHOT_OF_PAGE");
     try {
       this._installCurrentPageSnapshot(canvas);
       this._assignSnapshotToCurrentBrowser(canvas);
-    } finally {
-      TelemetryStopwatch.finish("FX_GESTURE_INSTALL_SNAPSHOT_OF_PAGE");
-    }
+    }  catch (e) {}
   },
 
   /**
@@ -1058,7 +1055,6 @@ var gHistorySwipeAnimation = {
       return;
     }
 
-    TelemetryStopwatch.start("FX_GESTURE_COMPRESS_SNAPSHOT_OF_PAGE");
     try {
       let browser = gBrowser.selectedBrowser;
       let snapshots = browser.snapshots;
@@ -1072,9 +1068,7 @@ var gHistorySwipeAnimation = {
           }
         }, "image/png"
       );
-    } finally {
-      TelemetryStopwatch.finish("FX_GESTURE_COMPRESS_SNAPSHOT_OF_PAGE");
-    }
+    }  catch (e) {}
   },
 
   /**

--- a/application/basilisk/base/content/browser.js
+++ b/application/basilisk/base/content/browser.js
@@ -45,7 +45,6 @@ Cu.import("resource://gre/modules/NotificationDB.jsm");
   ["SitePermissions", "resource:///modules/SitePermissions.jsm"],
   ["TabCrashHandler", "resource:///modules/ContentCrashHandlers.jsm"],
   ["Task", "resource://gre/modules/Task.jsm"],
-  ["TelemetryStopwatch", "resource://gre/modules/TelemetryStopwatch.jsm"],
   ["Translation", "resource:///modules/translation/Translation.jsm"],
   ["UpdateUtils", "resource://gre/modules/UpdateUtils.jsm"],
   ["Weave", "resource://services-sync/main.js"],
@@ -3818,8 +3817,6 @@ function toOpenWindowByType(inType, uri, features)
 
 function OpenBrowserWindow(options)
 {
-  var telemetryObj = {};
-  TelemetryStopwatch.start("FX_NEW_WINDOW_MS", telemetryObj);
 
   function newDocumentShown(doc, topic, data) {
     if (topic == "document-shown" &&
@@ -3827,7 +3824,6 @@ function OpenBrowserWindow(options)
         doc.defaultView == win) {
       Services.obs.removeObserver(newDocumentShown, "document-shown");
       Services.obs.removeObserver(windowClosed, "domwindowclosed");
-      TelemetryStopwatch.finish("FX_NEW_WINDOW_MS", telemetryObj);
     }
   }
 
@@ -4623,25 +4619,6 @@ var TabsProgressListener = {
   _startedLoadTimer: new WeakSet(),
 
   onStateChange: function (aBrowser, aWebProgress, aRequest, aStateFlags, aStatus) {
-    // Collect telemetry data about tab load times.
-    if (aWebProgress.isTopLevel && (!aRequest.originalURI || aRequest.originalURI.spec.scheme != "about")) {
-      if (aStateFlags & Ci.nsIWebProgressListener.STATE_IS_WINDOW) {
-        if (aStateFlags & Ci.nsIWebProgressListener.STATE_START) {
-          this._startedLoadTimer.add(aBrowser);
-          TelemetryStopwatch.start("FX_PAGE_LOAD_MS", aBrowser);
-          Services.telemetry.getHistogramById("FX_TOTAL_TOP_VISITS").add(true);
-        } else if (aStateFlags & Ci.nsIWebProgressListener.STATE_STOP &&
-                   this._startedLoadTimer.has(aBrowser)) {
-          this._startedLoadTimer.delete(aBrowser);
-          TelemetryStopwatch.finish("FX_PAGE_LOAD_MS", aBrowser);
-        }
-      } else if (aStateFlags & Ci.nsIWebProgressListener.STATE_STOP &&
-                 aStatus == Cr.NS_BINDING_ABORTED &&
-                 this._startedLoadTimer.has(aBrowser)) {
-        this._startedLoadTimer.delete(aBrowser);
-        TelemetryStopwatch.cancel("FX_PAGE_LOAD_MS", aBrowser);
-      }
-    }
 
     // We used to listen for clicks in the browser here, but when that
     // became unnecessary, removing the code below caused focus issues.

--- a/application/basilisk/base/content/browser.xul
+++ b/application/basilisk/base/content/browser.xul
@@ -521,8 +521,7 @@
             tabbrowser="content"
             flex="1"
             setfocus="false"
-            tooltip="tabbrowser-tab-tooltip"
-            stopwatchid="FX_TAB_CLICK_MS">
+            tooltip="tabbrowser-tab-tooltip">
         <tab class="tabbrowser-tab" selected="true" visuallyselected="true" fadein="true"/>
       </tabs>
 

--- a/application/basilisk/base/content/tabbrowser.xml
+++ b/application/basilisk/base/content/tabbrowser.xml
@@ -1042,11 +1042,6 @@
         </body>
       </method>
 
-      <!-- Holds a unique ID for the tab change that's currently being timed.
-           Used to make sure that multiple, rapid tab switches do not try to
-           create overlapping timers. -->
-      <field name="_tabSwitchID">null</field>
-
       <method name="updateCurrentBrowser">
         <parameter name="aForceUpdate"/>
         <body>
@@ -1054,33 +1049,6 @@
             var newBrowser = this.getBrowserAtIndex(this.tabContainer.selectedIndex);
             if (this.mCurrentBrowser == newBrowser && !aForceUpdate)
               return;
-
-            if (!aForceUpdate) {
-              TelemetryStopwatch.start("FX_TAB_SWITCH_UPDATE_MS");
-              if (!gMultiProcessBrowser) {
-                // old way of measuring tab paint which is not valid with e10s.
-                // Waiting until the next MozAfterPaint ensures that we capture
-                // the time it takes to paint, upload the textures to the compositor,
-                // and then composite.
-                if (this._tabSwitchID) {
-                  TelemetryStopwatch.cancel("FX_TAB_SWITCH_TOTAL_MS");
-                }
-
-                let tabSwitchID = Symbol();
-
-                TelemetryStopwatch.start("FX_TAB_SWITCH_TOTAL_MS");
-                this._tabSwitchID = tabSwitchID;
-
-                let onMozAfterPaint = () => {
-                  if (this._tabSwitchID === tabSwitchID) {
-                    TelemetryStopwatch.finish("FX_TAB_SWITCH_TOTAL_MS");
-                    this._tabSwitchID = null;
-                  }
-                  window.removeEventListener("MozAfterPaint", onMozAfterPaint);
-                }
-                window.addEventListener("MozAfterPaint", onMozAfterPaint);
-              }
-            }
 
             var oldTab = this.mCurrentTab;
 
@@ -1274,9 +1242,6 @@
               });
               this.dispatchEvent(event);
             }
-
-            if (!aForceUpdate)
-              TelemetryStopwatch.finish("FX_TAB_SWITCH_UPDATE_MS");
           ]]>
         </body>
       </method>
@@ -4145,8 +4110,6 @@
              */
 
             startTabSwitch: function () {
-              TelemetryStopwatch.cancel("FX_TAB_SWITCH_TOTAL_E10S_MS", window);
-              TelemetryStopwatch.start("FX_TAB_SWITCH_TOTAL_E10S_MS", window);
               this.addMarker("AsyncTabSwitch:Start");
               this.switchInProgress = true;
             },
@@ -4162,31 +4125,18 @@
                   this.getTabState(this.requestedTab) == this.STATE_LOADED) {
                 // After this point the tab has switched from the content thread's point of view.
                 // The changes will be visible after the next refresh driver tick + composite.
-                let time = TelemetryStopwatch.timeElapsed("FX_TAB_SWITCH_TOTAL_E10S_MS", window);
-                if (time != -1) {
-                  TelemetryStopwatch.finish("FX_TAB_SWITCH_TOTAL_E10S_MS", window);
-                  this.log("DEBUG: tab switch time = " + time);
                   this.addMarker("AsyncTabSwitch:Finish");
-                }
                 this.switchInProgress = false;
               }
             },
 
             spinnerDisplayed: function () {
               this.assert(!this.spinnerTab);
-              TelemetryStopwatch.start("FX_TAB_SWITCH_SPINNER_VISIBLE_MS", window);
-              // We have a second, similar probe for capturing recordings of
-              // when the spinner is displayed for very long periods.
-              TelemetryStopwatch.start("FX_TAB_SWITCH_SPINNER_VISIBLE_LONG_MS", window);
               this.addMarker("AsyncTabSwitch:SpinnerShown");
             },
 
             spinnerHidden: function () {
               this.assert(this.spinnerTab);
-              this.log("DEBUG: spinner time = " +
-                       TelemetryStopwatch.timeElapsed("FX_TAB_SWITCH_SPINNER_VISIBLE_MS", window));
-              TelemetryStopwatch.finish("FX_TAB_SWITCH_SPINNER_VISIBLE_MS", window);
-              TelemetryStopwatch.finish("FX_TAB_SWITCH_SPINNER_VISIBLE_LONG_MS", window);
               this.addMarker("AsyncTabSwitch:SpinnerHidden");
               // we do not get a onPaint after displaying the spinner
               this.maybeFinishTabSwitch();

--- a/application/basilisk/components/migration/AutoMigrate.jsm
+++ b/application/basilisk/components/migration/AutoMigrate.jsm
@@ -37,8 +37,6 @@ XPCOMUtils.defineLazyModuleGetter(this, "OS",
                                   "resource://gre/modules/osfile.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "PlacesUtils",
                                   "resource://gre/modules/PlacesUtils.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "TelemetryStopwatch",
-                                  "resource://gre/modules/TelemetryStopwatch.jsm");
 
 XPCOMUtils.defineLazyGetter(this, "gBrandBundle", function() {
   const kBrandBundle = "chrome://branding/locale/brand.properties";
@@ -211,7 +209,6 @@ const AutoMigrate = {
 
   undo: Task.async(function* () {
     let browserId = Preferences.get(kAutoMigrateBrowserPref, "unknown");
-    TelemetryStopwatch.startKeyed("FX_STARTUP_MIGRATION_UNDO_TOTAL_MS", browserId);
     let histogram = Services.telemetry.getHistogramById("FX_STARTUP_MIGRATION_AUTOMATED_IMPORT_UNDO");
     histogram.add(0);
     if (!(yield this.canUndo())) {
@@ -236,38 +233,24 @@ const AutoMigrate = {
       Services.telemetry.getKeyedHistogramById(histogramId).add(browserId, this._errorMap[type]);
     };
 
-    let startTelemetryStopwatch = resourceType => {
-      let histogramId = `FX_STARTUP_MIGRATION_UNDO_${resourceType.toUpperCase()}_MS`;
-      TelemetryStopwatch.startKeyed(histogramId, browserId);
-    };
-    let stopTelemetryStopwatch = resourceType => {
-      let histogramId = `FX_STARTUP_MIGRATION_UNDO_${resourceType.toUpperCase()}_MS`;
-      TelemetryStopwatch.finishKeyed(histogramId, browserId);
-    };
-    startTelemetryStopwatch("bookmarks");
     yield this._removeUnchangedBookmarks(stateData.get("bookmarks")).catch(ex => {
       Cu.reportError("Uncaught exception when removing unchanged bookmarks!");
       Cu.reportError(ex);
     });
-    stopTelemetryStopwatch("bookmarks");
     reportErrorTelemetry("bookmarks");
     histogram.add(15);
 
-    startTelemetryStopwatch("visits");
     yield this._removeSomeVisits(stateData.get("visits")).catch(ex => {
       Cu.reportError("Uncaught exception when removing history visits!");
       Cu.reportError(ex);
     });
-    stopTelemetryStopwatch("visits");
     reportErrorTelemetry("visits");
     histogram.add(20);
 
-    startTelemetryStopwatch("logins");
     yield this._removeUnchangedLogins(stateData.get("logins")).catch(ex => {
       Cu.reportError("Uncaught exception when removing unchanged logins!");
       Cu.reportError(ex);
     });
-    stopTelemetryStopwatch("logins");
     reportErrorTelemetry("logins");
     histogram.add(25);
 
@@ -278,7 +261,6 @@ const AutoMigrate = {
 
     this._purgeUndoState(this.UNDO_REMOVED_REASON_UNDO_USED);
     histogram.add(30);
-    TelemetryStopwatch.finishKeyed("FX_STARTUP_MIGRATION_UNDO_TOTAL_MS", browserId);
   }),
 
   _removeNotificationBars() {

--- a/application/basilisk/components/migration/MigrationUtils.jsm
+++ b/application/basilisk/components/migration/MigrationUtils.jsm
@@ -32,8 +32,6 @@ XPCOMUtils.defineLazyModuleGetter(this, "ResponsivenessMonitor",
                                   "resource://gre/modules/ResponsivenessMonitor.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Sqlite",
                                   "resource://gre/modules/Sqlite.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "TelemetryStopwatch",
-                                  "resource://gre/modules/TelemetryStopwatch.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "WindowsRegistry",
                                   "resource://gre/modules/WindowsRegistry.jsm");
 
@@ -254,14 +252,6 @@ this.MigratorPrototype = {
 
     let browserKey = this.getBrowserKey();
 
-    let maybeStartTelemetryStopwatch = resourceType => {
-      let histogramId = getHistogramIdForResourceType(resourceType, "FX_MIGRATION_*_IMPORT_MS");
-      if (histogramId) {
-        TelemetryStopwatch.startKeyed(histogramId, browserKey);
-      }
-      return histogramId;
-    };
-
     let maybeStartResponsivenessMonitor = resourceType => {
       let responsivenessMonitor;
       let responsivenessHistogramId =
@@ -323,8 +313,6 @@ this.MigratorPrototype = {
       for (let [migrationType, itemResources] of resourcesGroupedByItems) {
         notify("Migration:ItemBeforeMigrate", migrationType);
 
-        let stopwatchHistogramId = maybeStartTelemetryStopwatch(migrationType);
-
         let {responsivenessMonitor, responsivenessHistogramId} =
           maybeStartResponsivenessMonitor(migrationType);
 
@@ -339,10 +327,6 @@ this.MigratorPrototype = {
                      "Migration:ItemAfterMigrate" : "Migration:ItemError",
                      migrationType);
               resourcesGroupedByItems.delete(migrationType);
-
-              if (stopwatchHistogramId) {
-                TelemetryStopwatch.finishKeyed(stopwatchHistogramId, browserKey);
-              }
 
               maybeFinishResponsivenessMonitor(responsivenessMonitor, responsivenessHistogramId);
 

--- a/application/basilisk/components/places/content/history-panel.js
+++ b/application/basilisk/components/places/content/history-panel.js
@@ -3,8 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-Components.utils.import("resource://gre/modules/TelemetryStopwatch.jsm");
-
 var gHistoryTree;
 var gSearchBox;
 var gHistoryGrouping = "";
@@ -81,16 +79,11 @@ function searchHistory(aInput)
   options.resultType = resultType;
   options.includeHidden = !!aInput;
 
-  if (gHistoryGrouping == "lastvisited")
-    this.TelemetryStopwatch.start("HISTORY_LASTVISITED_TREE_QUERY_TIME_MS");
-
   // call load() on the tree manually
   // instead of setting the place attribute in history-panel.xul
   // otherwise, we will end up calling load() twice
   gHistoryTree.load([query], options);
 
-  if (gHistoryGrouping == "lastvisited")
-    this.TelemetryStopwatch.finish("HISTORY_LASTVISITED_TREE_QUERY_TIME_MS");
 }
 
 window.addEventListener("SidebarFocused",

--- a/application/basilisk/components/places/content/places.js
+++ b/application/basilisk/components/places/content/places.js
@@ -5,7 +5,6 @@
 
 Components.utils.import("resource://gre/modules/AppConstants.jsm");
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
-Components.utils.import("resource://gre/modules/TelemetryStopwatch.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "MigrationUtils",
                                   "resource:///modules/MigrationUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Task",
@@ -810,9 +809,7 @@ var PlacesSearchBox = {
           currentView.load([query], options);
         }
         else {
-          TelemetryStopwatch.start(HISTORY_LIBRARY_SEARCH_TELEMETRY);
           currentView.applyFilter(filterString, null, true);
-          TelemetryStopwatch.finish(HISTORY_LIBRARY_SEARCH_TELEMETRY);
         }
         break;
       case "downloads":

--- a/application/basilisk/components/sessionstore/SessionFile.jsm
+++ b/application/basilisk/components/sessionstore/SessionFile.jsm
@@ -43,8 +43,6 @@ XPCOMUtils.defineLazyModuleGetter(this, "PromiseUtils",
   "resource://gre/modules/PromiseUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "RunState",
   "resource:///modules/sessionstore/RunState.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "TelemetryStopwatch",
-  "resource://gre/modules/TelemetryStopwatch.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Task",
   "resource://gre/modules/Task.jsm");
 XPCOMUtils.defineLazyServiceGetter(this, "Telemetry",

--- a/application/basilisk/components/sessionstore/SessionSaver.jsm
+++ b/application/basilisk/components/sessionstore/SessionSaver.jsm
@@ -13,7 +13,6 @@ const Ci = Components.interfaces;
 Cu.import("resource://gre/modules/Timer.jsm", this);
 Cu.import("resource://gre/modules/Services.jsm", this);
 Cu.import("resource://gre/modules/XPCOMUtils.jsm", this);
-Cu.import("resource://gre/modules/TelemetryStopwatch.jsm", this);
 
 XPCOMUtils.defineLazyModuleGetter(this, "AppConstants",
   "resource://gre/modules/AppConstants.jsm");
@@ -51,19 +50,6 @@ XPCOMUtils.defineLazyGetter(this, "gInterval", function () {
 function notify(subject, topic) {
   Services.obs.notifyObservers(subject, topic, "");
 }
-
-// TelemetryStopwatch helper functions.
-function stopWatch(method) {
-  return function (...histograms) {
-    for (let hist of histograms) {
-      TelemetryStopwatch[method]("FX_SESSION_RESTORE_" + hist);
-    }
-  };
-}
-
-var stopWatchStart = stopWatch("start");
-var stopWatchCancel = stopWatch("cancel");
-var stopWatchFinish = stopWatch("finish");
 
 /**
  * The external API implemented by the SessionSaver module.
@@ -182,7 +168,6 @@ var SessionSaverInternal = {
       return Promise.resolve();
     }
 
-    stopWatchStart("COLLECT_DATA_MS", "COLLECT_DATA_LONGEST_OP_MS");
     let state = SessionStore.getCurrentState(forceUpdateAllWindows);
     PrivacyFilter.filterPrivateWindowsAndTabs(state);
 
@@ -226,7 +211,6 @@ var SessionSaverInternal = {
       }
     }
 
-    stopWatchFinish("COLLECT_DATA_MS", "COLLECT_DATA_LONGEST_OP_MS");
     return this._writeState(state);
   },
 

--- a/application/basilisk/components/sessionstore/SessionStore.jsm
+++ b/application/basilisk/components/sessionstore/SessionStore.jsm
@@ -135,7 +135,6 @@ Cu.import("resource://gre/modules/PrivateBrowsingUtils.jsm", this);
 Cu.import("resource://gre/modules/Promise.jsm", this);
 Cu.import("resource://gre/modules/Services.jsm", this);
 Cu.import("resource://gre/modules/Task.jsm", this);
-Cu.import("resource://gre/modules/TelemetryStopwatch.jsm", this);
 Cu.import("resource://gre/modules/TelemetryTimestamps.jsm", this);
 Cu.import("resource://gre/modules/Timer.jsm", this);
 Cu.import("resource://gre/modules/XPCOMUtils.jsm", this);
@@ -564,7 +563,6 @@ var SessionStoreInternal = {
    * Initialize the session using the state provided by SessionStartup
    */
   initSession: function () {
-    TelemetryStopwatch.start("FX_SESSION_RESTORE_STARTUP_INIT_SESSION_MS");
     let state;
     let ss = gSessionStartup;
 
@@ -640,7 +638,6 @@ var SessionStoreInternal = {
         this._prefBranch.getBoolPref("sessionstore.resume_session_once"))
       this._prefBranch.setBoolPref("sessionstore.resume_session_once", false);
 
-    TelemetryStopwatch.finish("FX_SESSION_RESTORE_STARTUP_INIT_SESSION_MS");
     return state;
   },
 
@@ -1247,9 +1244,7 @@ var SessionStoreInternal = {
         if (initialState) {
           Services.obs.notifyObservers(null, NOTIFY_RESTORING_ON_STARTUP, "");
         }
-        TelemetryStopwatch.start("FX_SESSION_RESTORE_STARTUP_ONLOAD_INITIAL_WINDOW_MS");
         this.initializeWindow(aWindow, initialState);
-        TelemetryStopwatch.finish("FX_SESSION_RESTORE_STARTUP_ONLOAD_INITIAL_WINDOW_MS");
 
         // Let everyone know we're done.
         this._deferredInitialized.resolve();
@@ -2857,7 +2852,6 @@ var SessionStoreInternal = {
 
     var activeWindow = this._getMostRecentBrowserWindow();
 
-    TelemetryStopwatch.start("FX_SESSION_RESTORE_COLLECT_ALL_WINDOWS_DATA_MS");
     if (RunState.isRunning) {
       // update the data for all windows with activities since the last save operation
       this._forEachBrowserWindow(function(aWindow) {
@@ -2872,7 +2866,6 @@ var SessionStoreInternal = {
       });
       DirtyWindows.clear();
     }
-    TelemetryStopwatch.finish("FX_SESSION_RESTORE_COLLECT_ALL_WINDOWS_DATA_MS");
 
     // An array that at the end will hold all current window data.
     var total = [];
@@ -2892,9 +2885,7 @@ var SessionStoreInternal = {
         nonPopupCount++;
     }
 
-    TelemetryStopwatch.start("FX_SESSION_RESTORE_COLLECT_COOKIES_MS");
     SessionCookies.update(total);
-    TelemetryStopwatch.finish("FX_SESSION_RESTORE_COLLECT_COOKIES_MS");
 
     // collect the data for all windows yet to be restored
     for (ix in this._statesToRestore) {
@@ -3062,8 +3053,6 @@ var SessionStoreInternal = {
     // initialize window if necessary
     if (aWindow && (!aWindow.__SSi || !this._windows[aWindow.__SSi]))
       this.onLoad(aWindow);
-
-    TelemetryStopwatch.start("FX_SESSION_RESTORE_RESTORE_WINDOW_MS");
 
     // We're not returning from this before we end up calling restoreTabs
     // for this window, so make sure we send the SSWindowStateBusy event.
@@ -3234,8 +3223,6 @@ var SessionStoreInternal = {
 
     // set smoothScroll back to the original value
     tabstrip.smoothScroll = smoothScroll;
-
-    TelemetryStopwatch.finish("FX_SESSION_RESTORE_RESTORE_WINDOW_MS");
 
     this._setWindowStateReady(aWindow);
 

--- a/application/basilisk/components/sessionstore/nsSessionStartup.js
+++ b/application/basilisk/components/sessionstore/nsSessionStartup.js
@@ -37,7 +37,6 @@ const Cr = Components.results;
 const Cu = Components.utils;
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://gre/modules/TelemetryStopwatch.jsm");
 Cu.import("resource://gre/modules/PrivateBrowsingUtils.jsm");
 Cu.import("resource://gre/modules/Promise.jsm");
 


### PR DESCRIPTION
This takes another small chunk of telemetry out of the browser application. Ran this for a few days without any side affects or bugs noticed. Reference bug #21 