### PR TITLE
Change mozilla.pdf to UXP.pdf

### DIFF
--- a/widget/gtk/nsDeviceContextSpecG.cpp
+++ b/widget/gtk/nsDeviceContextSpecG.cpp
@@ -415,9 +415,9 @@ NS_IMETHODIMP nsPrinterEnumeratorGTK::InitPrintSettingsFromPrinter(const char16_
     path = PR_GetEnv("HOME");
   
   if (path)
-    filename = nsPrintfCString("%s/mozilla.pdf", path);
+    filename = nsPrintfCString("%s/UXP.pdf", path);
   else
-    filename.AssignLiteral("mozilla.pdf");
+    filename.AssignLiteral("UXP.pdf");
 
   DO_PR_DEBUG_LOG(("Setting default filename to '%s'\n", filename.get()));
   aPrintSettings->SetToFileName(NS_ConvertUTF8toUTF16(filename).get());


### PR DESCRIPTION
Regression of Tycho behaviour:
https://github.com/MoonchildProductions/Pale-Moon/commits/6c1009bbf22aff8a003d296de1781126eb6906a7/widget/gtk/nsDeviceContextSpecG.cpp

Print to pdf or ps uses default file name of mozilla.p*
UXP.p* works in both Pale Moon and Basilisk, and is shorter, reducing binary and codebase size, improving performance as well as aesthetics.