### PR TITLE
Update ShouldAddToSessionHistory() rules for "about:newtab" and "about:logopage"

### DIFF
--- a/docshell/base/nsDocShell.cpp
+++ b/docshell/base/nsDocShell.cpp
@@ -12281,11 +12281,9 @@ nsDocShell::ShouldAddToSessionHistory(nsIURI* aURI)
       return false;
     }
 
-    if (buf.EqualsLiteral("blank") || buf.EqualsLiteral("logopage")
-#ifndef MC_PALEMOON
-        || buf.EqualsLiteral("newtab")
-#endif
-       ) {
+    if (buf.EqualsLiteral("blank") || buf.EqualsLiteral("logopage") ||
+        buf.EqualsLiteral("newtab") &&
+        !Preferences::GetBool("browser.newtabpage.add_to_session_history", false)) {
       return false;
     }
   }

--- a/docshell/base/nsDocShell.cpp
+++ b/docshell/base/nsDocShell.cpp
@@ -12282,8 +12282,8 @@ nsDocShell::ShouldAddToSessionHistory(nsIURI* aURI)
     }
 
     if (buf.EqualsLiteral("blank") || buf.EqualsLiteral("logopage") ||
-        buf.EqualsLiteral("newtab") &&
-        !Preferences::GetBool("browser.newtabpage.add_to_session_history", false)) {
+        (buf.EqualsLiteral("newtab") &&
+         !Preferences::GetBool("browser.newtabpage.add_to_session_history", false))) {
       return false;
     }
   }

--- a/docshell/base/nsDocShell.cpp
+++ b/docshell/base/nsDocShell.cpp
@@ -12281,7 +12281,11 @@ nsDocShell::ShouldAddToSessionHistory(nsIURI* aURI)
       return false;
     }
 
-    if (buf.EqualsLiteral("blank") || buf.EqualsLiteral("newtab")) {
+    if (buf.EqualsLiteral("blank") || buf.EqualsLiteral("logopage")
+#ifndef MC_PALEMOON
+        || buf.EqualsLiteral("newtab")
+#endif
+       ) {
       return false;
     }
   }

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -247,6 +247,10 @@ pref("dom.compartment_per_addon", true);
 // of content viewers to cache based on the amount of available memory.
 pref("browser.sessionhistory.max_total_viewers", -1);
 
+// Whether to store 'about:newtab' in the session history, disabled by default.
+// See https://github.com/MoonchildProductions/UXP/issues/719
+pref("browser.newtabpage.add_to_session_history", false);
+
 pref("ui.use_native_colors", true);
 pref("ui.click_hold_context_menus", false);
 // Duration of timeout of incremental search in menus (ms).  0 means infinite.


### PR DESCRIPTION
This excludes the `about:logopage` from the session history and allows the `about:newtab` to be stored based on `browser.newtabpage.add_to_session_history`.

This resolves #719.