### PR TITLE
Remove unused variable

### DIFF
--- a/gfx/gl/GLContextProviderGLX.cpp
+++ b/gfx/gl/GLContextProviderGLX.cpp
@@ -80,7 +80,6 @@ GLXLibrary::EnsureInitialized()
 
     if (!mOGLLibrary) {
         const char* libGLfilename = nullptr;
-        bool forceFeatureReport = false;
 
         // see e.g. bug 608526: it is intrinsically interesting to know whether we have dynamically linked to libGL.so.1
         // because at least the NVIDIA implementation requires an executable stack, which causes mprotect calls,


### PR DESCRIPTION
Just what it says in the tin. Followup to commit fc001cc.

Fixes a compiler warning with all supported versions of GCC.