### PR TITLE
Don't build ffvpx on 32-bit platforms (except Windows)

### DIFF
--- a/old-configure.in
+++ b/old-configure.in
@@ -3542,11 +3542,15 @@ dnl = FFmpeg's ffvpx configuration
 dnl ========================================================
 
 MOZ_FFVPX=
-case "$CPU_ARCH" in
-  x86)
+
+dnl Build ffvpx on 32-bit Windows and all supported 64-bit platforms.
+dnl 32-bit *nix has performance issues due to not supporting assembly decoder.
+
+case "$OS_ARCH:$CPU_ARCH" in
+  WINNT:x86)
       MOZ_FFVPX=1
   ;;
-  x86_64)
+  *:x86_64)
       MOZ_FFVPX=1
   ;;
 esac


### PR DESCRIPTION
Our in-tree FFmpeg doesn't support optimized assembly code very well on 32-bit *nix systems, which causes performance issues during video playback.

Essentially, this commit restores the behavior from Pale Moon 27 on 32-bit Linux builds (for video playback rely on the system-installed FFmpeg packages or libvpx if FFmpeg packages can't be found).

Tested and works as intended (also provides a modest performance improvement when watching YouTube on my 32-bit system).

The alternative to this would be to enable the optimized assembly code for 32-bit ffvpx, but this could cause issues with some of our 3rd party builds (Debian/Ubuntu by default uses the -fPIC compiler flag which would cause 32-bit build bustage due to FFmpeg not supporting -fPIC on 32-bit). After research and discussion with stevepusser, I feel this is the simplest solution.
