### PR TITLE
Remove all C++ Telemetry Accumulation calls.

### DIFF
--- a/accessible/base/Statistics.h
+++ b/accessible/base/Statistics.h
@@ -14,22 +14,22 @@ namespace a11y {
 namespace statistics {
 
   inline void A11yInitialized()
-    { Telemetry::Accumulate(Telemetry::A11Y_INSTANTIATED_FLAG, true); }
+    { /* STUB */ }
 
   inline void A11yConsumers(uint32_t aConsumer)
-    { Telemetry::Accumulate(Telemetry::A11Y_CONSUMERS, aConsumer); }
+    { /* STUB */ }
 
   /**
    * Report that ISimpleDOM* has been used.
    */
   inline void ISimpleDOMUsed()
-    { Telemetry::Accumulate(Telemetry::A11Y_ISIMPLEDOM_USAGE_FLAG, true); }
+    { /* STUB */ }
 
   /**
    * Report that IAccessibleTable has been used.
    */
   inline void IAccessibleTableUsed()
-    { Telemetry::Accumulate(Telemetry::A11Y_IATABLE_USAGE_FLAG, true); }
+    { /* STUB */ }
 
 } // namespace statistics
 } // namespace a11y

--- a/devtools/shared/heapsnapshot/HeapSnapshot.cpp
+++ b/devtools/shared/heapsnapshot/HeapSnapshot.cpp
@@ -28,7 +28,6 @@
 #include "mozilla/dom/ContentChild.h"
 #include "mozilla/dom/HeapSnapshotBinding.h"
 #include "mozilla/RangedPtr.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/Unused.h"
 
 #include "jsapi.h"
@@ -1610,13 +1609,6 @@ ThreadSafeChromeUtils::SaveHeapSnapshot(GlobalObject& global,
       return;
     }
   }
-
-  Telemetry::AccumulateTimeDelta(Telemetry::DEVTOOLS_SAVE_HEAP_SNAPSHOT_MS,
-                                 start);
-  Telemetry::Accumulate(Telemetry::DEVTOOLS_HEAP_SNAPSHOT_NODE_COUNT,
-                        nodeCount);
-  Telemetry::Accumulate(Telemetry::DEVTOOLS_HEAP_SNAPSHOT_EDGE_COUNT,
-                        edgeCount);
 }
 
 /* static */ already_AddRefed<HeapSnapshot>
@@ -1640,10 +1632,6 @@ ThreadSafeChromeUtils::ReadHeapSnapshot(GlobalObject& global,
   RefPtr<HeapSnapshot> snapshot = HeapSnapshot::Create(
       global.Context(), global, reinterpret_cast<const uint8_t*>(mm.address()),
       mm.size(), rv);
-
-  if (!rv.Failed())
-    Telemetry::AccumulateTimeDelta(Telemetry::DEVTOOLS_READ_HEAP_SNAPSHOT_MS,
-                                   start);
 
   return snapshot.forget();
 }

--- a/docshell/base/nsDocShell.cpp
+++ b/docshell/base/nsDocShell.cpp
@@ -1972,71 +1972,7 @@ nsDocShell::GetCharset(nsACString& aCharset)
 NS_IMETHODIMP
 nsDocShell::GatherCharsetMenuTelemetry()
 {
-  nsCOMPtr<nsIContentViewer> viewer;
-  GetContentViewer(getter_AddRefs(viewer));
-  if (!viewer) {
-    return NS_OK;
-  }
-
-  nsIDocument* doc = viewer->GetDocument();
-  if (!doc || doc->WillIgnoreCharsetOverride()) {
-    return NS_OK;
-  }
-
-  Telemetry::Accumulate(Telemetry::CHARSET_OVERRIDE_USED, true);
-
-  bool isFileURL = false;
-  nsIURI* url = doc->GetOriginalURI();
-  if (url) {
-    url->SchemeIs("file", &isFileURL);
-  }
-
-  int32_t charsetSource = doc->GetDocumentCharacterSetSource();
-  switch (charsetSource) {
-    case kCharsetFromTopLevelDomain:
-      // Unlabeled doc on a domain that we map to a fallback encoding
-      Telemetry::Accumulate(Telemetry::CHARSET_OVERRIDE_SITUATION, 7);
-      break;
-    case kCharsetFromFallback:
-    case kCharsetFromDocTypeDefault:
-    case kCharsetFromCache:
-    case kCharsetFromParentFrame:
-    case kCharsetFromHintPrevDoc:
-      // Changing charset on an unlabeled doc.
-      if (isFileURL) {
-        Telemetry::Accumulate(Telemetry::CHARSET_OVERRIDE_SITUATION, 0);
-      } else {
-        Telemetry::Accumulate(Telemetry::CHARSET_OVERRIDE_SITUATION, 1);
-      }
-      break;
-    case kCharsetFromAutoDetection:
-      // Changing charset on unlabeled doc where chardet fired
-      if (isFileURL) {
-        Telemetry::Accumulate(Telemetry::CHARSET_OVERRIDE_SITUATION, 2);
-      } else {
-        Telemetry::Accumulate(Telemetry::CHARSET_OVERRIDE_SITUATION, 3);
-      }
-      break;
-    case kCharsetFromMetaPrescan:
-    case kCharsetFromMetaTag:
-    case kCharsetFromChannel:
-      // Changing charset on a doc that had a charset label.
-      Telemetry::Accumulate(Telemetry::CHARSET_OVERRIDE_SITUATION, 4);
-      break;
-    case kCharsetFromParentForced:
-    case kCharsetFromUserForced:
-      // Changing charset on a document that already had an override.
-      Telemetry::Accumulate(Telemetry::CHARSET_OVERRIDE_SITUATION, 5);
-      break;
-    case kCharsetFromIrreversibleAutoDetection:
-    case kCharsetFromOtherComponent:
-    case kCharsetFromByteOrderMark:
-    case kCharsetUninitialized:
-    default:
-      // Bug. This isn't supposed to happen.
-      Telemetry::Accumulate(Telemetry::CHARSET_OVERRIDE_SITUATION, 6);
-      break;
-  }
+  /* STUB */
   return NS_OK;
 }
 
@@ -5062,10 +4998,6 @@ nsDocShell::DisplayLoadError(nsresult aError, nsIURI* aURI,
           errorPage.Assign(alternateErrorPage);
         }
 
-        if (!IsFrame() && errorPage.EqualsIgnoreCase("certerror")) {
-          Telemetry::Accumulate(mozilla::Telemetry::SECURITY_UI, bucketId);
-        }
-
       } else {
         error.AssignLiteral("nssFailure2");
       }
@@ -5103,10 +5035,6 @@ nsDocShell::DisplayLoadError(nsresult aError, nsIURI* aURI,
       error.AssignLiteral("unwantedBlocked");
       bucketId = IsFrame() ? nsISecurityUITelemetry::WARNING_UNWANTED_PAGE_FRAME
                            : nsISecurityUITelemetry::WARNING_UNWANTED_PAGE_TOP;
-    }
-
-    if (sendTelemetry && errorPage.EqualsIgnoreCase("blocked")) {
-      Telemetry::Accumulate(Telemetry::SECURITY_UI, bucketId);
     }
 
     cssClass.AssignLiteral("blacklist");
@@ -7622,8 +7550,6 @@ nsDocShell::EndPageLoad(nsIWebProgress* aProgress,
     TimeStamp channelCreationTime;
     rv = timingChannel->GetChannelCreation(&channelCreationTime);
     if (NS_SUCCEEDED(rv) && !channelCreationTime.IsNull()) {
-      Telemetry::AccumulateTimeDelta(Telemetry::TOTAL_CONTENT_PAGE_LOAD_TIME,
-                                     channelCreationTime);
       nsCOMPtr<nsPILoadGroupInternal> internalLoadGroup =
         do_QueryInterface(mLoadGroup);
       if (internalLoadGroup) {

--- a/dom/base/nsDOMClassInfo.cpp
+++ b/dom/base/nsDOMClassInfo.cpp
@@ -49,7 +49,6 @@
 #include "nsContentUtils.h"
 #include "nsIDOMGlobalPropertyInitializer.h"
 #include "mozilla/Attributes.h"
-#include "mozilla/Telemetry.h"
 
 // Window scriptable helper includes
 #include "nsScriptNameSpaceManager.h"
@@ -1903,9 +1902,6 @@ LookupComponentsShim(JSContext *cx, JS::Handle<JSObject*> global,
                      nsPIDOMWindowInner *win,
                      JS::MutableHandle<JS::PropertyDescriptor> desc)
 {
-  // Keep track of how often this happens.
-  Telemetry::Accumulate(Telemetry::COMPONENTS_SHIM_ACCESSED_BY_CONTENT, true);
-
   // Warn once.
   nsCOMPtr<nsIDocument> doc = win->GetExtantDoc();
   if (doc) {

--- a/dom/base/nsDOMNavigationTiming.cpp
+++ b/dom/base/nsDOMNavigationTiming.cpp
@@ -15,7 +15,6 @@
 #include "nsPrintfCString.h"
 #include "mozilla/dom/PerformanceNavigation.h"
 #include "mozilla/TimeStamp.h"
-#include "mozilla/Telemetry.h"
 
 using namespace mozilla;
 
@@ -202,12 +201,6 @@ nsDOMNavigationTiming::NotifyNonBlankPaintForRootContentDocument()
                            int(elapsed.ToMilliseconds()), spec.get(),
                            mDocShellHasBeenActiveSinceNavigationStart ? "foreground tab" : "this tab was inactive some of the time between navigation start and first non-blank paint");
     PROFILER_MARKER(marker.get());
-  }
-
-  if (mDocShellHasBeenActiveSinceNavigationStart) {
-    Telemetry::AccumulateTimeDelta(Telemetry::TIME_TO_NON_BLANK_PAINT_MS,
-                                   mNavigationStart,
-                                   mNonBlankPaint);
   }
 }
 

--- a/dom/base/nsDocument.cpp
+++ b/dom/base/nsDocument.cpp
@@ -25,7 +25,6 @@
 #include "plstr.h"
 #include "mozilla/Sprintf.h"
 
-#include "mozilla/Telemetry.h"
 #include "nsIInterfaceRequestor.h"
 #include "nsIInterfaceRequestorUtils.h"
 #include "nsILoadContext.h"
@@ -12370,101 +12369,7 @@ MightBeAboutOrChromeScheme(nsIURI* aURI)
 void
 nsDocument::ReportUseCounters()
 {
-  static const bool sDebugUseCounters = false;
-  if (mReportedUseCounters) {
-    return;
-  }
-
-  mReportedUseCounters = true;
-
-  if (Telemetry::HistogramUseCounterCount > 0 &&
-      (IsContentDocument() || IsResourceDoc())) {
-    nsCOMPtr<nsIURI> uri;
-    NodePrincipal()->GetURI(getter_AddRefs(uri));
-    if (!uri || MightBeAboutOrChromeScheme(uri)) {
-      return;
-    }
-
-    if (sDebugUseCounters) {
-      nsCString spec = uri->GetSpecOrDefault();
-
-      // URIs can be rather long for data documents, so truncate them to
-      // some reasonable length.
-      spec.Truncate(std::min(128U, spec.Length()));
-      printf("-- Use counters for %s --\n", spec.get());
-    }
-
-    // We keep separate counts for individual documents and top-level
-    // pages to more accurately track how many web pages might break if
-    // certain features were removed.  Consider the case of a single
-    // HTML document with several SVG images and/or iframes with
-    // sub-documents of their own.  If we maintained a single set of use
-    // counters and all the sub-documents use a particular feature, then
-    // telemetry would indicate that we would be breaking N documents if
-    // that feature were removed.  Whereas with a document/top-level
-    // page split, we can see that N documents would be affected, but
-    // only a single web page would be affected.
-
-    // The difference between the values of these two histograms and the
-    // related use counters below tell us how many pages did *not* use
-    // the feature in question.  For instance, if we see that a given
-    // session has destroyed 30 content documents, but a particular use
-    // counter shows only a count of 5, we can infer that the use
-    // counter was *not* used in 25 of those 30 documents.
-    //
-    // We do things this way, rather than accumulating a boolean flag
-    // for each use counter, to avoid sending histograms for features
-    // that don't get widely used.  Doing things in this fashion means
-    // smaller telemetry payloads and faster processing on the server
-    // side.
-    Telemetry::Accumulate(Telemetry::CONTENT_DOCUMENTS_DESTROYED, 1);
-    if (IsTopLevelContentDocument()) {
-      Telemetry::Accumulate(Telemetry::TOP_LEVEL_CONTENT_DOCUMENTS_DESTROYED, 1);
-    }
-
-    for (int32_t c = 0;
-         c < eUseCounter_Count; ++c) {
-      UseCounter uc = static_cast<UseCounter>(c);
-
-      Telemetry::ID id =
-        static_cast<Telemetry::ID>(Telemetry::HistogramFirstUseCounter + uc * 2);
-      bool value = GetUseCounter(uc);
-
-      if (value) {
-        if (sDebugUseCounters) {
-          const char* name = Telemetry::GetHistogramName(id);
-          if (name) {
-            printf("  %s", name);
-          } else {
-            printf("  #%d", id);
-          }
-          printf(": %d\n", value);
-        }
-
-        Telemetry::Accumulate(id, 1);
-      }
-
-      if (IsTopLevelContentDocument()) {
-        id = static_cast<Telemetry::ID>(Telemetry::HistogramFirstUseCounter +
-                                        uc * 2 + 1);
-        value = GetUseCounter(uc) || GetChildDocumentUseCounter(uc);
-
-        if (value) {
-          if (sDebugUseCounters) {
-            const char* name = Telemetry::GetHistogramName(id);
-            if (name) {
-              printf("  %s", name);
-            } else {
-              printf("  #%d", id);
-            }
-            printf(": %d\n", value);
-          }
-
-          Telemetry::Accumulate(id, 1);
-        }
-      }
-    }
-  }
+/* STUB */
 }
 
 void

--- a/dom/base/nsFrameMessageManager.cpp
+++ b/dom/base/nsFrameMessageManager.cpp
@@ -32,7 +32,6 @@
 #include "mozilla/CycleCollectedJSContext.h"
 #include "mozilla/IntentionalCrash.h"
 #include "mozilla/Preferences.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/dom/File.h"
 #include "mozilla/dom/MessagePort.h"
 #include "mozilla/dom/nsIContentParent.h"
@@ -716,9 +715,6 @@ AllowMessage(size_t aDataLength, const nsAString& aMessageName)
   NS_ConvertUTF16toUTF8 messageName(aMessageName);
   messageName.StripChars("0123456789");
 
-  Telemetry::Accumulate(Telemetry::MESSAGE_MANAGER_MESSAGE_SIZE2, messageName,
-                        aDataLength);
-
   // A message includes more than structured clone data, so subtract
   // 20KB to make it more likely that a message within this bound won't
   // result in an overly large IPC message.
@@ -726,9 +722,6 @@ AllowMessage(size_t aDataLength, const nsAString& aMessageName)
   if (aDataLength < kMaxMessageSize) {
     return true;
   }
-
-  Telemetry::Accumulate(Telemetry::REJECTED_MESSAGE_MANAGER_MESSAGE,
-                        messageName);
 
   return false;
 }
@@ -2248,7 +2241,6 @@ nsSameProcessAsyncMessageBase::Init(const nsAString& aMessage,
                                     nsIPrincipal* aPrincipal)
 {
   if (!mData.Copy(aData)) {
-    Telemetry::Accumulate(Telemetry::IPC_SAME_PROCESS_MESSAGE_COPY_OOM_KB, aData.DataLength());
     return NS_ERROR_OUT_OF_MEMORY;
   }
 

--- a/dom/base/nsJSEnvironment.cpp
+++ b/dom/base/nsJSEnvironment.cpp
@@ -70,7 +70,6 @@
 #include "prthread.h"
 
 #include "mozilla/Preferences.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/dom/BindingUtils.h"
 #include "mozilla/Attributes.h"
 #include "mozilla/dom/asmjscache/AsmJSCache.h"
@@ -1477,21 +1476,7 @@ nsJSContext::EndCycleCollectionCallback(CycleCollectorResults &aResults)
            NS_GC_DELAY - std::min(ccNowDuration, kMaxICCDuration));
   }
 
-  // Log information about the CC via telemetry, JSON and the console.
-  Telemetry::Accumulate(Telemetry::CYCLE_COLLECTOR_FINISH_IGC, gCCStats.mAnyLockedOut);
-  Telemetry::Accumulate(Telemetry::CYCLE_COLLECTOR_SYNC_SKIPPABLE, gCCStats.mRanSyncForgetSkippable);
-  Telemetry::Accumulate(Telemetry::CYCLE_COLLECTOR_FULL, ccNowDuration);
-  Telemetry::Accumulate(Telemetry::CYCLE_COLLECTOR_MAX_PAUSE, gCCStats.mMaxSliceTime);
-
-  if (!sLastCCEndTime.IsNull()) {
-    // TimeBetween returns milliseconds, but we want to report seconds.
-    uint32_t timeBetween = TimeBetween(sLastCCEndTime, gCCStats.mBeginTime) / 1000;
-    Telemetry::Accumulate(Telemetry::CYCLE_COLLECTOR_TIME_BETWEEN, timeBetween);
-  }
   sLastCCEndTime = endCCTimeStamp;
-
-  Telemetry::Accumulate(Telemetry::FORGET_SKIPPABLE_MAX,
-                        sMaxForgetSkippableTime / PR_USEC_PER_MSEC);
 
   PRTime delta = GetCollectionTimeDelta();
 

--- a/dom/base/nsNodeInfoManager.cpp
+++ b/dom/base/nsNodeInfoManager.cpp
@@ -392,9 +392,6 @@ nsNodeInfoManager::SetDocumentPrincipal(nsIPrincipal *aPrincipal)
   NS_ASSERTION(aPrincipal, "Must have principal by this point!");
   MOZ_DIAGNOSTIC_ASSERT(!nsContentUtils::IsExpandedPrincipal(aPrincipal),
                         "Documents shouldn't have an expanded principal");
-  if (nsContentUtils::IsExpandedPrincipal(aPrincipal)) {
-    Telemetry::Accumulate(Telemetry::DOCUMENT_WITH_EXPANDED_PRINCIPAL, 1);
-  }
 
   mPrincipal = aPrincipal;
 }

--- a/dom/base/nsObjectLoadingContent.cpp
+++ b/dom/base/nsObjectLoadingContent.cpp
@@ -85,7 +85,6 @@
 #include "mozilla/AsyncEventDispatcher.h"
 #include "mozilla/EventDispatcher.h"
 #include "mozilla/EventStates.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/dom/HTMLObjectElementBinding.h"
 #include "mozilla/dom/HTMLSharedObjectElement.h"
 #include "nsChannelClassifier.h"
@@ -1149,7 +1148,6 @@ nsObjectLoadingContent::OnStartRequest(nsIRequest *aRequest,
         NS_LITERAL_STRING(" since it was found on an internal Firefox blocklist.");
       console->LogStringMessage(message.get());
     }
-    Telemetry::Accumulate(Telemetry::PLUGIN_BLOCKED_FOR_STABILITY, 1);
     mContentBlockingEnabled = true;
     return NS_ERROR_FAILURE;
   } else if (status == NS_ERROR_TRACKING_URI) {
@@ -1565,7 +1563,6 @@ nsObjectLoadingContent::MaybeRewriteYoutubeEmbed(nsIURI* aURI, nsIURI* aBaseURI,
   }
 
   if (uri.Find("enablejsapi=1", true, 0, -1) != kNotFound) {
-    Telemetry::Accumulate(Telemetry::YOUTUBE_NONREWRITABLE_EMBED_SEEN, 1);
     return;
   }
 
@@ -1584,10 +1581,6 @@ nsObjectLoadingContent::MaybeRewriteYoutubeEmbed(nsIURI* aURI, nsIURI* aBaseURI,
       replaceQuery = true;
     }
   }
-
-  // If we've made it this far, we've got a rewritable embed. Log it in
-  // telemetry.
-  Telemetry::Accumulate(Telemetry::YOUTUBE_REWRITABLE_EMBED_SEEN, 1);
 
   // If we're pref'd off, return after telemetry has been logged.
   if (!Preferences::GetBool(kPrefYoutubeRewrite)) {
@@ -3800,8 +3793,6 @@ nsObjectLoadingContent::LegacyCall(JSContext* aCx,
     aRv.Throw(NS_ERROR_FAILURE);
     return;
   }
-
-  Telemetry::Accumulate(Telemetry::PLUGIN_CALLED_DIRECTLY, true);
 }
 
 void

--- a/dom/canvas/CanvasRenderingContextHelper.cpp
+++ b/dom/canvas/CanvasRenderingContextHelper.cpp
@@ -7,7 +7,6 @@
 #include "ImageBitmapRenderingContext.h"
 #include "ImageEncoder.h"
 #include "mozilla/dom/CanvasRenderingContext2D.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/UniquePtr.h"
 #include "nsContentUtils.h"
 #include "nsDOMJSUtils.h"
@@ -138,13 +137,10 @@ CanvasRenderingContextHelper::CreateContextHelper(CanvasContextType aContextType
     break;
 
   case CanvasContextType::Canvas2D:
-    Telemetry::Accumulate(Telemetry::CANVAS_2D_USED, 1);
     ret = new CanvasRenderingContext2D(aCompositorBackend);
     break;
 
   case CanvasContextType::WebGL1:
-    Telemetry::Accumulate(Telemetry::CANVAS_WEBGL_USED, 1);
-
     ret = WebGL1Context::Create();
     if (!ret)
       return nullptr;
@@ -152,8 +148,6 @@ CanvasRenderingContextHelper::CreateContextHelper(CanvasContextType aContextType
     break;
 
   case CanvasContextType::WebGL2:
-    Telemetry::Accumulate(Telemetry::CANVAS_WEBGL_USED, 1);
-
     ret = WebGL2Context::Create();
     if (!ret)
       return nullptr;
@@ -205,16 +199,8 @@ CanvasRenderingContextHelper::GetContext(JSContext* aCx,
       // See bug 645792 and bug 1215072.
       // We want to throw only if dictionary initialization fails,
       // so only in case aRv has been set to some error value.
-      if (contextType == CanvasContextType::WebGL1)
-        Telemetry::Accumulate(Telemetry::CANVAS_WEBGL_SUCCESS, 0);
-      else if (contextType == CanvasContextType::WebGL2)
-        Telemetry::Accumulate(Telemetry::CANVAS_WEBGL2_SUCCESS, 0);
       return nullptr;
     }
-    if (contextType == CanvasContextType::WebGL1)
-      Telemetry::Accumulate(Telemetry::CANVAS_WEBGL_SUCCESS, 1);
-    else if (contextType == CanvasContextType::WebGL2)
-      Telemetry::Accumulate(Telemetry::CANVAS_WEBGL2_SUCCESS, 1);
   } else {
     // We already have a context of some type.
     if (contextType != mCurrentContextType)

--- a/dom/canvas/WebGL1Context.cpp
+++ b/dom/canvas/WebGL1Context.cpp
@@ -6,7 +6,6 @@
 #include "WebGL1Context.h"
 
 #include "mozilla/dom/WebGLRenderingContextBinding.h"
-#include "mozilla/Telemetry.h"
 #include "WebGLFormats.h"
 
 namespace mozilla {
@@ -43,8 +42,6 @@ WebGL1Context::WrapObject(JSContext* cx, JS::Handle<JSObject*> givenProto)
 nsresult
 NS_NewCanvasRenderingContextWebGL(nsIDOMWebGLRenderingContext** out_result)
 {
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::CANVAS_WEBGL_USED, 1);
-
     nsIDOMWebGLRenderingContext* ctx = mozilla::WebGL1Context::Create();
 
     NS_ADDREF(*out_result = ctx);

--- a/dom/canvas/WebGLContext.cpp
+++ b/dom/canvas/WebGLContext.cpp
@@ -825,10 +825,6 @@ NS_IMETHODIMP
 WebGLContext::SetDimensions(int32_t signedWidth, int32_t signedHeight)
 {
     if (signedWidth < 0 || signedHeight < 0) {
-        if (!gl) {
-            Telemetry::Accumulate(Telemetry::CANVAS_WEBGL_FAILURE_ID,
-                                  NS_LITERAL_CSTRING("FEATURE_FAILURE_WEBGL_SIZE"));
-        }
         GenerateWarning("Canvas size is too large (seems like a negative value wrapped)");
         return NS_ERROR_OUT_OF_MEMORY;
     }
@@ -884,12 +880,6 @@ WebGLContext::SetDimensions(int32_t signedWidth, int32_t signedHeight)
         return NS_OK;
     }
 
-    nsCString failureId = NS_LITERAL_CSTRING("FEATURE_FAILURE_WEBGL_UNKOWN");
-    auto autoTelemetry = mozilla::MakeScopeExit([&] {
-        Telemetry::Accumulate(Telemetry::CANVAS_WEBGL_FAILURE_ID,
-                              failureId);
-    });
-
     // End of early return cases.
     // At this point we know that we're not just resizing an existing context,
     // we are initializing a new context.
@@ -911,7 +901,6 @@ WebGLContext::SetDimensions(int32_t signedWidth, int32_t signedHeight)
     // resource handles created from older context generations.
     if (!(mGeneration + 1).isValid()) {
         // exit without changing the value of mGeneration
-        failureId = NS_LITERAL_CSTRING("FEATURE_FAILURE_WEBGL_TOO_MANY");
         const nsLiteralCString text("Too many WebGL contexts created this run.");
         ThrowEvent_WebGLContextCreationError(text);
         return NS_ERROR_FAILURE;
@@ -928,11 +917,6 @@ WebGLContext::SetDimensions(int32_t signedWidth, int32_t signedHeight)
     disabled |= gfxPlatform::InSafeMode();
 
     if (disabled) {
-        if (gfxPlatform::InSafeMode()) {
-            failureId = NS_LITERAL_CSTRING("FEATURE_FAILURE_WEBGL_SAFEMODE");
-        } else {
-            failureId = NS_LITERAL_CSTRING("FEATURE_FAILURE_WEBGL_DISABLED");
-        }
         const nsLiteralCString text("WebGL is currently disabled.");
         ThrowEvent_WebGLContextCreationError(text);
         return NS_ERROR_FAILURE;
@@ -945,7 +929,6 @@ WebGLContext::SetDimensions(int32_t signedWidth, int32_t signedHeight)
     if (mOptions.failIfMajorPerformanceCaveat) {
         nsCOMPtr<nsIGfxInfo> gfxInfo = services::GetGfxInfo();
         if (!HasAcceleratedLayers(gfxInfo)) {
-            failureId = NS_LITERAL_CSTRING("FEATURE_FAILURE_WEBGL_PERF_CAVEAT");
             const nsLiteralCString text("failIfMajorPerformanceCaveat: Compositor is not"
                                         " hardware-accelerated.");
             ThrowEvent_WebGLContextCreationError(text);
@@ -961,12 +944,9 @@ WebGLContext::SetDimensions(int32_t signedWidth, int32_t signedHeight)
     if (!CreateAndInitGL(forceEnabled, &failReasons)) {
         nsCString text("WebGL creation failed: ");
         for (const auto& cur : failReasons) {
-            Telemetry::Accumulate(Telemetry::CANVAS_WEBGL_FAILURE_ID, cur.key);
-
             text.AppendASCII("\n* ");
             text.Append(cur.info);
         }
-        failureId = NS_LITERAL_CSTRING("FEATURE_FAILURE_REASON");
         ThrowEvent_WebGLContextCreationError(text);
         return NS_ERROR_FAILURE;
     }
@@ -978,7 +958,6 @@ WebGLContext::SetDimensions(int32_t signedWidth, int32_t signedHeight)
             DestroyResourcesAndContext();
             MOZ_ASSERT(!gl);
 
-            failureId = NS_LITERAL_CSTRING("FEATURE_FAILURE_WEBGL_PERF_WARP");
             const nsLiteralCString text("failIfMajorPerformanceCaveat: Driver is not"
                                         " hardware-accelerated.");
             ThrowEvent_WebGLContextCreationError(text);
@@ -992,7 +971,6 @@ WebGLContext::SetDimensions(int32_t signedWidth, int32_t signedHeight)
             DestroyResourcesAndContext();
             MOZ_ASSERT(!gl);
 
-            failureId = NS_LITERAL_CSTRING("FEATURE_FAILURE_WEBGL_DXGL_INTEROP2");
             const nsLiteralCString text("Caveat: WGL without DXGLInterop2.");
             ThrowEvent_WebGLContextCreationError(text);
             return NS_ERROR_FAILURE;
@@ -1001,7 +979,6 @@ WebGLContext::SetDimensions(int32_t signedWidth, int32_t signedHeight)
     }
 
     if (!ResizeBackbuffer(width, height)) {
-        failureId = NS_LITERAL_CSTRING("FEATURE_FAILURE_WEBGL_BACKBUFFER");
         const nsLiteralCString text("Initializing WebGL backbuffer failed.");
         ThrowEvent_WebGLContextCreationError(text);
         return NS_ERROR_FAILURE;
@@ -1085,7 +1062,6 @@ WebGLContext::SetDimensions(int32_t signedWidth, int32_t signedHeight)
 
     //////
 
-    failureId = NS_LITERAL_CSTRING("SUCCESS");
     return NS_OK;
 }
 

--- a/dom/events/EventDispatcher.cpp
+++ b/dom/events/EventDispatcher.cpp
@@ -858,63 +858,46 @@ EventDispatcher::CreateEvent(EventTarget* aOwner,
 
   // And if we didn't get an event, check the type argument.
 
-#define LOG_EVENT_CREATION(name) mozilla::Telemetry::Accumulate( \
-    mozilla::Telemetry::CREATE_EVENT_##name, true);
-
   if (aEventType.LowerCaseEqualsLiteral("mouseevent")) {
-    LOG_EVENT_CREATION(MOUSEEVENT);
     return NS_NewDOMMouseEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("mouseevents")) {
-    LOG_EVENT_CREATION(MOUSEEVENTS);
     return NS_NewDOMMouseEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("popupevents")) {
-    LOG_EVENT_CREATION(POPUPEVENTS);
     return NS_NewDOMMouseEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("mousescrollevents")) {
-    LOG_EVENT_CREATION(MOUSESCROLLEVENTS);
     return NS_NewDOMMouseScrollEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("dragevent")) {
-    LOG_EVENT_CREATION(DRAGEVENT);
     return NS_NewDOMDragEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("dragevents")) {
-    LOG_EVENT_CREATION(DRAGEVENTS);
     return NS_NewDOMDragEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("keyboardevent")) {
-    LOG_EVENT_CREATION(KEYBOARDEVENT);
     return NS_NewDOMKeyboardEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("keyevents")) {
-    LOG_EVENT_CREATION(KEYEVENTS);
     return NS_NewDOMKeyboardEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("compositionevent")) {
-    LOG_EVENT_CREATION(COMPOSITIONEVENT);
     return NS_NewDOMCompositionEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("textevent")) {
-    LOG_EVENT_CREATION(TEXTEVENT);
     return NS_NewDOMCompositionEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("textevents")) {
-    LOG_EVENT_CREATION(TEXTEVENTS);
     return NS_NewDOMCompositionEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("mutationevent")) {
-    LOG_EVENT_CREATION(MUTATIONEVENT);
     return NS_NewDOMMutationEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("mutationevents")) {
-    LOG_EVENT_CREATION(MUTATIONEVENTS);
     return NS_NewDOMMutationEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("deviceorientationevent")) {
-    LOG_EVENT_CREATION(DEVICEORIENTATIONEVENT);
     DeviceOrientationEventInit init;
     RefPtr<Event> event =
       DeviceOrientationEvent::Constructor(aOwner, EmptyString(), init);
@@ -922,97 +905,74 @@ EventDispatcher::CreateEvent(EventTarget* aOwner,
     return event.forget();
   }
   if (aEventType.LowerCaseEqualsLiteral("devicemotionevent")) {
-    LOG_EVENT_CREATION(DEVICEMOTIONEVENT);
     return NS_NewDOMDeviceMotionEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("uievent")) {
-    LOG_EVENT_CREATION(UIEVENT);
     return NS_NewDOMUIEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("uievents")) {
-    LOG_EVENT_CREATION(UIEVENTS);
     return NS_NewDOMUIEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("event")) {
-    LOG_EVENT_CREATION(EVENT);
     return NS_NewDOMEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("events")) {
-    LOG_EVENT_CREATION(EVENTS);
     return NS_NewDOMEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("htmlevents")) {
-    LOG_EVENT_CREATION(HTMLEVENTS);
     return NS_NewDOMEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("svgevent")) {
-    LOG_EVENT_CREATION(SVGEVENT);
     return NS_NewDOMEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("svgevents")) {
-    LOG_EVENT_CREATION(SVGEVENTS);
     return NS_NewDOMEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("svgzoomevent")) {
-    LOG_EVENT_CREATION(SVGZOOMEVENT);
     return NS_NewDOMSVGZoomEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("svgzoomevents")) {
-    LOG_EVENT_CREATION(SVGZOOMEVENTS);
     return NS_NewDOMSVGZoomEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("timeevent")) {
-    LOG_EVENT_CREATION(TIMEEVENT);
     return NS_NewDOMTimeEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("timeevents")) {
-    LOG_EVENT_CREATION(TIMEEVENTS);
     return NS_NewDOMTimeEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("xulcommandevent")) {
-    LOG_EVENT_CREATION(XULCOMMANDEVENT);
     return NS_NewDOMXULCommandEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("xulcommandevents")) {
-    LOG_EVENT_CREATION(XULCOMMANDEVENTS);
     return NS_NewDOMXULCommandEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("commandevent")) {
-    LOG_EVENT_CREATION(COMMANDEVENT);
     return NS_NewDOMCommandEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("commandevents")) {
-    LOG_EVENT_CREATION(COMMANDEVENTS);
     return NS_NewDOMCommandEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("datacontainerevent")) {
-    LOG_EVENT_CREATION(DATACONTAINEREVENT);
     return NS_NewDOMDataContainerEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("datacontainerevents")) {
-    LOG_EVENT_CREATION(DATACONTAINEREVENTS);
     return NS_NewDOMDataContainerEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("messageevent")) {
-    LOG_EVENT_CREATION(MESSAGEEVENT);
     RefPtr<Event> event = new MessageEvent(aOwner, aPresContext, nullptr);
     return event.forget();
   }
   if (aEventType.LowerCaseEqualsLiteral("notifypaintevent")) {
-    LOG_EVENT_CREATION(NOTIFYPAINTEVENT);
     return NS_NewDOMNotifyPaintEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("simplegestureevent")) {
-    LOG_EVENT_CREATION(SIMPLEGESTUREEVENT);
     return NS_NewDOMSimpleGestureEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("beforeunloadevent")) {
-    LOG_EVENT_CREATION(BEFOREUNLOADEVENT);
     return NS_NewDOMBeforeUnloadEvent(aOwner, aPresContext, nullptr);
   }
   // XXXkhuey this is broken
   if (aEventType.LowerCaseEqualsLiteral("pagetransition")) {
-    LOG_EVENT_CREATION(PAGETRANSITION);
     PageTransitionEventInit init;
     RefPtr<Event> event =
       PageTransitionEvent::Constructor(aOwner, EmptyString(), init);
@@ -1020,14 +980,12 @@ EventDispatcher::CreateEvent(EventTarget* aOwner,
     return event.forget();
   }
   if (aEventType.LowerCaseEqualsLiteral("scrollareaevent")) {
-    LOG_EVENT_CREATION(SCROLLAREAEVENT);
     return NS_NewDOMScrollAreaEvent(aOwner, aPresContext, nullptr);
   }
   // XXXkhuey Chrome supports popstateevent here, even though it provides no
   // initPopStateEvent method.  This is nuts ... but copying it is unlikely to
   // break the web.
   if (aEventType.LowerCaseEqualsLiteral("popstateevent")) {
-    LOG_EVENT_CREATION(POPSTATEEVENT);
     AutoJSContext cx;
     RootedDictionary<PopStateEventInit> init(cx);
     RefPtr<Event> event =
@@ -1037,11 +995,9 @@ EventDispatcher::CreateEvent(EventTarget* aOwner,
   }
   if (aEventType.LowerCaseEqualsLiteral("touchevent") &&
       TouchEvent::PrefEnabled(nsContentUtils::GetDocShellForEventTarget(aOwner))) {
-    LOG_EVENT_CREATION(TOUCHEVENT);
     return NS_NewDOMTouchEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("hashchangeevent")) {
-    LOG_EVENT_CREATION(HASHCHANGEEVENT);
     HashChangeEventInit init;
     RefPtr<Event> event =
       HashChangeEvent::Constructor(aOwner, EmptyString(), init);
@@ -1049,11 +1005,9 @@ EventDispatcher::CreateEvent(EventTarget* aOwner,
     return event.forget();
   }
   if (aEventType.LowerCaseEqualsLiteral("customevent")) {
-    LOG_EVENT_CREATION(CUSTOMEVENT);
     return NS_NewDOMCustomEvent(aOwner, aPresContext, nullptr);
   }
   if (aEventType.LowerCaseEqualsLiteral("storageevent")) {
-    LOG_EVENT_CREATION(STORAGEEVENT);
     return NS_NewDOMStorageEvent(aOwner);
   }
   if (aEventType.LowerCaseEqualsLiteral("focusevent")) {
@@ -1061,8 +1015,6 @@ EventDispatcher::CreateEvent(EventTarget* aOwner,
     event->MarkUninitialized();
     return event.forget();
   }
-
-#undef LOG_EVENT_CREATION
 
   // NEW EVENT TYPES SHOULD NOT BE ADDED HERE; THEY SHOULD USE ONLY EVENT
   // CONSTRUCTORS

--- a/dom/fetch/Fetch.cpp
+++ b/dom/fetch/Fetch.cpp
@@ -38,7 +38,6 @@
 #include "mozilla/dom/ScriptSettings.h"
 #include "mozilla/dom/URLSearchParams.h"
 #include "mozilla/dom/workers/ServiceWorkerManager.h"
-#include "mozilla/Telemetry.h"
 
 #include "InternalRequest.h"
 #include "InternalResponse.h"
@@ -237,8 +236,6 @@ FetchRequest(nsIGlobalObject* aGlobal, const RequestOrUSVString& aInput,
       }
     }
 
-    Telemetry::Accumulate(Telemetry::FETCH_IS_MAINTHREAD, 1);
-
     RefPtr<MainThreadFetchResolver> resolver = new MainThreadFetchResolver(p);
     RefPtr<FetchDriver> fetch = new FetchDriver(r, principal, loadGroup);
     fetch->SetDocument(doc);
@@ -250,8 +247,6 @@ FetchRequest(nsIGlobalObject* aGlobal, const RequestOrUSVString& aInput,
   } else {
     WorkerPrivate* worker = GetCurrentThreadWorkerPrivate();
     MOZ_ASSERT(worker);
-
-    Telemetry::Accumulate(Telemetry::FETCH_IS_MAINTHREAD, 0);
 
     if (worker->IsServiceWorker()) {
       r->SetSkipServiceWorker();

--- a/dom/fetch/FetchDriver.cpp
+++ b/dom/fetch/FetchDriver.cpp
@@ -77,9 +77,6 @@ FetchDriver::Fetch(FetchDriverObserver* aObserver)
 
   mObserver = aObserver;
 
-  Telemetry::Accumulate(Telemetry::SERVICE_WORKER_REQUEST_PASSTHROUGH,
-                        mRequest->WasCreatedByFetchEvent());
-
   // FIXME(nsm): Deal with HSTS.
 
   MOZ_RELEASE_ASSERT(!mRequest->IsSynchronous(),

--- a/dom/html/HTMLFormElement.cpp
+++ b/dom/html/HTMLFormElement.cpp
@@ -38,7 +38,6 @@
 // form submission
 #include "HTMLFormSubmissionConstants.h"
 #include "mozilla/dom/FormData.h"
-#include "mozilla/Telemetry.h"
 #include "nsIFormSubmitObserver.h"
 #include "nsIObserverService.h"
 #include "nsICategoryManager.h"
@@ -957,13 +956,6 @@ HTMLFormElement::DoSecureToInsecureSubmitCheck(nsIURI* aActionURL,
   *aCancelSubmit = (buttonPressed == 1);
   uint32_t telemetryBucket =
     nsISecurityUITelemetry::WARNING_CONFIRM_POST_TO_INSECURE_FROM_SECURE;
-  mozilla::Telemetry::Accumulate(mozilla::Telemetry::SECURITY_UI,
-                                 telemetryBucket);
-  if (!*aCancelSubmit) {
-    // The user opted to continue, so note that in the next telemetry bucket.
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::SECURITY_UI,
-                                   telemetryBucket + 1);
-  }
   return NS_OK;
 }
 

--- a/dom/html/HTMLInputElement.cpp
+++ b/dom/html/HTMLInputElement.cpp
@@ -24,7 +24,6 @@
 #include "nsIPhonetic.h"
 
 #include "HTMLFormSubmissionConstants.h"
-#include "mozilla/Telemetry.h"
 #include "nsIControllers.h"
 #include "nsIStringBundle.h"
 #include "nsFocusManager.h"
@@ -1274,10 +1273,6 @@ HTMLInputElement::BeforeSetAttr(int32_t aNameSpaceID, nsIAtom* aName,
         GetAttr(kNameSpaceID_None, nsGkAtoms::name, name);
         container->RadioRequiredWillChange(name, !!aValue);
       }
-    }
-
-    if (aName == nsGkAtoms::webkitdirectory) {
-      Telemetry::Accumulate(Telemetry::WEBKIT_DIRECTORY_USED, true);
     }
   }
 
@@ -4989,10 +4984,6 @@ HTMLInputElement::BindToTree(nsIDocument* aDocument, nsIContent* aParent,
                                  true);
       dispatcher->PostDOMEvent();
     }
-
-#ifdef EARLY_BETA_OR_EARLIER
-    Telemetry::Accumulate(Telemetry::PWMGR_PASSWORD_INPUT_IN_FORM, !!mForm);
-#endif
   }
 
   return rv;
@@ -8863,7 +8854,6 @@ HTMLInputElement::UpdateEntries(const nsTArray<OwningFileOrDirectory>& aFilesOrD
 void
 HTMLInputElement::GetWebkitEntries(nsTArray<RefPtr<FileSystemEntry>>& aSequence)
 {
-  Telemetry::Accumulate(Telemetry::BLINK_FILESYSTEM_USED, true);
   aSequence.AppendElements(mEntries);
 }
 

--- a/dom/html/TextTrackManager.cpp
+++ b/dom/html/TextTrackManager.cpp
@@ -12,7 +12,6 @@
 #include "mozilla/dom/TextTrackCue.h"
 #include "mozilla/dom/Event.h"
 #include "mozilla/ClearOnShutdown.h"
-#include "mozilla/Telemetry.h"
 #include "nsComponentManagerUtils.h"
 #include "nsVariant.h"
 #include "nsVideoFrame.h"
@@ -824,24 +823,13 @@ TextTrackManager::NotifyReset()
 void
 TextTrackManager::ReportTelemetryForTrack(TextTrack* aTextTrack) const
 {
-  MOZ_ASSERT(NS_IsMainThread());
-  MOZ_ASSERT(aTextTrack);
-  MOZ_ASSERT(mTextTracks->Length() > 0);
-
-  TextTrackKind kind = aTextTrack->Kind();
-  Telemetry::Accumulate(Telemetry::WEBVTT_TRACK_KINDS, uint32_t(kind));
+/* STUB */
 }
 
 void
 TextTrackManager::ReportTelemetryForCue()
 {
-  MOZ_ASSERT(NS_IsMainThread());
-  MOZ_ASSERT(!mNewCues->IsEmpty() || !mLastActiveCues->IsEmpty());
-
-  if (!mCueTelemetryReported) {
-    Telemetry::Accumulate(Telemetry::WEBVTT_USED_VTT_CUES, 1);
-    mCueTelemetryReported = true;
-  }
+/* STUB */
 }
 
 } // namespace dom

--- a/dom/html/nsTextEditorState.cpp
+++ b/dom/html/nsTextEditorState.cpp
@@ -47,7 +47,6 @@
 #include "mozilla/dom/HTMLInputElement.h"
 #include "nsNumberControlFrame.h"
 #include "nsFrameSelection.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/layers/ScrollInputMethods.h"
 
 using namespace mozilla;
@@ -585,9 +584,6 @@ nsTextInputSelectionImpl::CompleteScroll(bool aForward)
   if (!mScrollFrame)
     return NS_ERROR_NOT_INITIALIZED;
 
-  mozilla::Telemetry::Accumulate(mozilla::Telemetry::SCROLL_INPUT_METHODS,
-      (uint32_t) ScrollInputMethod::MainThreadCompleteScroll);
-
   mScrollFrame->ScrollBy(nsIntPoint(0, aForward ? 1 : -1),
                          nsIScrollableFrame::WHOLE,
                          nsIScrollableFrame::INSTANT);
@@ -640,9 +636,6 @@ nsTextInputSelectionImpl::ScrollPage(bool aForward)
   if (!mScrollFrame)
     return NS_ERROR_NOT_INITIALIZED;
 
-  mozilla::Telemetry::Accumulate(mozilla::Telemetry::SCROLL_INPUT_METHODS,
-      (uint32_t) ScrollInputMethod::MainThreadScrollPage);
-
   mScrollFrame->ScrollBy(nsIntPoint(0, aForward ? 1 : -1),
                          nsIScrollableFrame::PAGES,
                          nsIScrollableFrame::SMOOTH);
@@ -655,9 +648,6 @@ nsTextInputSelectionImpl::ScrollLine(bool aForward)
   if (!mScrollFrame)
     return NS_ERROR_NOT_INITIALIZED;
 
-  mozilla::Telemetry::Accumulate(mozilla::Telemetry::SCROLL_INPUT_METHODS,
-      (uint32_t) ScrollInputMethod::MainThreadScrollLine);
-
   mScrollFrame->ScrollBy(nsIntPoint(0, aForward ? 1 : -1),
                          nsIScrollableFrame::LINES,
                          nsIScrollableFrame::SMOOTH);
@@ -669,9 +659,6 @@ nsTextInputSelectionImpl::ScrollCharacter(bool aRight)
 {
   if (!mScrollFrame)
     return NS_ERROR_NOT_INITIALIZED;
-
-  mozilla::Telemetry::Accumulate(mozilla::Telemetry::SCROLL_INPUT_METHODS,
-      (uint32_t) ScrollInputMethod::MainThreadScrollCharacter);
 
   mScrollFrame->ScrollBy(nsIntPoint(aRight ? 1 : -1, 0),
                          nsIScrollableFrame::LINES,

--- a/dom/ipc/ContentParent.cpp
+++ b/dom/ipc/ContentParent.cpp
@@ -1718,9 +1718,6 @@ ContentParent::ActorDestroy(ActorDestroyReason why)
     props->SetPropertyAsUint64(NS_LITERAL_STRING("childID"), mChildID);
 
     if (AbnormalShutdown == why) {
-      Telemetry::Accumulate(Telemetry::SUBPROCESS_ABNORMAL_ABORT,
-                            NS_LITERAL_CSTRING("content"), 1);
-
       props->SetPropertyAsBool(NS_LITERAL_STRING("abnormal"), true);
     }
     nsAutoString cpId;
@@ -4778,7 +4775,7 @@ bool
 ContentParent::RecvAccumulateChildHistogram(
                 InfallibleTArray<Accumulation>&& aAccumulations)
 {
-  Telemetry::AccumulateChild(GeckoProcessType_Content, aAccumulations);
+  /* STUB */
   return true;
 }
 
@@ -4786,6 +4783,6 @@ bool
 ContentParent::RecvAccumulateChildKeyedHistogram(
                 InfallibleTArray<KeyedAccumulation>&& aAccumulations)
 {
-  Telemetry::AccumulateChildKeyed(GeckoProcessType_Content, aAccumulations);
+  /* STUB */
   return true;
 }

--- a/dom/media/AudioStream.cpp
+++ b/dom/media/AudioStream.cpp
@@ -14,7 +14,6 @@
 #include "mozilla/Mutex.h"
 #include "mozilla/Sprintf.h"
 #include <algorithm>
-#include "mozilla/Telemetry.h"
 #include "CubebUtils.h"
 #include "nsPrintfCString.h"
 #include "gfxPrefs.h"
@@ -378,8 +377,6 @@ AudioStream::OpenCubeb(cubeb* aContext, cubeb_stream_params& aParams,
   TimeDuration timeDelta = TimeStamp::Now() - aStartTime;
   LOG("creation time %sfirst: %u ms", aIsFirst ? "" : "not ",
       (uint32_t) timeDelta.ToMilliseconds());
-  Telemetry::Accumulate(aIsFirst ? Telemetry::AUDIOSTREAM_FIRST_OPEN_MS :
-      Telemetry::AUDIOSTREAM_LATER_OPEN_MS, timeDelta.ToMilliseconds());
 
   return NS_OK;
 }

--- a/dom/media/Benchmark.cpp
+++ b/dom/media/Benchmark.cpp
@@ -11,7 +11,6 @@
 #include "PDMFactory.h"
 #include "WebMDemuxer.h"
 #include "mozilla/Preferences.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/dom/ContentChild.h"
 
 #ifndef MOZ_WIDGET_ANDROID
@@ -68,7 +67,6 @@ VP9Benchmark::IsVP9DecodeFast()
           Preferences::SetUint(sBenchmarkFpsPref, aDecodeFps);
           Preferences::SetUint(sBenchmarkFpsVersionCheck, sBenchmarkVersionID);
         }
-        Telemetry::Accumulate(Telemetry::ID::VIDEO_VP9_BENCHMARK_FPS, aDecodeFps);
       },
       []() { });
   }

--- a/dom/media/CubebUtils.cpp
+++ b/dom/media/CubebUtils.cpp
@@ -248,13 +248,8 @@ void ReportCubebBackendUsed()
   bool foundBackend = false;
   for (uint32_t i = 0; i < ArrayLength(AUDIOSTREAM_BACKEND_ID_STR); i++) {
     if (!strcmp(cubeb_get_backend_id(sCubebContext), AUDIOSTREAM_BACKEND_ID_STR[i])) {
-      Telemetry::Accumulate(Telemetry::AUDIOSTREAM_BACKEND_USED, i);
       foundBackend = true;
     }
-  }
-  if (!foundBackend) {
-    Telemetry::Accumulate(Telemetry::AUDIOSTREAM_BACKEND_USED,
-                          CUBEB_BACKEND_UNKNOWN);
   }
 }
 
@@ -267,9 +262,6 @@ void ReportCubebStreamInitFailure(bool aIsFirst)
     // failures to open multiple streams in a process over time.
     return;
   }
-  Telemetry::Accumulate(Telemetry::AUDIOSTREAM_BACKEND_USED,
-                        aIsFirst ? CUBEB_BACKEND_INIT_FAILURE_FIRST
-                                 : CUBEB_BACKEND_INIT_FAILURE_OTHER);
 }
 
 uint32_t GetCubebPlaybackLatencyInMilliseconds()

--- a/dom/media/DecoderTraits.cpp
+++ b/dom/media/DecoderTraits.cpp
@@ -288,7 +288,7 @@ CanHandleMediaType(const MediaContentType& aType,
   MOZ_ASSERT(NS_IsMainThread());
 
   if (IsHttpLiveStreamingType(aType.GetMIMEType())) {
-    Telemetry::Accumulate(Telemetry::MEDIA_HLS_CANPLAY_REQUESTED, true);
+    /* Telemetry STUB */
   }
 
   if (aType.HaveCodecs()) {
@@ -432,11 +432,6 @@ InstantiateDecoder(const nsACString& aType,
     return decoder.forget();
   }
 #endif
-
-  if (IsHttpLiveStreamingType(aType)) {
-    // We don't have an HLS decoder.
-    Telemetry::Accumulate(Telemetry::MEDIA_HLS_DECODER_SUCCESS, false);
-  }
 
   return nullptr;
 }

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -877,7 +877,6 @@ MediaDecoder::EnsureTelemetryReported()
   }
   for (const nsCString& codec : codecs) {
     DECODER_LOG("Telemetry MEDIA_CODEC_USED= '%s'", codec.get());
-    Telemetry::Accumulate(Telemetry::ID::MEDIA_CODEC_USED, codec);
   }
 
   mTelemetryReported = true;

--- a/dom/media/MediaDecoderStateMachine.cpp
+++ b/dom/media/MediaDecoderStateMachine.cpp
@@ -1178,40 +1178,7 @@ ReportRecoveryTelemetry(const TimeStamp& aRecoveryStart,
                         const MediaInfo& aMediaInfo,
                         bool aIsHardwareAccelerated)
 {
-  MOZ_ASSERT(NS_IsMainThread());
-  if (!aMediaInfo.HasVideo()) {
-    return;
-  }
-
-  // Keyed by audio+video or video alone, hardware acceleration,
-  // and by a resolution range.
-  nsCString key(aMediaInfo.HasAudio() ? "AV" : "V");
-  key.AppendASCII(aIsHardwareAccelerated ? "(hw)," : ",");
-  static const struct { int32_t mH; const char* mRes; } sResolutions[] = {
-    {  240, "0-240" },
-    {  480, "241-480" },
-    {  720, "481-720" },
-    { 1080, "721-1080" },
-    { 2160, "1081-2160" }
-  };
-  const char* resolution = "2161+";
-  int32_t height = aMediaInfo.mVideo.mImage.height;
-  for (const auto& res : sResolutions) {
-    if (height <= res.mH) {
-      resolution = res.mRes;
-      break;
-    }
-  }
-  key.AppendASCII(resolution);
-
-  TimeDuration duration = TimeStamp::Now() - aRecoveryStart;
-  double duration_ms = duration.ToMilliseconds();
-  Telemetry::Accumulate(Telemetry::VIDEO_SUSPEND_RECOVERY_TIME_MS,
-                        key,
-                        uint32_t(duration_ms + 0.5));
-  Telemetry::Accumulate(Telemetry::VIDEO_SUSPEND_RECOVERY_TIME_MS,
-                        NS_LITERAL_CSTRING("All"),
-                        uint32_t(duration_ms + 0.5));
+/* STUB */
 }
 
 void

--- a/dom/media/MediaManager.cpp
+++ b/dom/media/MediaManager.cpp
@@ -32,7 +32,6 @@
 #include "nsAppDirectoryServiceDefs.h"
 #include "nsIInputStream.h"
 #include "nsILineInputStream.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/Types.h"
 #include "mozilla/PeerIdentity.h"
 #include "mozilla/dom/ContentChild.h"
@@ -2058,28 +2057,6 @@ MediaManager::GetUserMedia(nsPIDOMWindowInner* aWindow,
                       host.LowerCaseEqualsLiteral("127.0.0.1") ||
                       host.LowerCaseEqualsLiteral("::1"));
 
-  // Record telemetry about whether the source of the call was secure, i.e.,
-  // privileged or HTTPS.  We may handle other cases
-if (privileged) {
-    Telemetry::Accumulate(Telemetry::WEBRTC_GET_USER_MEDIA_SECURE_ORIGIN,
-                          (uint32_t) GetUserMediaSecurityState::Privileged);
-  } else if (isHTTPS) {
-    Telemetry::Accumulate(Telemetry::WEBRTC_GET_USER_MEDIA_SECURE_ORIGIN,
-                          (uint32_t) GetUserMediaSecurityState::HTTPS);
-  } else if (isFile) {
-    Telemetry::Accumulate(Telemetry::WEBRTC_GET_USER_MEDIA_SECURE_ORIGIN,
-                          (uint32_t) GetUserMediaSecurityState::File);
-  } else if (isApp) {
-    Telemetry::Accumulate(Telemetry::WEBRTC_GET_USER_MEDIA_SECURE_ORIGIN,
-                          (uint32_t) GetUserMediaSecurityState::App);
-  } else if (isLocalhost) {
-    Telemetry::Accumulate(Telemetry::WEBRTC_GET_USER_MEDIA_SECURE_ORIGIN,
-                          (uint32_t) GetUserMediaSecurityState::Localhost);
-  } else {
-    Telemetry::Accumulate(Telemetry::WEBRTC_GET_USER_MEDIA_SECURE_ORIGIN,
-                          (uint32_t) GetUserMediaSecurityState::Other);
-  }
-
   nsCString origin;
   rv = nsPrincipal::GetOriginForURI(docURI, origin);
   if (NS_WARN_IF(NS_FAILED(rv))) {
@@ -2098,8 +2075,6 @@ if (privileged) {
     videoType = StringToEnum(dom::MediaSourceEnumValues::strings,
                              vc.mMediaSource,
                              MediaSourceEnum::Other);
-    Telemetry::Accumulate(Telemetry::WEBRTC_GET_USER_MEDIA_TYPE,
-                          (uint32_t) videoType);
     switch (videoType) {
       case MediaSourceEnum::Camera:
         break;
@@ -2182,8 +2157,6 @@ if (privileged) {
       ac.mMediaSource.AssignASCII(EnumToASCII(dom::MediaSourceEnumValues::strings,
                                               audioType));
     }
-    Telemetry::Accumulate(Telemetry::WEBRTC_GET_USER_MEDIA_TYPE,
-                          (uint32_t) audioType);
 
     switch (audioType) {
       case MediaSourceEnum::Microphone:

--- a/dom/media/VideoUtils.cpp
+++ b/dom/media/VideoUtils.cpp
@@ -6,7 +6,6 @@
 
 #include "mozilla/Base64.h"
 #include "mozilla/TaskQueue.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/Function.h"
 
 #include "MediaContentType.h"
@@ -247,24 +246,6 @@ ExtractH264CodecDetails(const nsAString& aCodec,
   } else if (aLevel <= 5) {
     aLevel *= 10;
   }
-
-  // Capture the constraint_set flag value for the purpose of Telemetry.
-  // We don't NS_ENSURE_SUCCESS here because ExtractH264CodecDetails doesn't
-  // care about this, but we make sure constraints is above 4 (constraint_set5_flag)
-  // otherwise collect 0 for unknown.
-  uint8_t constraints = PromiseFlatString(Substring(aCodec, 7, 2)).ToInteger(&rv, 16);
-  Telemetry::Accumulate(Telemetry::VIDEO_CANPLAYTYPE_H264_CONSTRAINT_SET_FLAG,
-                        constraints >= 4 ? constraints : 0);
-
-  // 244 is the highest meaningful profile value (High 4:4:4 Intra Profile)
-  // that can be represented as single hex byte, otherwise collect 0 for unknown.
-  Telemetry::Accumulate(Telemetry::VIDEO_CANPLAYTYPE_H264_PROFILE,
-                        aProfile <= 244 ? aProfile : 0);
-
-  // Make sure aLevel represents a value between levels 1 and 5.2,
-  // otherwise collect 0 for unknown.
-  Telemetry::Accumulate(Telemetry::VIDEO_CANPLAYTYPE_H264_LEVEL,
-                        (aLevel >= 10 && aLevel <= 52) ? aLevel : 0);
 
   return true;
 }

--- a/dom/media/eme/DetailedPromise.cpp
+++ b/dom/media/eme/DetailedPromise.cpp
@@ -96,9 +96,6 @@ DetailedPromise::MaybeReportTelemetry(Status aStatus)
   uint32_t latency = (TimeStamp::Now() - mStartTime).ToMilliseconds();
   EME_LOG("%s %s latency %ums reported via telemetry", mName.get(),
           ((aStatus == Succeeded) ? "succcess" : "failure"), latency);
-  Telemetry::ID tid = (aStatus == Succeeded) ? mSuccessLatencyProbe.Value()
-                                             : mFailureLatencyProbe.Value();
-  Telemetry::Accumulate(tid, latency);
 }
 
 } // namespace dom

--- a/dom/media/eme/MediaKeySession.cpp
+++ b/dom/media/eme/MediaKeySession.cpp
@@ -315,9 +315,6 @@ MediaKeySession::GenerateRequest(const nsAString& aInitDataType,
 
   // Note: Remaining steps of generateRequest method continue in CDM.
 
-  Telemetry::Accumulate(Telemetry::VIDEO_CDM_GENERATE_REQUEST_CALLED,
-                        ToCDMTypeTelemetryEnum(mKeySystem));
-
   // Convert initData to base64 for easier logging.
   // Note: CreateSession() Move()s the data out of the array, so we have
   // to copy it here.

--- a/dom/media/eme/MediaKeys.cpp
+++ b/dom/media/eme/MediaKeys.cpp
@@ -13,7 +13,6 @@
 #include "mozilla/dom/MediaKeySession.h"
 #include "mozilla/dom/DOMException.h"
 #include "mozilla/dom/UnionTypes.h"
-#include "mozilla/Telemetry.h"
 #include "GMPCDMProxy.h"
 #ifdef MOZ_WIDGET_ANDROID
 #include "mozilla/MediaDrmCDMProxy.h"
@@ -457,7 +456,6 @@ MediaKeys::OnCDMCreated(PromiseId aId, const nsACString& aNodeId, const uint32_t
                                         mKeySystem,
                                         MediaKeySystemStatus::Cdm_created);
 
-  Telemetry::Accumulate(Telemetry::VIDEO_CDM_CREATED, ToCDMTypeTelemetryEnum(mKeySystem));
 }
 
 static bool

--- a/dom/media/fmp4/MP4Demuxer.cpp
+++ b/dom/media/fmp4/MP4Demuxer.cpp
@@ -81,35 +81,11 @@ private:
 bool
 AccumulateSPSTelemetry(const MediaByteBuffer* aExtradata)
 {
+  // XXX: Do we still need this without telemetry?
   mp4_demuxer::SPSData spsdata;
   if (mp4_demuxer::H264::DecodeSPSFromExtraData(aExtradata, spsdata)) {
-    uint8_t constraints = (spsdata.constraint_set0_flag ? (1 << 0) : 0) |
-                          (spsdata.constraint_set1_flag ? (1 << 1) : 0) |
-                          (spsdata.constraint_set2_flag ? (1 << 2) : 0) |
-                          (spsdata.constraint_set3_flag ? (1 << 3) : 0) |
-                          (spsdata.constraint_set4_flag ? (1 << 4) : 0) |
-                          (spsdata.constraint_set5_flag ? (1 << 5) : 0);
-    Telemetry::Accumulate(Telemetry::VIDEO_DECODED_H264_SPS_CONSTRAINT_SET_FLAG,
-                          constraints);
-
-    // Collect profile_idc values up to 244, otherwise 0 for unknown.
-    Telemetry::Accumulate(Telemetry::VIDEO_DECODED_H264_SPS_PROFILE,
-                          spsdata.profile_idc <= 244 ? spsdata.profile_idc : 0);
-
-    // Make sure level_idc represents a value between levels 1 and 5.2,
-    // otherwise collect 0 for unknown level.
-    Telemetry::Accumulate(Telemetry::VIDEO_DECODED_H264_SPS_LEVEL,
-                          (spsdata.level_idc >= 10 && spsdata.level_idc <= 52) ?
-                          spsdata.level_idc : 0);
-
-    // max_num_ref_frames should be between 0 and 16, anything larger will
-    // be treated as invalid.
-    Telemetry::Accumulate(Telemetry::VIDEO_H264_SPS_MAX_NUM_REF_FRAMES,
-                          std::min(spsdata.max_num_ref_frames, 17u));
-
     return false;
   }
-
   return true;
 }
 

--- a/dom/media/ogg/OggDemuxer.cpp
+++ b/dom/media/ogg/OggDemuxer.cpp
@@ -12,7 +12,6 @@
 #include "mozilla/Atomics.h"
 #include "mozilla/PodOperations.h"
 #include "mozilla/SharedThreadPool.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/TimeStamp.h"
 #include "MediaDataDemuxer.h"
 #include "nsAutoRef.h"
@@ -164,7 +163,6 @@ OggDemuxer::~OggDemuxer()
       MOZ_LOG(gMediaDemuxerLog, mozilla::LogLevel::Debug,
               ("OggDemuxer(%p)::%s: Reporting telemetry MEDIA_OGG_LOADED_IS_CHAINED=%d",
                ptr, __func__, isChained));
-      Telemetry::Accumulate(Telemetry::ID::MEDIA_OGG_LOADED_IS_CHAINED, isChained);
     });
     AbstractThread::MainThread()->Dispatch(task.forget());
   }

--- a/dom/media/platforms/wmf/DXVA2Manager.cpp
+++ b/dom/media/platforms/wmf/DXVA2Manager.cpp
@@ -14,7 +14,6 @@
 #include "mozilla/layers/D3D11ShareHandleImage.h"
 #include "mozilla/layers/ImageBridgeChild.h"
 #include "mozilla/layers/TextureForwarder.h"
-#include "mozilla/Telemetry.h"
 #include "MediaTelemetryConstants.h"
 #include "mfapi.h"
 #include "gfxPrefs.h"
@@ -442,9 +441,6 @@ D3D9DXVA2Manager::Init(layers::KnowsCompositor* aKnowsCompositor,
   }
   mTextureClientAllocator->SetMaxPoolSize(5);
 
-  Telemetry::Accumulate(Telemetry::MEDIA_DECODER_BACKEND_USED,
-                        uint32_t(media::MediaDecoderBackend::WMFDXVA2D3D9));
-
   return S_OK;
 }
 
@@ -774,9 +770,6 @@ D3D11DXVA2Manager::Init(layers::KnowsCompositor* aKnowsCompositor,
                                                         mDevice);
   }
   mTextureClientAllocator->SetMaxPoolSize(5);
-
-  Telemetry::Accumulate(Telemetry::MEDIA_DECODER_BACKEND_USED,
-                        uint32_t(media::MediaDecoderBackend::WMFDXVA2D3D11));
 
   return S_OK;
 }

--- a/dom/media/platforms/wmf/WMFAudioMFTManager.cpp
+++ b/dom/media/platforms/wmf/WMFAudioMFTManager.cpp
@@ -252,7 +252,6 @@ WMFAudioMFTManager::Output(int64_t aStreamOffset,
     LOG("Audio MFTDecoder returned success but null output.");
     nsCOMPtr<nsIRunnable> task = NS_NewRunnableFunction([]() -> void {
       LOG("Reporting telemetry AUDIO_MFT_OUTPUT_NULL_SAMPLES");
-      Telemetry::Accumulate(Telemetry::ID::AUDIO_MFT_OUTPUT_NULL_SAMPLES, 1);
     });
     AbstractThread::MainThread()->Dispatch(task.forget());
     return E_FAIL;

--- a/dom/media/platforms/wmf/WMFMediaDataDecoder.cpp
+++ b/dom/media/platforms/wmf/WMFMediaDataDecoder.cpp
@@ -8,7 +8,6 @@
 #include "VideoUtils.h"
 #include "WMFUtils.h"
 #include "nsTArray.h"
-#include "mozilla/Telemetry.h"
 
 #include "mozilla/Logging.h"
 #include "mozilla/SyncRunnable.h"
@@ -67,7 +66,7 @@ SendTelemetry(unsigned long hr)
 
   nsCOMPtr<nsIRunnable> runnable = NS_NewRunnableFunction(
     [sample] {
-      Telemetry::Accumulate(Telemetry::MEDIA_WMF_DECODE_ERROR, sample);
+      /* Telemetry STUB */
     });
   NS_DispatchToMainThread(runnable);
 }

--- a/dom/media/platforms/wmf/WMFVideoMFTManager.cpp
+++ b/dom/media/platforms/wmf/WMFVideoMFTManager.cpp
@@ -128,7 +128,6 @@ WMFVideoMFTManager::~WMFVideoMFTManager()
 
   nsCOMPtr<nsIRunnable> task = NS_NewRunnableFunction([=]() -> void {
     LOG(nsPrintfCString("Reporting telemetry VIDEO_MFT_OUTPUT_NULL_SAMPLES=%d", telemetry).get());
-    Telemetry::Accumulate(Telemetry::ID::VIDEO_MFT_OUTPUT_NULL_SAMPLES, telemetry);
   });
   AbstractThread::MainThread()->Dispatch(task.forget());
 }
@@ -511,8 +510,6 @@ WMFVideoMFTManager::InitInternal(bool aForceD3D9)
     if (mStreamType == VP9 || mStreamType == VP8) {
       return false;
     }
-    Telemetry::Accumulate(Telemetry::MEDIA_DECODER_BACKEND_USED,
-                          uint32_t(media::MediaDecoderBackend::WMFSoftware));
   }
 
   mDecoder = decoder;

--- a/dom/media/systemservices/LoadManager.cpp
+++ b/dom/media/systemservices/LoadManager.cpp
@@ -15,7 +15,6 @@
 #include "nsThreadUtils.h"
 #include "nsReadableUtils.h"
 #include "nsIObserverService.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/ArrayUtils.h"
 
 // MOZ_LOG=LoadManager:5
@@ -191,23 +190,6 @@ LoadManagerSingleton::RemoveObserver(webrtc::CPULoadStateObserver * aObserver)
     float total = 0;
     for (size_t i = 0; i < MOZ_ARRAY_LENGTH(mTimeInState); i++) {
       total += mTimeInState[i];
-    }
-    // Don't include short calls; we don't have reasonable load data, and
-    // such short calls rarely reach a stable state.  Keep relatively
-    // short calls separate from longer ones
-    bool log = total > 5*PR_MSEC_PER_SEC;
-    bool small = log && total < 30*PR_MSEC_PER_SEC;
-    if (log) {
-      // Note: We don't care about rounding here; thus total may be < 100
-      Telemetry::Accumulate(small ? Telemetry::WEBRTC_LOAD_STATE_RELAXED_SHORT :
-                            Telemetry::WEBRTC_LOAD_STATE_RELAXED,
-                            (uint32_t) (mTimeInState[webrtc::CPULoadState::kLoadRelaxed]/total * 100));
-      Telemetry::Accumulate(small ? Telemetry::WEBRTC_LOAD_STATE_NORMAL_SHORT :
-                            Telemetry::WEBRTC_LOAD_STATE_NORMAL,
-                            (uint32_t) (mTimeInState[webrtc::CPULoadState::kLoadNormal]/total * 100));
-      Telemetry::Accumulate(small ? Telemetry::WEBRTC_LOAD_STATE_STRESSED_SHORT :
-                            Telemetry::WEBRTC_LOAD_STATE_STRESSED,
-                            (uint32_t) (mTimeInState[webrtc::CPULoadState::kLoadStressed]/total * 100));
     }
     for (auto &in_state : mTimeInState) {
       in_state = 0;

--- a/dom/media/webaudio/MediaBufferDecoder.cpp
+++ b/dom/media/webaudio/MediaBufferDecoder.cpp
@@ -23,7 +23,6 @@
 #include "VideoUtils.h"
 #include "WebAudioUtils.h"
 #include "mozilla/dom/Promise.h"
-#include "mozilla/Telemetry.h"
 #include "nsPrintfCString.h"
 #include "GMPService.h"
 
@@ -302,7 +301,6 @@ MediaDecodeTask::OnMetadataRead(MetadataHolder* aMetadata)
     MOZ_LOG(gMediaDecoderLog,
             LogLevel::Debug,
             ("Telemetry (WebAudio) MEDIA_CODEC_USED= '%s'", codec.get()));
-    Telemetry::Accumulate(Telemetry::ID::MEDIA_CODEC_USED, codec);
   });
   AbstractThread::MainThread()->Dispatch(task.forget());
 

--- a/dom/plugins/ipc/PluginHangUIParent.cpp
+++ b/dom/plugins/ipc/PluginHangUIParent.cpp
@@ -8,7 +8,6 @@
 
 #include "PluginHangUIParent.h"
 
-#include "mozilla/Telemetry.h"
 #include "mozilla/ipc/ProtocolUtils.h"
 #include "mozilla/plugins/PluginModuleParent.h"
 
@@ -48,14 +47,6 @@ public:
   NS_IMETHOD
   Run() override
   {
-    mozilla::Telemetry::Accumulate(
-              mozilla::Telemetry::PLUGIN_HANG_UI_USER_RESPONSE, mResponseCode);
-    mozilla::Telemetry::Accumulate(
-              mozilla::Telemetry::PLUGIN_HANG_UI_DONT_ASK, mDontAskCode);
-    mozilla::Telemetry::Accumulate(
-              mozilla::Telemetry::PLUGIN_HANG_UI_RESPONSE_TIME, mResponseTimeMs);
-    mozilla::Telemetry::Accumulate(
-              mozilla::Telemetry::PLUGIN_HANG_TIME, mTimeoutMs + mResponseTimeMs);
     return NS_OK;
   }
 

--- a/dom/plugins/ipc/PluginInstanceParent.cpp
+++ b/dom/plugins/ipc/PluginInstanceParent.cpp
@@ -9,7 +9,6 @@
 
 #include "mozilla/BasicEvents.h"
 #include "mozilla/Preferences.h"
-#include "mozilla/Telemetry.h"
 #include "PluginInstanceParent.h"
 #include "BrowserStreamParent.h"
 #include "PluginAsyncSurrogate.h"
@@ -2504,6 +2503,5 @@ PluginInstanceParent::RecordDrawingModel()
     }
     MOZ_ASSERT(mode >= 0);
 
-    Telemetry::Accumulate(Telemetry::PLUGIN_DRAWING_MODEL, mode);
     mLastRecordedDrawingModel = mode;
 }

--- a/dom/plugins/ipc/PluginModuleParent.cpp
+++ b/dom/plugins/ipc/PluginModuleParent.cpp
@@ -20,7 +20,6 @@
 #include "mozilla/Preferences.h"
 #include "mozilla/ProcessHangMonitor.h"
 #include "mozilla/Services.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/Unused.h"
 #include "nsAutoPtr.h"
 #include "nsCRT.h"
@@ -1172,11 +1171,6 @@ PluginModuleParent::GetRunID(uint32_t* aRunID)
 void
 PluginModuleChromeParent::ActorDestroy(ActorDestroyReason why)
 {
-    if (why == AbnormalShutdown) {
-        Telemetry::Accumulate(Telemetry::SUBPROCESS_ABNORMAL_ABORT,
-                              NS_LITERAL_CSTRING("plugin"), 1);
-    }
-
     // We can't broadcast settings changes anymore.
     UnregisterSettingsCallbacks();
 
@@ -2203,12 +2197,8 @@ public:
 void
 PluginModuleParent::AccumulateModuleInitBlockedTime()
 {
-    if (mPluginName.IsEmpty()) {
-        GetPluginDetails();
-    }
-    Telemetry::Accumulate(Telemetry::BLOCKED_ON_PLUGIN_MODULE_INIT_MS,
-                          GetHistogramKey(),
-                          static_cast<uint32_t>(mTimeBlocked.ToMilliseconds()));
+    // XXX: mTimeBlocked can probably go if not used for anything besides
+    // telemetry.
     mTimeBlocked = TimeDuration();
 }
 

--- a/dom/security/nsMixedContentBlocker.cpp
+++ b/dom/security/nsMixedContentBlocker.cpp
@@ -983,44 +983,5 @@ enum MixedContentHSTSState {
 void
 nsMixedContentBlocker::AccumulateMixedContentHSTS(nsIURI* aURI, bool aActive)
 {
-  // This method must only be called in the parent, because
-  // nsSiteSecurityService is only available in the parent
-  if (!XRE_IsParentProcess()) {
-    MOZ_ASSERT(false);
-    return;
-  }
-
-  bool hsts;
-  nsresult rv;
-  nsCOMPtr<nsISiteSecurityService> sss = do_GetService(NS_SSSERVICE_CONTRACTID, &rv);
-  if (NS_FAILED(rv)) {
-    return;
-  }
-  rv = sss->IsSecureURI(nsISiteSecurityService::HEADER_HSTS, aURI, 0, nullptr, &hsts);
-  if (NS_FAILED(rv)) {
-    return;
-  }
-
-  // states: would upgrade, hsts info cached
-  // active, passive
-  //
-  if (!aActive) {
-    if (!hsts) {
-      Telemetry::Accumulate(Telemetry::MIXED_CONTENT_HSTS,
-                            MCB_HSTS_PASSIVE_NO_HSTS);
-    }
-    else {
-      Telemetry::Accumulate(Telemetry::MIXED_CONTENT_HSTS,
-                            MCB_HSTS_PASSIVE_WITH_HSTS);
-    }
-  } else {
-    if (!hsts) {
-      Telemetry::Accumulate(Telemetry::MIXED_CONTENT_HSTS,
-                            MCB_HSTS_ACTIVE_NO_HSTS);
-    }
-    else {
-      Telemetry::Accumulate(Telemetry::MIXED_CONTENT_HSTS,
-                            MCB_HSTS_ACTIVE_WITH_HSTS);
-    }
-  }
+/* STUB */
 }

--- a/dom/storage/DOMStorageCache.cpp
+++ b/dom/storage/DOMStorageCache.cpp
@@ -309,7 +309,7 @@ public:
   explicit TelemetryAutoTimer(Telemetry::ID aId)
     : id(aId), start(TimeStamp::Now()) {}
   ~TelemetryAutoTimer()
-    { Telemetry::AccumulateDelta_impl<Telemetry::Millisecond>::compute(id, start); }
+    { /* STUB */ }
 private:
   Telemetry::ID id;
   const TimeStamp start;
@@ -329,9 +329,6 @@ DOMStorageCache::WaitForPreload(Telemetry::ID aTelemetryID)
   // Telemetry of rates of pending preloads
   if (!mPreloadTelemetryRecorded) {
     mPreloadTelemetryRecorded = true;
-    Telemetry::Accumulate(
-      Telemetry::LOCALDOMSTORAGE_PRELOAD_PENDING_ON_FIRST_ACCESS,
-      !loaded);
   }
 
   if (loaded) {

--- a/dom/system/mac/CoreLocationLocationProvider.mm
+++ b/dom/system/mac/CoreLocationLocationProvider.mm
@@ -13,7 +13,6 @@
 #include "CoreLocationLocationProvider.h"
 #include "nsCocoaFeatures.h"
 #include "prtime.h"
-#include "mozilla/Telemetry.h"
 #include "MLSFallback.h"
 
 #include <CoreLocation/CLError.h>
@@ -103,7 +102,6 @@ static const CLLocationAccuracy kDEFAULT_ACCURACY = kCLLocationAccuracyNearestTe
                       PR_Now() / PR_USEC_PER_MSEC);
 
   mProvider->Update(geoPosition);
-  Telemetry::Accumulate(Telemetry::GEOLOCATION_OSX_SOURCE_IS_MLS, false);
 }
 @end
 
@@ -127,7 +125,6 @@ CoreLocationLocationProvider::MLSUpdate::Update(nsIDOMGeoPosition *position)
     return NS_ERROR_FAILURE;
   }
   mParentLocationProvider.Update(position);
-  Telemetry::Accumulate(Telemetry::GEOLOCATION_OSX_SOURCE_IS_MLS, true);
   return NS_OK;
 }
 NS_IMETHODIMP

--- a/dom/system/windows/WindowsLocationProvider.cpp
+++ b/dom/system/windows/WindowsLocationProvider.cpp
@@ -10,7 +10,6 @@
 #include "nsComponentManagerUtils.h"
 #include "prtime.h"
 #include "MLSFallback.h"
-#include "mozilla/Telemetry.h"
 
 namespace mozilla {
 namespace dom {
@@ -34,7 +33,6 @@ WindowsLocationProvider::MLSUpdate::Update(nsIDOMGeoPosition *aPosition)
   if (!coords) {
     return NS_ERROR_FAILURE;
   }
-  Telemetry::Accumulate(Telemetry::GEOLOCATION_WIN8_SOURCE_IS_MLS, true);
   return mCallback->Update(aPosition);
 }
 NS_IMETHODIMP
@@ -175,8 +173,6 @@ LocationEvent::OnLocationChanged(REFIID aReportType,
     new nsGeoPosition(latitude, longitude, alt, herror, verror, 0.0, 0.0,
                       PR_Now() / PR_USEC_PER_MSEC);
   mCallback->Update(position);
-
-  Telemetry::Accumulate(Telemetry::GEOLOCATION_WIN8_SOURCE_IS_MLS, false);
 
   return S_OK;
 }

--- a/dom/workers/RuntimeService.cpp
+++ b/dom/workers/RuntimeService.cpp
@@ -30,7 +30,6 @@
 #include "mozilla/AsyncEventDispatcher.h"
 #include "mozilla/Atomics.h"
 #include "mozilla/CycleCollectedJSContext.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/TimeStamp.h"
 #include "mozilla/dom/asmjscache/AsmJSCache.h"
 #include "mozilla/dom/AtomList.h"
@@ -1534,7 +1533,6 @@ RuntimeService::RegisterWorker(WorkerPrivate* aWorkerPrivate)
   const bool isDedicatedWorker = aWorkerPrivate->IsDedicatedWorker();
   if (isServiceWorker) {
     AssertIsOnMainThread();
-    Telemetry::Accumulate(Telemetry::SERVICE_WORKER_SPAWN_ATTEMPTS, 1);
   }
 
   nsCString sharedWorkerScriptSpec;
@@ -1586,14 +1584,6 @@ RuntimeService::RegisterWorker(WorkerPrivate* aWorkerPrivate)
       // Worker spawn gets queued due to hitting max workers per domain
       // limit so let's log a warning.
       WorkerPrivate::ReportErrorToConsole("HittingMaxWorkersPerDomain2");
-
-      if (isServiceWorker) {
-        Telemetry::Accumulate(Telemetry::SERVICE_WORKER_SPAWN_GETS_QUEUED, 1);
-      } else if (isSharedWorker) {
-        Telemetry::Accumulate(Telemetry::SHARED_WORKER_SPAWN_GETS_QUEUED, 1);
-      } else if (isDedicatedWorker) {
-        Telemetry::Accumulate(Telemetry::DEDICATED_WORKER_SPAWN_GETS_QUEUED, 1);
-      }
     }
     else if (parent) {
       domainInfo->mChildWorkerCount++;
@@ -1669,7 +1659,6 @@ RuntimeService::RegisterWorker(WorkerPrivate* aWorkerPrivate)
 
   if (isServiceWorker) {
     AssertIsOnMainThread();
-    Telemetry::Accumulate(Telemetry::SERVICE_WORKER_WAS_SPAWNED, 1);
   }
   return true;
 }
@@ -1766,8 +1755,6 @@ RuntimeService::UnregisterWorker(WorkerPrivate* aWorkerPrivate)
 
   if (aWorkerPrivate->IsServiceWorker()) {
     AssertIsOnMainThread();
-    Telemetry::AccumulateTimeDelta(Telemetry::SERVICE_WORKER_LIFE_TIME,
-                                   aWorkerPrivate->CreationTimeStamp());
   }
 
   if (aWorkerPrivate->IsSharedWorker() ||

--- a/dom/workers/ServiceWorkerManager.cpp
+++ b/dom/workers/ServiceWorkerManager.cpp
@@ -33,7 +33,6 @@
 #include "mozilla/ClearOnShutdown.h"
 #include "mozilla/ErrorNames.h"
 #include "mozilla/LoadContext.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/dom/BindingUtils.h"
 #include "mozilla/dom/ContentParent.h"
 #include "mozilla/dom/DOMError.h"
@@ -676,7 +675,6 @@ ServiceWorkerManager::Register(mozIDOMWindow* aWindow,
   queue->ScheduleJob(job);
 
   AssertIsOnMainThread();
-  Telemetry::Accumulate(Telemetry::SERVICE_WORKER_REGISTRATIONS, 1);
 
   promise.forget(aPromise);
   return NS_OK;
@@ -2180,7 +2178,6 @@ ServiceWorkerManager::StartControllingADocument(ServiceWorkerRegistrationInfo* a
   if (!aDocumentId.IsEmpty()) {
     aDoc->SetId(aDocumentId);
   }
-  Telemetry::Accumulate(Telemetry::SERVICE_WORKER_CONTROLLED_DOCUMENTS, 1);
 }
 
 void

--- a/dom/workers/ServiceWorkerRegistrar.cpp
+++ b/dom/workers/ServiceWorkerRegistrar.cpp
@@ -135,9 +135,6 @@ ServiceWorkerRegistrar::GetRegistrations(
 
   if (firstTime) {
     firstTime = false;
-    Telemetry::AccumulateTimeDelta(
-      Telemetry::SERVICE_WORKER_REGISTRATION_LOADING,
-      startTime);
   }
 }
 

--- a/dom/workers/ServiceWorkerUpdateJob.cpp
+++ b/dom/workers/ServiceWorkerUpdateJob.cpp
@@ -408,8 +408,6 @@ ServiceWorkerUpdateJob::ComparisonResult(nsresult aStatus,
     return;
   }
 
-  Telemetry::Accumulate(Telemetry::SERVICE_WORKER_UPDATED, 1);
-
   // Begin step 7 of the Update algorithm to evaluate the new script.
 
   RefPtr<ServiceWorkerInfo> sw =

--- a/dom/workers/SharedWorker.cpp
+++ b/dom/workers/SharedWorker.cpp
@@ -12,7 +12,6 @@
 #include "mozilla/Preferences.h"
 #include "mozilla/dom/MessagePort.h"
 #include "mozilla/dom/SharedWorkerBinding.h"
-#include "mozilla/Telemetry.h"
 #include "nsContentUtils.h"
 #include "nsIClassInfoImpl.h"
 #include "nsIDOMEvent.h"
@@ -72,8 +71,6 @@ SharedWorker::Constructor(const GlobalObject& aGlobal, JSContext* aCx,
     aRv = rv;
     return nullptr;
   }
-
-  Telemetry::Accumulate(Telemetry::SHARED_WORKER_COUNT, 1);
 
   return sharedWorker.forget();
 }

--- a/dom/workers/WorkerRunnable.cpp
+++ b/dom/workers/WorkerRunnable.cpp
@@ -15,7 +15,6 @@
 #include "mozilla/DebugOnly.h"
 #include "mozilla/ErrorResult.h"
 #include "mozilla/dom/ScriptSettings.h"
-#include "mozilla/Telemetry.h"
 
 #include "js/RootingAPI.h"
 #include "js/Value.h"
@@ -572,8 +571,6 @@ WorkerMainThreadRunnable::Dispatch(Status aFailStatus, ErrorResult& aRv)
 {
   mWorkerPrivate->AssertIsOnWorkerThread();
 
-  TimeStamp startTime = TimeStamp::NowLoRes();
-
   AutoSyncLoopHolder syncLoop(mWorkerPrivate, aFailStatus);
 
   mSyncLoopTarget = syncLoop.GetEventTarget();
@@ -590,11 +587,6 @@ WorkerMainThreadRunnable::Dispatch(Status aFailStatus, ErrorResult& aRv)
   if (!syncLoop.Run()) {
     aRv.ThrowUncatchableException();
   }
-
-  Telemetry::Accumulate(Telemetry::SYNC_WORKER_OPERATION, mTelemetryKey,
-                        static_cast<uint32_t>((TimeStamp::NowLoRes() - startTime)
-                                                .ToMilliseconds()));
-  Unused << startTime; // Shut the compiler up.
 }
 
 NS_IMETHODIMP

--- a/dom/xhr/XMLHttpRequestMainThread.cpp
+++ b/dom/xhr/XMLHttpRequestMainThread.cpp
@@ -757,15 +757,6 @@ XMLHttpRequestMainThread::SetResponseType(XMLHttpRequestResponseType aResponseTy
     return;
   }
 
-  // We want to get rid of this moz-only types. Bug 1335365.
-  if (aResponseType == XMLHttpRequestResponseType::Moz_blob) {
-    Telemetry::Accumulate(Telemetry::MOZ_BLOB_IN_XHR, 1);
-  } else if (aResponseType == XMLHttpRequestResponseType::Moz_chunked_text) {
-    Telemetry::Accumulate(Telemetry::MOZ_CHUNKED_TEXT_IN_XHR, 1);
-  } else if (aResponseType == XMLHttpRequestResponseType::Moz_chunked_arraybuffer) {
-    Telemetry::Accumulate(Telemetry::MOZ_CHUNKED_ARRAYBUFFER_IN_XHR, 1);
-  }
-
   // Set the responseType attribute's value to the given value.
   mResponseType = aResponseType;
 }
@@ -1520,8 +1511,6 @@ XMLHttpRequestMainThread::Open(const nsACString& aMethod,
       GetOwner()->GetExtantDoc()) {
     GetOwner()->GetExtantDoc()->WarnOnceAbout(nsIDocument::eSyncXMLHttpRequest);
   }
-
-  Telemetry::Accumulate(Telemetry::XMLHTTPREQUEST_ASYNC_OR_SYNC, aAsync ? 0 : 1);
 
   // Step 1
   nsCOMPtr<nsIDocument> responsibleDocument = GetDocumentIfCurrent();

--- a/dom/xhr/XMLHttpRequestWorker.cpp
+++ b/dom/xhr/XMLHttpRequestWorker.cpp
@@ -1588,8 +1588,6 @@ XMLHttpRequestWorker::Construct(const GlobalObject& aGlobal,
   WorkerPrivate* workerPrivate = GetWorkerPrivateFromContext(cx);
   MOZ_ASSERT(workerPrivate);
 
-  Telemetry::Accumulate(Telemetry::XHR_IN_WORKER, 1);
-
   RefPtr<XMLHttpRequestWorker> xhr = new XMLHttpRequestWorker(workerPrivate);
 
   if (workerPrivate->XHRParamsAllowed()) {

--- a/dom/xul/nsXULPrototypeCache.cpp
+++ b/dom/xul/nsXULPrototypeCache.cpp
@@ -45,12 +45,6 @@ UpdategDisableXULCache()
     // Get the value of "nglayout.debug.disable_xul_cache" preference
     gDisableXULCache =
         Preferences::GetBool(kDisableXULCachePref, gDisableXULCache);
-
-    // Sets the flag if the XUL cache is disabled
-    if (gDisableXULCache) {
-        Telemetry::Accumulate(Telemetry::XUL_CACHE_DISABLED, true);
-    }
-
 }
 
 static void

--- a/extensions/auth/nsAuthGSSAPI.cpp
+++ b/extensions/auth/nsAuthGSSAPI.cpp
@@ -22,7 +22,6 @@
 #include "nsIPrefBranch.h"
 #include "nsIServiceManager.h"
 #include "nsNativeCharsetUtils.h"
-#include "mozilla/Telemetry.h"
 
 #include "nsAuthGSSAPI.h"
 
@@ -376,16 +375,6 @@ nsAuthGSSAPI::Init(const char *serviceName,
 
     mServiceName = serviceName;
     mServiceFlags = serviceFlags;
-
-    static bool sTelemetrySent = false;
-    if (!sTelemetrySent) {
-        mozilla::Telemetry::Accumulate(
-            mozilla::Telemetry::NTLM_MODULE_USED_2,
-            serviceFlags & nsIAuthModule::REQ_PROXY_AUTH
-                ? NTLM_MODULE_KERBEROS_PROXY
-                : NTLM_MODULE_KERBEROS_DIRECT);
-        sTelemetrySent = true;
-    }
 
     return NS_OK;
 }

--- a/extensions/auth/nsAuthSSPI.cpp
+++ b/extensions/auth/nsAuthSSPI.cpp
@@ -20,7 +20,6 @@
 #include "nsNetCID.h"
 #include "nsCOMPtr.h"
 #include "nsICryptoHash.h"
-#include "mozilla/Telemetry.h"
 
 #include <windows.h>
 
@@ -274,16 +273,6 @@ nsAuthSSPI::Init(const char *serviceName,
                                            &useBefore);
     if (rc != SEC_E_OK)
         return NS_ERROR_UNEXPECTED;
-
-    static bool sTelemetrySent = false;
-    if (!sTelemetrySent) {
-        mozilla::Telemetry::Accumulate(
-            mozilla::Telemetry::NTLM_MODULE_USED_2,
-            serviceFlags & nsIAuthModule::REQ_PROXY_AUTH
-                ? NTLM_MODULE_WIN_API_PROXY
-                : NTLM_MODULE_WIN_API_DIRECT);
-        sTelemetrySent = true;
-    }
 
     LOG(("AcquireCredentialsHandle() succeeded.\n"));
     return NS_OK;

--- a/extensions/auth/nsAuthSambaNTLM.cpp
+++ b/extensions/auth/nsAuthSambaNTLM.cpp
@@ -9,7 +9,6 @@
 #include "prenv.h"
 #include "plbase64.h"
 #include "prerror.h"
-#include "mozilla/Telemetry.h"
 
 #include <stdlib.h>
 
@@ -212,17 +211,6 @@ nsAuthSambaNTLM::Init(const char *serviceName,
                       const char16_t *password)
 {
     NS_ASSERTION(!username && !domain && !password, "unexpected credentials");
-
-    static bool sTelemetrySent = false;
-    if (!sTelemetrySent) {
-        mozilla::Telemetry::Accumulate(
-            mozilla::Telemetry::NTLM_MODULE_USED_2,
-            serviceFlags & nsIAuthModule::REQ_PROXY_AUTH
-                ? NTLM_MODULE_SAMBA_AUTH_PROXY
-                : NTLM_MODULE_SAMBA_AUTH_DIRECT);
-        sTelemetrySent = true;
-    }
-
     return NS_OK;
 }
 

--- a/extensions/cookie/nsPermissionManager.cpp
+++ b/extensions/cookie/nsPermissionManager.cpp
@@ -866,9 +866,6 @@ nsPermissionManager::InitDB(bool aRemoveFile)
   if (rv == NS_ERROR_FILE_CORRUPTED) {
     LogToConsole(NS_LITERAL_STRING("permissions.sqlite is corrupted! Try again!"));
 
-    // Add telemetry probe
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::PERMISSIONS_SQL_CORRUPTED, 1);
-
     // delete corrupted permissions.sqlite and try again
     rv = permissionsFile->Remove(false);
     NS_ENSURE_SUCCESS(rv, rv);
@@ -890,9 +887,6 @@ nsPermissionManager::InitDB(bool aRemoveFile)
     rv = permissionsFile->Remove(false);
     NS_ENSURE_SUCCESS(rv, rv);
     LogToConsole(NS_LITERAL_STRING("Defective permissions.sqlite has been removed."));
-
-    // Add telemetry probe
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::DEFECTIVE_PERMISSIONS_SQL_REMOVED, 1);
 
     rv = OpenDatabase(permissionsFile);
     NS_ENSURE_SUCCESS(rv, rv);
@@ -1185,25 +1179,7 @@ nsPermissionManager::InitDB(bool aRemoveFile)
             if (NS_SUCCEEDED(rv) &&
                 NS_SUCCEEDED(countStmt->ExecuteStep(&hasResult)) &&
                 hasResult) {
-              int32_t permsCount = countStmt->AsInt32(0);
-
-              // The id variable contains the number of rows inserted into the
-              // moz_hosts_new table (as one ID was used per entry)
-              uint32_t telemetryValue;
-              if (permsCount > id) {
-                telemetryValue = 3; // NEW > OLD
-              } else if (permsCount == id) {
-                telemetryValue = 2; // NEW == OLD
-              } else if (permsCount == 0) {
-                telemetryValue = 0; // NEW = 0
-              } else {
-                telemetryValue = 1; // NEW < OLD
-              }
-
-              // Report the telemetry value to telemetry
-              mozilla::Telemetry::Accumulate(
-                  mozilla::Telemetry::PERMISSIONS_REMIGRATION_COMPARISON,
-                  telemetryValue);
+              // Telemetry STUB (count rows and report)
             } else {
               NS_WARNING("Could not count the rows in moz_perms");
             }
@@ -1221,9 +1197,6 @@ nsPermissionManager::InitDB(bool aRemoveFile)
 
           rv = mDBConn->CommitTransaction();
           NS_ENSURE_SUCCESS(rv, rv);
-
-          mozilla::Telemetry::Accumulate(mozilla::Telemetry::PERMISSIONS_MIGRATION_7_ERROR,
-                                         NS_WARN_IF(migrationError));
         } else {
           // We don't have a moz_hosts table, so we create one for downgrading purposes.
           // This table is empty.

--- a/gfx/gl/GLLibraryEGL.cpp
+++ b/gfx/gl/GLLibraryEGL.cpp
@@ -9,7 +9,6 @@
 #include "gfxUtils.h"
 #include "mozilla/Preferences.h"
 #include "mozilla/Assertions.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/Tokenizer.h"
 #include "mozilla/ScopeExit.h"
 #include "mozilla/Unused.h"
@@ -470,20 +469,6 @@ GLLibraryEGL::EnsureInitialized(bool forceAccel, nsACString* const out_failureId
         // Hardware accelerated ANGLE path (supported or force accel)
         if (shouldTryAccel) {
             chosenDisplay = GetAndInitDisplayForAccelANGLE(*this, out_failureId);
-        }
-
-        // Report the acceleration status to telemetry
-        if (!chosenDisplay) {
-            if (accelAngleFailureId.IsEmpty()) {
-                Telemetry::Accumulate(Telemetry::CANVAS_WEBGL_ACCL_FAILURE_ID,
-                                      NS_LITERAL_CSTRING("FEATURE_FAILURE_ACCL_ANGLE_UNKNOWN"));
-            } else {
-                Telemetry::Accumulate(Telemetry::CANVAS_WEBGL_ACCL_FAILURE_ID,
-                                      accelAngleFailureId);
-            }
-        } else {
-            Telemetry::Accumulate(Telemetry::CANVAS_WEBGL_ACCL_FAILURE_ID,
-                                  NS_LITERAL_CSTRING("SUCCESS"));
         }
 
         // Fallback to a WARP display if ANGLE fails, or if WARP is forced

--- a/gfx/ipc/GPUChild.cpp
+++ b/gfx/ipc/GPUChild.cpp
@@ -8,7 +8,6 @@
 #include "gfxPrefs.h"
 #include "GPUProcessHost.h"
 #include "GPUProcessManager.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/dom/CheckerboardReportService.h"
 #include "mozilla/gfx/gfxVars.h"
 #if defined(XP_WIN)
@@ -80,7 +79,6 @@ GPUChild::EnsureGPUReady()
   SendGetDeviceStatus(&data);
 
   gfxPlatform::GetPlatform()->ImportGPUDeviceData(data);
-  Telemetry::AccumulateTimeDelta(Telemetry::GPU_PROCESS_LAUNCH_TIME_MS, mHost->GetLaunchTime());
   mGPUReady = true;
 }
 
@@ -93,7 +91,6 @@ GPUChild::RecvInitComplete(const GPUDeviceData& aData)
   }
 
   gfxPlatform::GetPlatform()->ImportGPUDeviceData(aData);
-  Telemetry::AccumulateTimeDelta(Telemetry::GPU_PROCESS_LAUNCH_TIME_MS, mHost->GetLaunchTime());
   mGPUReady = true;
   return true;
 }
@@ -131,14 +128,14 @@ GPUChild::RecvNotifyUiObservers(const nsCString& aTopic)
 bool
 GPUChild::RecvAccumulateChildHistogram(InfallibleTArray<Accumulation>&& aAccumulations)
 {
-  Telemetry::AccumulateChild(GeckoProcessType_GPU, aAccumulations);
+  /* Telemetry STUB */
   return true;
 }
 
 bool
 GPUChild::RecvAccumulateChildKeyedHistogram(InfallibleTArray<KeyedAccumulation>&& aAccumulations)
 {
-  Telemetry::AccumulateChildKeyed(GeckoProcessType_GPU, aAccumulations);
+  /* Telemetry STUB */
   return true;
 }
 
@@ -152,11 +149,6 @@ GPUChild::RecvNotifyDeviceReset()
 void
 GPUChild::ActorDestroy(ActorDestroyReason aWhy)
 {
-  if (aWhy == AbnormalShutdown) {
-    Telemetry::Accumulate(Telemetry::SUBPROCESS_ABNORMAL_ABORT,
-        nsDependentCString(XRE_ChildProcessTypeToString(GeckoProcessType_GPU), 1));
-  }
-
   gfxVars::RemoveReceiver(this);
   mHost->OnChannelClosed();
 }

--- a/gfx/layers/Layers.cpp
+++ b/gfx/layers/Layers.cpp
@@ -22,7 +22,6 @@
 #include "gfxUtils.h"                   // for gfxUtils, etc
 #include "gfx2DGlue.h"
 #include "mozilla/DebugOnly.h"          // for DebugOnly
-#include "mozilla/Telemetry.h"          // for Accumulate
 #include "mozilla/ToString.h"
 #include "mozilla/dom/Animation.h"      // for ComputedTimingFunction
 #include "mozilla/gfx/2D.h"             // for DrawTarget
@@ -1621,8 +1620,6 @@ void
 LayerManager::PostPresent()
 {
   if (!mTabSwitchStart.IsNull()) {
-    Telemetry::Accumulate(Telemetry::FX_TAB_SWITCH_TOTAL_MS,
-                          uint32_t((TimeStamp::Now() - mTabSwitchStart).ToMilliseconds()));
     mTabSwitchStart = TimeStamp();
   }
 }

--- a/gfx/layers/apz/src/AsyncPanZoomController.cpp
+++ b/gfx/layers/apz/src/AsyncPanZoomController.cpp
@@ -904,9 +904,6 @@ nsEventStatus AsyncPanZoomController::HandleDragEvent(const MouseInput& aEvent,
     return nsEventStatus_eConsumeNoDefault;
   }
 
-  mozilla::Telemetry::Accumulate(mozilla::Telemetry::SCROLL_INPUT_METHODS,
-      (uint32_t) ScrollInputMethod::ApzScrollbarDrag);
-
   ReentrantMonitorAutoEnter lock(mMonitor);
   CSSPoint scrollFramePoint = aEvent.mLocalOrigin / GetFrameMetrics().GetZoom();
   // The scrollbar can be transformed with the frame but the pres shell
@@ -1731,10 +1728,6 @@ nsEventStatus AsyncPanZoomController::OnScrollWheel(const ScrollWheelInput& aEve
     return nsEventStatus_eIgnore;
   }
 
-  mozilla::Telemetry::Accumulate(mozilla::Telemetry::SCROLL_INPUT_METHODS,
-      (uint32_t) ScrollInputMethodForWheelDeltaType(aEvent.mDeltaType));
-
-
   switch (aEvent.mScrollMode) {
     case ScrollWheelInput::SCROLLMODE_INSTANT: {
 
@@ -1933,9 +1926,6 @@ nsEventStatus AsyncPanZoomController::OnPan(const PanGestureInput& aEvent, bool 
   mY.UpdateWithTouchAtDevicePoint(aEvent.mLocalPanStartPoint.y, logicalPanDisplacement.y, aEvent.mTime);
 
   HandlePanningUpdate(physicalPanDisplacement);
-
-  mozilla::Telemetry::Accumulate(mozilla::Telemetry::SCROLL_INPUT_METHODS,
-      (uint32_t) ScrollInputMethod::ApzPanGesture);
 
   ScreenPoint panDistance(fabs(physicalPanDisplacement.x), fabs(physicalPanDisplacement.y));
   MOZ_ASSERT(GetCurrentPanGestureBlock());
@@ -2600,8 +2590,6 @@ void AsyncPanZoomController::TrackTouch(const MultiTouchInput& aEvent) {
   UpdateWithTouchAtDevicePoint(aEvent);
 
   if (prevTouchPoint != touchPoint) {
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::SCROLL_INPUT_METHODS,
-        (uint32_t) ScrollInputMethod::ApzTouch);
     MOZ_ASSERT(GetCurrentTouchBlock());
     OverscrollHandoffState handoffState(
         *GetCurrentTouchBlock()->GetOverscrollHandoffChain(),
@@ -3260,14 +3248,7 @@ AsyncPanZoomController::UpdateCheckerboardEvent(const MutexAutoLock& aProofOfLoc
                                                 uint32_t aMagnitude)
 {
   if (mCheckerboardEvent && mCheckerboardEvent->RecordFrameInfo(aMagnitude)) {
-    // This checkerboard event is done. Report some metrics to telemetry.
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::CHECKERBOARD_SEVERITY,
-      mCheckerboardEvent->GetSeverity());
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::CHECKERBOARD_PEAK,
-      mCheckerboardEvent->GetPeak());
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::CHECKERBOARD_DURATION,
-      (uint32_t)mCheckerboardEvent->GetDuration().ToMilliseconds());
-
+    // This checkerboard event is done.
     mPotentialCheckerboardTracker.CheckerboardDone();
 
     if (gfxPrefs::APZRecordCheckerboarding()) {

--- a/gfx/layers/apz/src/InputBlockState.cpp
+++ b/gfx/layers/apz/src/InputBlockState.cpp
@@ -10,7 +10,6 @@
 #include "gfxPrefs.h"                       // for gfxPrefs
 #include "mozilla/MouseEvents.h"
 #include "mozilla/SizePrintfMacros.h"       // for PRIuSIZE
-#include "mozilla/Telemetry.h"              // for Telemetry
 #include "mozilla/layers/APZCTreeManager.h" // for AllowedTouchBehavior
 #include "OverscrollHandoffState.h"
 #include "QueuedInput.h"
@@ -246,8 +245,6 @@ CancelableBlockState::RecordContentResponseTime()
     // Not done yet, we'll get called again
     return;
   }
-  mozilla::Telemetry::Accumulate(mozilla::Telemetry::CONTENT_RESPONSE_DURATION,
-    (uint32_t)(TimeStamp::Now() - mContentResponseTimer).ToMilliseconds());
   mContentResponseTimer = TimeStamp();
 }
 

--- a/gfx/layers/apz/src/PotentialCheckerboardDurationTracker.cpp
+++ b/gfx/layers/apz/src/PotentialCheckerboardDurationTracker.cpp
@@ -33,9 +33,7 @@ PotentialCheckerboardDurationTracker::CheckerboardDone()
   MOZ_ASSERT(Tracking());
   mInCheckerboard = false;
   if (!Tracking()) {
-    mozilla::Telemetry::AccumulateTimeDelta(
-        mozilla::Telemetry::CHECKERBOARD_POTENTIAL_DURATION,
-        mCurrentPeriodStart);
+    /* Telemetry STUB */
   }
 }
 
@@ -63,9 +61,7 @@ PotentialCheckerboardDurationTracker::InTransform(bool aInTransform)
     // would have taken the other !Tracking branch above. If it's false now,
     // it means we just stopped tracking, so we are ending a potential
     // checkerboard period.
-    mozilla::Telemetry::AccumulateTimeDelta(
-        mozilla::Telemetry::CHECKERBOARD_POTENTIAL_DURATION,
-        mCurrentPeriodStart);
+    /* Telemetry STUB */
   }
 }
 

--- a/gfx/layers/ipc/CompositorBridgeParent.cpp
+++ b/gfx/layers/ipc/CompositorBridgeParent.cpp
@@ -484,8 +484,6 @@ CompositorVsyncScheduler::Composite(TimeStamp aVsyncTimestamp)
     mVsyncNotificationsSkipped = 0;
 
     TimeDuration compositeFrameTotal = TimeStamp::Now() - aVsyncTimestamp;
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::COMPOSITE_FRAME_ROUNDTRIP_TIME,
-                                   compositeFrameTotal.ToMilliseconds());
   } else if (mVsyncNotificationsSkipped++ > gfxPrefs::CompositorUnobserveCount()) {
     UnobserveVsync();
   }
@@ -1305,7 +1303,6 @@ CompositorBridgeParent::CompositeToTarget(DrawTarget* aTarget, const gfx::IntRec
   }
   mCompositor->SetCompositionTime(TimeStamp());
 
-  mozilla::Telemetry::AccumulateTimeDelta(mozilla::Telemetry::COMPOSITE_TIME, start);
   profiler_tracing("Paint", "Composite", TRACING_INTERVAL_END);
 }
 
@@ -1660,19 +1657,6 @@ CompositorBridgeParent::NewCompositor(const nsTArray<LayersBackend>& aBackendHin
         failureReason = "SUCCESS";
       }
 
-      // should only report success here
-      if (aBackendHints[i] == LayersBackend::LAYERS_OPENGL){
-        Telemetry::Accumulate(Telemetry::OPENGL_COMPOSITING_FAILURE_ID, failureReason);
-      }
-#ifdef XP_WIN
-      else if (aBackendHints[i] == LayersBackend::LAYERS_D3D9){
-        Telemetry::Accumulate(Telemetry::D3D9_COMPOSITING_FAILURE_ID, failureReason);
-      }
-      else if (aBackendHints[i] == LayersBackend::LAYERS_D3D11){
-        Telemetry::Accumulate(Telemetry::D3D11_COMPOSITING_FAILURE_ID, failureReason);
-      }
-#endif
-
       compositor->SetCompositorID(mCompositorID);
       return compositor;
     }
@@ -1681,18 +1665,15 @@ CompositorBridgeParent::NewCompositor(const nsTArray<LayersBackend>& aBackendHin
     if (aBackendHints[i] == LayersBackend::LAYERS_OPENGL){
       gfxCriticalNote << "[OPENGL] Failed to init compositor with reason: "
                       << failureReason.get();
-      Telemetry::Accumulate(Telemetry::OPENGL_COMPOSITING_FAILURE_ID, failureReason);
     }
 #ifdef XP_WIN
     else if (aBackendHints[i] == LayersBackend::LAYERS_D3D9){
       gfxCriticalNote << "[D3D9] Failed to init compositor with reason: "
                       << failureReason.get();
-      Telemetry::Accumulate(Telemetry::D3D9_COMPOSITING_FAILURE_ID, failureReason);
     }
     else if (aBackendHints[i] == LayersBackend::LAYERS_D3D11){
       gfxCriticalNote << "[D3D11] Failed to init compositor with reason: "
                       << failureReason.get();
-      Telemetry::Accumulate(Telemetry::D3D11_COMPOSITING_FAILURE_ID, failureReason);
     }
 #endif
   }

--- a/gfx/src/DriverCrashGuard.cpp
+++ b/gfx/src/DriverCrashGuard.cpp
@@ -11,7 +11,6 @@
 #include "nsString.h"
 #include "nsXULAppAPI.h"
 #include "mozilla/Preferences.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/Services.h"
 #include "mozilla/gfx/Logging.h"
 #include "mozilla/dom/ContentChild.h"
@@ -469,20 +468,7 @@ D3D11LayersCrashGuard::LogFeatureDisabled()
 void
 D3D11LayersCrashGuard::RecordTelemetry(TelemetryState aState)
 {
-  // D3D11LayersCrashGuard is a no-op in the child process.
-  if (!XRE_IsParentProcess()) {
-    return;
-  }
-
-  // Since we instantiate this class more than once, make sure we only record
-  // the first state (since that is really all we care about).
-  static bool sTelemetryStateRecorded = false;
-  if (sTelemetryStateRecorded) {
-    return;
-  }
-
-  Telemetry::Accumulate(Telemetry::GRAPHICS_DRIVER_STARTUP_TEST, int32_t(aState));
-  sTelemetryStateRecorded = true;
+  /* STUB */
 }
 
 D3D9VideoCrashGuard::D3D9VideoCrashGuard(dom::ContentParent* aContentParent)

--- a/gfx/thebes/DeviceManagerDx.cpp
+++ b/gfx/thebes/DeviceManagerDx.cpp
@@ -10,7 +10,6 @@
 #include "gfxPrefs.h"
 #include "gfxWindowsPlatform.h"
 #include "mozilla/D3DMessageUtils.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/WindowsVersion.h"
 #include "mozilla/gfx/GraphicsMessages.h"
 #include "mozilla/gfx/Logging.h"
@@ -589,10 +588,6 @@ DeviceManagerDx::MaybeResetAndReacquireDevices()
     return false;
   }
 
-  if (resetReason != DeviceResetReason::FORCED_RESET) {
-    Telemetry::Accumulate(Telemetry::DEVICE_RESET_REASON, uint32_t(resetReason));
-  }
-
   bool createCompositorDevice = !!mCompositorDevice;
   bool createContentDevice = !!mContentDevice;
 
@@ -724,7 +719,6 @@ DeviceManagerDx::GetAnyDeviceRemovedReason(DeviceResetReason* aOutReason)
 void
 DeviceManagerDx::ForceDeviceReset(ForcedDeviceResetReason aReason)
 {
-  Telemetry::Accumulate(Telemetry::FORCED_DEVICE_RESET_REASON, uint32_t(aReason));
   {
     MutexAutoLock lock(mDeviceLock);
     mDeviceResetReason = Some(DeviceResetReason::FORCED_RESET);

--- a/gfx/thebes/gfxDWriteFontList.cpp
+++ b/gfx/thebes/gfxDWriteFontList.cpp
@@ -14,7 +14,6 @@
 #include "nsCharSeparatedTokenizer.h"
 #include "mozilla/Preferences.h"
 #include "mozilla/Sprintf.h"
-#include "mozilla/Telemetry.h"
 #include "nsDirectoryServiceUtils.h"
 #include "nsDirectoryServiceDefs.h"
 #include "nsAppDirectoryServiceDefs.h"
@@ -864,8 +863,6 @@ gfxDWriteFontList::InitFontListForPlatform()
     hr = gfxWindowsPlatform::GetPlatform()->GetDWriteFactory()->
         GetGdiInterop(getter_AddRefs(mGDIInterop));
     if (FAILED(hr)) {
-        Telemetry::Accumulate(Telemetry::DWRITEFONT_INIT_PROBLEM,
-                              uint32_t(errGDIInterop));
         return NS_ERROR_FAILURE;
     }
 
@@ -878,8 +875,6 @@ gfxDWriteFontList::InitFontListForPlatform()
     NS_ASSERTION(SUCCEEDED(hr), "GetSystemFontCollection failed!");
 
     if (FAILED(hr)) {
-        Telemetry::Accumulate(Telemetry::DWRITEFONT_INIT_PROBLEM,
-                              uint32_t(errSystemFontCollection));
         return NS_ERROR_FAILURE;
     }
 
@@ -891,8 +886,6 @@ gfxDWriteFontList::InitFontListForPlatform()
     NS_ASSERTION(mFontFamilies.Count() != 0,
                  "no fonts found in the system fontlist -- holy crap batman!");
     if (mFontFamilies.Count() == 0) {
-        Telemetry::Accumulate(Telemetry::DWRITEFONT_INIT_PROBLEM,
-                              uint32_t(errNoFonts));
         return NS_ERROR_FAILURE;
     }
 
@@ -1001,9 +994,6 @@ gfxDWriteFontList::InitFontListForPlatform()
     }
 
     elapsedTime = (t5.QuadPart - t1.QuadPart) * 1000.0 / frequency.QuadPart;
-    Telemetry::Accumulate(Telemetry::DWRITEFONT_DELAYEDINITFONTLIST_TOTAL, elapsedTime);
-    Telemetry::Accumulate(Telemetry::DWRITEFONT_DELAYEDINITFONTLIST_COUNT,
-                          mSystemFonts->GetFontFamilyCount());
     LOG_FONTINIT((
        "(fontinit) Total time in InitFontList:    %9.3f ms (families: %d, %s)\n",
        elapsedTime, mSystemFonts->GetFontFamilyCount(),
@@ -1013,7 +1003,6 @@ gfxDWriteFontList::InitFontListForPlatform()
     LOG_FONTINIT(("(fontinit)  --- base/interop obj initialization init: %9.3f ms\n", elapsedTime));
 
     elapsedTime = (t3.QuadPart - t2.QuadPart) * 1000.0 / frequency.QuadPart;
-    Telemetry::Accumulate(Telemetry::DWRITEFONT_DELAYEDINITFONTLIST_COLLECT, elapsedTime);
     LOG_FONTINIT(("(fontinit)  --- GetSystemFontCollection:  %9.3f ms\n", elapsedTime));
 
     elapsedTime = (t4.QuadPart - t3.QuadPart) * 1000.0 / frequency.QuadPart;
@@ -1455,7 +1444,6 @@ gfxDWriteFontList::PlatformGlobalFontFallback(const uint32_t aCh,
             *aMatchedFamily = family;
             return fontEntry;
         }
-        Telemetry::Accumulate(Telemetry::BAD_FALLBACK_FONT, true);
     }
 
     return nullptr;

--- a/gfx/thebes/gfxFont.cpp
+++ b/gfx/thebes/gfxFont.cpp
@@ -229,7 +229,6 @@ gfxFontCache::Lookup(const gfxFontEntry* aFontEntry,
     Key key(aFontEntry, aStyle, aUnicodeRangeMap);
     HashEntry *entry = mFonts.GetEntry(key);
 
-    Telemetry::Accumulate(Telemetry::FONT_CACHE_HIT, entry != nullptr);
     if (!entry)
         return nullptr;
 
@@ -2578,9 +2577,6 @@ gfxFont::GetShapedWord(DrawTarget *aDrawTarget,
 
     if (sw) {
         sw->ResetAge();
-        Telemetry::Accumulate((isContent ? Telemetry::WORD_CACHE_HITS_CONTENT :
-                                   Telemetry::WORD_CACHE_HITS_CHROME),
-                              aLength);
 #ifndef RELEASE_OR_BETA
         if (aTextPerf) {
             aTextPerf->current.wordCacheHit++;
@@ -2589,9 +2585,6 @@ gfxFont::GetShapedWord(DrawTarget *aDrawTarget,
         return sw;
     }
 
-    Telemetry::Accumulate((isContent ? Telemetry::WORD_CACHE_MISSES_CONTENT :
-                               Telemetry::WORD_CACHE_MISSES_CHROME),
-                          aLength);
 #ifndef RELEASE_OR_BETA
     if (aTextPerf) {
         aTextPerf->current.wordCacheMiss++;

--- a/gfx/thebes/gfxGradientCache.cpp
+++ b/gfx/thebes/gfxGradientCache.cpp
@@ -8,7 +8,6 @@
 #include "PLDHashTable.h"
 #include "nsExpirationTracker.h"
 #include "nsClassHashtable.h"
-#include "mozilla/Telemetry.h"
 #include "gfxGradientCache.h"
 #include <time.h>
 
@@ -127,7 +126,6 @@ class GradientCache final : public nsExpirationTracker<GradientCacheData,4>
     {
       srand(time(nullptr));
       mTimerPeriod = rand() % MAX_GENERATION_MS + 1;
-      Telemetry::Accumulate(Telemetry::GRADIENT_RETENTION_TIME, mTimerPeriod);
     }
 
     virtual void NotifyExpired(GradientCacheData* aObject)

--- a/gfx/thebes/gfxMacPlatformFontList.mm
+++ b/gfx/thebes/gfxMacPlatformFontList.mm
@@ -65,7 +65,6 @@
 #include "mozilla/MemoryReporting.h"
 #include "mozilla/Preferences.h"
 #include "mozilla/Sprintf.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/gfx/2D.h"
 
 #include <unistd.h>
@@ -1041,10 +1040,6 @@ gfxMacPlatformFontList::PlatformGlobalFontFallback(const uint32_t aCh,
         if (familyNameRef) {
             ::CFRelease(familyNameRef);
         }
-    }
-
-    if (cantUseFallbackFont) {
-        Telemetry::Accumulate(Telemetry::BAD_FALLBACK_FONT, cantUseFallbackFont);
     }
 
     ::CFRelease(str);

--- a/gfx/thebes/gfxPlatform.cpp
+++ b/gfx/thebes/gfxPlatform.cpp
@@ -361,7 +361,6 @@ class CrashTelemetryEvent : public Runnable
 
   NS_IMETHOD Run() override {
     MOZ_ASSERT(NS_IsMainThread());
-    Telemetry::Accumulate(Telemetry::GFX_CRASH, mReason);
     return NS_OK;
   }
 
@@ -374,29 +373,7 @@ NS_IMPL_ISUPPORTS_INHERITED0(CrashTelemetryEvent, Runnable);
 void
 CrashStatsLogForwarder::CrashAction(LogReason aReason)
 {
-#ifndef RELEASE_OR_BETA
-  // Non-release builds crash by default, but will use telemetry
-  // if this environment variable is present.
-  static bool useTelemetry = gfxEnv::GfxDevCrashTelemetry();
-#else
-  // Release builds use telemetry by default, but will crash instead
-  // if this environment variable is present.
-  static bool useTelemetry = !gfxEnv::GfxDevCrashMozCrash();
-#endif
-
-  if (useTelemetry) {
-    // The callers need to assure that aReason is in the range
-    // that the telemetry call below supports.
-    if (NS_IsMainThread()) {
-      Telemetry::Accumulate(Telemetry::GFX_CRASH, (uint32_t)aReason);
-    } else {
-      nsCOMPtr<nsIRunnable> r1 = new CrashTelemetryEvent((uint32_t)aReason);
-      NS_DispatchToMainThread(r1);
-    }
-  } else {
-    // ignoring aReason, we can get the information we need from the stack
-    MOZ_CRASH("GFX_CRASH");
-  }
+  MOZ_CRASH("GFX_CRASH");
 }
 
 NS_IMPL_ISUPPORTS(SRGBOverrideObserver, nsIObserver, nsISupportsWeakReference)

--- a/gfx/thebes/gfxPlatformFontList.cpp
+++ b/gfx/thebes/gfxPlatformFontList.cpp
@@ -322,8 +322,6 @@ gfxPlatformFontList::InitOtherFamilyNames()
         mOtherFamilyNamesInitialized = true;
     }
     TimeStamp end = TimeStamp::Now();
-    Telemetry::AccumulateTimeDelta(Telemetry::FONTLIST_INITOTHERFAMILYNAMES,
-                                   start, end);
 
     if (LOG_FONTINIT_ENABLED()) {
         TimeDuration elapsed = end - start;
@@ -370,8 +368,6 @@ gfxPlatformFontList::SearchFamiliesForFaceName(const nsAString& aFaceName)
     lookup = FindFaceName(aFaceName);
 
     TimeStamp end = TimeStamp::Now();
-    Telemetry::AccumulateTimeDelta(Telemetry::FONTLIST_INITFACENAMELISTS,
-                                   start, end);
     if (LOG_FONTINIT_ENABLED()) {
         TimeDuration elapsed = end - start;
         LOG_FONTINIT(("(fontinit) SearchFamiliesForFaceName took %8.2f ms %s %s",
@@ -587,15 +583,7 @@ gfxPlatformFontList::SystemFindFontForChar(uint32_t aCh, uint32_t aNextCh,
     static bool first = true;
     int32_t intElapsed = int32_t(first ? elapsed.ToMilliseconds() :
                                          elapsed.ToMicroseconds());
-    Telemetry::Accumulate((first ? Telemetry::SYSTEM_FONT_FALLBACK_FIRST :
-                                   Telemetry::SYSTEM_FONT_FALLBACK),
-                          intElapsed);
     first = false;
-
-    // track the script for which fallback occurred (incremented one make it
-    // 1-based)
-    Telemetry::Accumulate(Telemetry::SYSTEM_FONT_FALLBACK_SCRIPT,
-                          int(aRunScript) + 1);
 
     return fontEntry;
 }

--- a/gfx/thebes/gfxUserFontSet.cpp
+++ b/gfx/thebes/gfxUserFontSet.cpp
@@ -453,8 +453,6 @@ gfxUserFontEntry::LoadNextSrc()
                                   gfxUserFontData::kUnknownCompression);
                 mPlatformFontEntry = fe;
                 SetLoadState(STATUS_LOADED);
-                Telemetry::Accumulate(Telemetry::WEBFONT_SRCTYPE,
-                                      currSrc.mSourceType + 1);
                 return;
             } else {
                 LOG(("userfonts (%p) [src %d] failed local: (%s) for (%s)\n",
@@ -517,8 +515,6 @@ gfxUserFontEntry::LoadNextSrc()
                         if (NS_SUCCEEDED(rv) &&
                             LoadPlatformFont(buffer, bufferLength)) {
                             SetLoadState(STATUS_LOADED);
-                            Telemetry::Accumulate(Telemetry::WEBFONT_SRCTYPE,
-                                                  currSrc.mSourceType + 1);
                             return;
                         } else {
                             mFontSet->LogMessage(this,
@@ -572,8 +568,6 @@ gfxUserFontEntry::LoadNextSrc()
                 // LoadPlatformFont takes ownership of the buffer, so no need
                 // to free it here.
                 SetLoadState(STATUS_LOADED);
-                Telemetry::Accumulate(Telemetry::WEBFONT_SRCTYPE,
-                                      currSrc.mSourceType + 1);
                 return;
             } else {
                 mFontSet->LogMessage(this,
@@ -617,7 +611,6 @@ gfxUserFontEntry::LoadPlatformFont(const uint8_t* aFontData, uint32_t& aLength)
 
     gfxUserFontType fontType =
         gfxFontUtils::DetermineFontDataType(aFontData, aLength);
-    Telemetry::Accumulate(Telemetry::WEBFONT_FONTTYPE, uint32_t(fontType));
 
     // Unwrap/decompress/sanitize or otherwise munge the downloaded data
     // to make a usable sfnt structure.
@@ -650,13 +643,6 @@ gfxUserFontEntry::LoadPlatformFont(const uint8_t* aFontData, uint32_t& aLength)
     if (saneData) {
         if (saneLen) {
             fontCompressionRatio = uint32_t(100.0 * aLength / saneLen + 0.5);
-            if (fontType == GFX_USERFONT_WOFF ||
-                fontType == GFX_USERFONT_WOFF2) {
-                Telemetry::Accumulate(fontType == GFX_USERFONT_WOFF ?
-                                      Telemetry::WEBFONT_COMPRESSION_WOFF :
-                                      Telemetry::WEBFONT_COMPRESSION_WOFF2,
-                                      fontCompressionRatio);
-                }
         }
 
         // The sanitizer ensures that we have a valid sfnt and a usable

--- a/gfx/thebes/gfxWindowsPlatform.cpp
+++ b/gfx/thebes/gfxWindowsPlatform.cpp
@@ -430,10 +430,6 @@ gfxWindowsPlatform::HandleDeviceReset()
     return false;
   }
 
-  if (resetReason != DeviceResetReason::FORCED_RESET) {
-    Telemetry::Accumulate(Telemetry::DEVICE_RESET_REASON, uint32_t(resetReason));
-  }
-
   // Remove devices and adapters.
   DeviceManagerDx::Get()->ResetDevices();
 
@@ -1442,15 +1438,7 @@ gfxWindowsPlatform::InitializeD3D11Config()
 /* static */ void
 gfxWindowsPlatform::RecordContentDeviceFailure(TelemetryDeviceCode aDevice)
 {
-  // If the parent process fails to acquire a device, we record this
-  // normally as part of the environment. The exceptional case we're
-  // looking for here is when the parent process successfully acquires
-  // a device, but the content process fails to acquire the same device.
-  // This would not normally be displayed in about:support.
-  if (!XRE_IsContentProcess()) {
-    return;
-  }
-  Telemetry::Accumulate(Telemetry::GFX_CONTENT_FAILED_TO_ACQUIRE_DEVICE, uint32_t(aDevice));
+  /* STUB */
 }
 
 void

--- a/image/imgFrame.cpp
+++ b/image/imgFrame.cpp
@@ -22,7 +22,6 @@
 #include "mozilla/gfx/Tools.h"
 #include "mozilla/Likely.h"
 #include "mozilla/MemoryReporting.h"
-#include "mozilla/Telemetry.h"
 #include "nsMargin.h"
 #include "nsThreadUtils.h"
 
@@ -620,8 +619,6 @@ imgFrame::Finish(Opacity aFrameOpacity /* = Opacity::SOME_TRANSPARENCY */,
 
   if (aFrameOpacity == Opacity::FULLY_OPAQUE) {
     mHasNoAlpha = true;
-    Telemetry::Accumulate(Telemetry::IMAGE_DECODE_OPAQUE_BGRA,
-                          mFormat == SurfaceFormat::B8G8R8A8);
   }
 
   mDisposalMethod = aDisposalMethod;

--- a/intl/uconv/ucvja/nsJapaneseToUnicode.h
+++ b/intl/uconv/ucvja/nsJapaneseToUnicode.h
@@ -83,8 +83,6 @@ public:
         mGB2312Decoder = nullptr;
         mEUCKRDecoder = nullptr;
         mISO88597Decoder = nullptr;
-        mozilla::Telemetry::Accumulate(
-          mozilla::Telemetry::DECODER_INSTANTIATED_ISO2022JP, true);
      }
  virtual ~nsISO2022JPToUnicodeV2()
      {

--- a/intl/uconv/ucvlatin/nsCP866ToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsCP866ToUnicode.cpp
@@ -20,7 +20,6 @@ nsCP866ToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "cp866.ut"
   };
 
-  Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_IBM866, true);
   return CreateOneByteDecoder((uMappingTable*) &g_utMappingTable,
                               aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsISO88595ToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsISO88595ToUnicode.cpp
@@ -20,7 +20,6 @@ nsISO88595ToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "8859-5.ut"
   };
 
-  Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_ISO_8859_5, true);
   return CreateOneByteDecoder((uMappingTable*) &g_utMappingTable,
                               aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsKOI8RToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsKOI8RToUnicode.cpp
@@ -5,7 +5,6 @@
 
 #include "nsUCConstructors.h"
 #include "nsKOI8RToUnicode.h"
-#include "mozilla/Telemetry.h"
 
 using namespace mozilla;
 
@@ -20,7 +19,6 @@ nsKOI8RToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "koi8r.ut"
   };
 
-  Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_KOI8R, true);
   return CreateOneByteDecoder((uMappingTable*) &g_utMappingTable,
                               aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsKOI8UToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsKOI8UToUnicode.cpp
@@ -20,7 +20,6 @@ nsKOI8UToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "koi8u.ut"
   };
 
-  Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_KOI8U, true);
   return CreateOneByteDecoder((uMappingTable*) &g_utMappingTable,
                               aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsMacArabicToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsMacArabicToUnicode.cpp
@@ -5,7 +5,6 @@
 
 #include "nsUCConstructors.h"
 #include "nsMacArabicToUnicode.h"
-#include "mozilla/Telemetry.h"
 
 using namespace mozilla;
 
@@ -20,7 +19,6 @@ nsMacArabicToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "macarabic.ut"
    };
 
-   Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_MACARABIC, true);
    return CreateOneByteDecoder((uMappingTable*) &g_utMappingTable,
                                aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsMacCEToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsMacCEToUnicode.cpp
@@ -20,7 +20,6 @@ nsMacCEToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "macce.ut"
   };
 
-  Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_MACCE, true);
   return CreateOneByteDecoder((uMappingTable*) &g_MacCEMappingTable,
                             aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsMacCroatianToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsMacCroatianToUnicode.cpp
@@ -5,7 +5,6 @@
 
 #include "nsUCConstructors.h"
 #include "nsMacCroatianToUnicode.h"
-#include "mozilla/Telemetry.h"
 
 using namespace mozilla;
 
@@ -20,7 +19,6 @@ nsMacCroatianToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "maccroat.ut"
   };
 
-  Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_MACCROATIAN, true);
   return CreateOneByteDecoder((uMappingTable*) &g_utMappingTable,
                               aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsMacCyrillicToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsMacCyrillicToUnicode.cpp
@@ -5,7 +5,6 @@
 
 #include "nsUCConstructors.h"
 #include "nsMacCyrillicToUnicode.h"
-#include "mozilla/Telemetry.h"
 
 using namespace mozilla;
 
@@ -20,7 +19,6 @@ nsMacCyrillicToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "maccyril.ut"
   };
 
-  Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_MACCYRILLIC, true);
   return CreateOneByteDecoder((uMappingTable*) &g_utMappingTable,
                               aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsMacDevanagariToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsMacDevanagariToUnicode.cpp
@@ -5,7 +5,6 @@
 
 #include "nsUCConstructors.h"
 #include "nsMacDevanagariToUnicode.h"
-#include "mozilla/Telemetry.h"
 
 using namespace mozilla;
 
@@ -20,7 +19,6 @@ nsMacDevanagariToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "macdevanaga.ut"
    };
 
-   Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_MACDEVANAGARI, true);
    return CreateOneByteDecoder((uMappingTable*) &g_utMappingTable,
                                aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsMacFarsiToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsMacFarsiToUnicode.cpp
@@ -5,7 +5,6 @@
 
 #include "nsUCConstructors.h"
 #include "nsMacFarsiToUnicode.h"
-#include "mozilla/Telemetry.h"
 
 using namespace mozilla;
 
@@ -20,7 +19,6 @@ nsMacFarsiToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "macfarsi.ut"
    };
 
-   Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_MACFARSI, true);
    return CreateOneByteDecoder((uMappingTable*) &g_utMappingTable,
                                aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsMacGreekToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsMacGreekToUnicode.cpp
@@ -5,7 +5,6 @@
 
 #include "nsUCConstructors.h"
 #include "nsMacGreekToUnicode.h"
-#include "mozilla/Telemetry.h"
 
 using namespace mozilla;
 
@@ -20,7 +19,6 @@ nsMacGreekToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "macgreek.ut"
   };
 
-  Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_MACGREEK, true);
   return CreateOneByteDecoder((uMappingTable*) &g_MacGreekMappingTable,
                             aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsMacGujaratiToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsMacGujaratiToUnicode.cpp
@@ -17,7 +17,6 @@ nsMacGujaratiToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "macgujarati.ut"
    };
 
-   Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_MACGUJARATI, true);
    return CreateOneByteDecoder((uMappingTable*) &g_utMappingTable,
                                aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsMacGurmukhiToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsMacGurmukhiToUnicode.cpp
@@ -5,7 +5,6 @@
 
 #include "nsUCConstructors.h"
 #include "nsMacGurmukhiToUnicode.h"
-#include "mozilla/Telemetry.h"
 
 using namespace mozilla;
 
@@ -20,7 +19,6 @@ nsMacGurmukhiToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "macgurmukhi.ut"
    };
 
-   Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_MACGURMUKHI, true);
    return CreateOneByteDecoder((uMappingTable*) &g_utMappingTable,
                                aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsMacHebrewToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsMacHebrewToUnicode.cpp
@@ -5,7 +5,6 @@
 
 #include "nsUCConstructors.h"
 #include "nsMacHebrewToUnicode.h"
-#include "mozilla/Telemetry.h"
 
 using namespace mozilla;
 
@@ -20,7 +19,6 @@ nsMacHebrewToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "machebrew.ut"
    };
 
-   Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_MACHEBREW, true);
    return CreateOneByteDecoder((uMappingTable*) &g_utMappingTable,
                                aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsMacIcelandicToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsMacIcelandicToUnicode.cpp
@@ -5,7 +5,6 @@
 
 #include "nsUCConstructors.h"
 #include "nsMacIcelandicToUnicode.h"
-#include "mozilla/Telemetry.h"
 
 using namespace mozilla;
 
@@ -20,7 +19,6 @@ nsMacIcelandicToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "macicela.ut"
   };
 
-  Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_MACICELANDIC, true);
   return CreateOneByteDecoder((uMappingTable*) &g_utMappingTable,
                               aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsMacRomanianToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsMacRomanianToUnicode.cpp
@@ -5,7 +5,6 @@
 
 #include "nsUCConstructors.h"
 #include "nsMacRomanianToUnicode.h"
-#include "mozilla/Telemetry.h"
 
 using namespace mozilla;
 
@@ -20,7 +19,6 @@ nsMacRomanianToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "macro.ut"
   };
 
-  Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_MACROMANIAN, true);
   return CreateOneByteDecoder((uMappingTable*) &g_utMappingTable,
                               aOuter, aIID, aResult);
 }

--- a/intl/uconv/ucvlatin/nsMacTurkishToUnicode.cpp
+++ b/intl/uconv/ucvlatin/nsMacTurkishToUnicode.cpp
@@ -5,7 +5,6 @@
 
 #include "nsUCConstructors.h"
 #include "nsMacTurkishToUnicode.h"
-#include "mozilla/Telemetry.h"
 
 using namespace mozilla;
 
@@ -20,7 +19,6 @@ nsMacTurkishToUnicodeConstructor(nsISupports *aOuter, REFNSIID aIID,
 #include "macturki.ut"
   };
 
-  Telemetry::Accumulate(Telemetry::DECODER_INSTANTIATED_MACTURKISH, true);
   return CreateOneByteDecoder((uMappingTable*) &g_MacTurkishMappingTable,
                             aOuter, aIID, aResult);
 }

--- a/ipc/glue/GeckoChildProcessHost.cpp
+++ b/ipc/glue/GeckoChildProcessHost.cpp
@@ -32,7 +32,6 @@
 #include "mozilla/ClearOnShutdown.h"
 #include "mozilla/ipc/BrowserProcessSubThread.h"
 #include "mozilla/Omnijar.h"
-#include "mozilla/Telemetry.h"
 #include "ProtocolUtils.h"
 #include <sys/stat.h>
 
@@ -534,8 +533,6 @@ GeckoChildProcessHost::RunPerformAsyncLaunch(std::vector<std::string> aExtraOpts
     lock.Notify();
     CHROMIUM_LOG(ERROR) << "Failed to launch " <<
       XRE_ChildProcessTypeToString(mProcessType) << " subprocess";
-    Telemetry::Accumulate(Telemetry::SUBPROCESS_LAUNCH_FAILURE,
-      nsDependentCString(XRE_ChildProcessTypeToString(mProcessType)));
   }
   return ok;
 }

--- a/ipc/glue/MessageChannel.cpp
+++ b/ipc/glue/MessageChannel.cpp
@@ -760,11 +760,6 @@ MessageChannel::Echo(Message* aMsg)
 bool
 MessageChannel::Send(Message* aMsg)
 {
-    if (aMsg->size() >= kMinTelemetryMessageSize) {
-        Telemetry::Accumulate(Telemetry::IPC_MESSAGE_SIZE,
-                              nsDependentCString(aMsg->name()), aMsg->size());
-    }
-
     MOZ_RELEASE_ASSERT(!aMsg->is_sync());
     MOZ_RELEASE_ASSERT(aMsg->nested_level() != IPC::Message::NESTED_INSIDE_SYNC);
 
@@ -1059,11 +1054,6 @@ MessageChannel::ProcessPendingRequests(AutoEnterTransaction& aTransaction)
 bool
 MessageChannel::Send(Message* aMsg, Message* aReply)
 {
-    if (aMsg->size() >= kMinTelemetryMessageSize) {
-        Telemetry::Accumulate(Telemetry::IPC_MESSAGE_SIZE,
-                              nsDependentCString(aMsg->name()), aMsg->size());
-    }
-
     nsAutoPtr<Message> msg(aMsg);
 
     // Sanity checks.
@@ -1249,10 +1239,6 @@ MessageChannel::Send(Message* aMsg, Message* aReply)
     MOZ_RELEASE_ASSERT(reply->is_sync());
 
     *aReply = Move(*reply);
-    if (aReply->size() >= kMinTelemetryMessageSize) {
-        Telemetry::Accumulate(Telemetry::IPC_REPLY_SIZE,
-                              nsDependentCString(msgName), aReply->size());
-    }
     return true;
 }
 
@@ -2546,7 +2532,6 @@ void
 CancelCPOWs()
 {
     if (gParentProcessBlocker) {
-        mozilla::Telemetry::Accumulate(mozilla::Telemetry::IPC_TRANSACTION_CANCEL, true);
         gParentProcessBlocker->CancelCurrentTransaction();
     }
 }

--- a/js/ipc/JavaScriptParent.cpp
+++ b/js/ipc/JavaScriptParent.cpp
@@ -15,7 +15,6 @@
 #include "js/HeapAPI.h"
 #include "xpcprivate.h"
 #include "mozilla/Casting.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/Unused.h"
 #include "nsAutoPtr.h"
 
@@ -110,7 +109,6 @@ JavaScriptParent::allowMessage(JSContext* cx)
 
         if (!xpc::CompartmentPrivate::Get(jsGlobal)->allowCPOWs) {
             if (!addonId && ForbidUnsafeBrowserCPOWs() && !isSafe) {
-                Telemetry::Accumulate(Telemetry::BROWSER_SHIM_USAGE_BLOCKED, 1);
                 JS_ReportErrorASCII(cx, "unsafe CPOW usage forbidden");
                 return false;
             }
@@ -120,7 +118,6 @@ JavaScriptParent::allowMessage(JSContext* cx)
                 nsString addonIdString;
                 AssignJSFlatString(addonIdString, flat);
                 NS_ConvertUTF16toUTF8 addonIdCString(addonIdString);
-                Telemetry::Accumulate(Telemetry::ADDON_FORBIDDEN_CPOW_USAGE, addonIdCString);
 
                 if (ForbidCPOWsInCompatibleAddon(addonIdCString)) {
                     JS_ReportErrorASCII(cx, "CPOW usage forbidden in this add-on");

--- a/js/xpconnect/src/XPCJSContext.cpp
+++ b/js/xpconnect/src/XPCJSContext.cpp
@@ -28,7 +28,6 @@
 #include "nsPIDOMWindow.h"
 #include "nsPrintfCString.h"
 #include "mozilla/Preferences.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/Services.h"
 #include "mozilla/dom/ScriptSettings.h"
 
@@ -135,8 +134,6 @@ public:
   {
       TimeStamp start = TimeStamp::Now();
       bool hadSnowWhiteObjects = nsCycleCollector_doDeferredDeletion();
-      Telemetry::Accumulate(Telemetry::CYCLE_COLLECTOR_ASYNC_SNOW_WHITE_FREEING,
-                            uint32_t((TimeStamp::Now() - start).ToMilliseconds()));
       if (hadSnowWhiteObjects && !mContinuation) {
           mContinuation = true;
           if (NS_FAILED(NS_DispatchToCurrentThread(this))) {
@@ -1317,7 +1314,6 @@ XPCJSContext::InterruptCallback(JSContext* cx)
     // Accumulate slow script invokation delay.
     if (!chrome && !self->mTimeoutAccumulated) {
       uint32_t delay = uint32_t(self->mSlowScriptActualWait.ToMilliseconds() - (limit * 1000.0));
-      Telemetry::Accumulate(Telemetry::SLOW_SCRIPT_NOTIFY_DELAY, delay);
       self->mTimeoutAccumulated = true;
     }
 
@@ -2955,100 +2951,7 @@ JSSizeOfTab(JSObject* objArg, size_t* jsObjectsSize, size_t* jsStringsSize,
 static void
 AccumulateTelemetryCallback(int id, uint32_t sample, const char* key)
 {
-    switch (id) {
-      case JS_TELEMETRY_GC_REASON:
-        Telemetry::Accumulate(Telemetry::GC_REASON_2, sample);
-        break;
-      case JS_TELEMETRY_GC_IS_ZONE_GC:
-        Telemetry::Accumulate(Telemetry::GC_IS_COMPARTMENTAL, sample);
-        break;
-      case JS_TELEMETRY_GC_MS:
-        Telemetry::Accumulate(Telemetry::GC_MS, sample);
-        break;
-      case JS_TELEMETRY_GC_BUDGET_MS:
-        Telemetry::Accumulate(Telemetry::GC_BUDGET_MS, sample);
-        break;
-      case JS_TELEMETRY_GC_ANIMATION_MS:
-        Telemetry::Accumulate(Telemetry::GC_ANIMATION_MS, sample);
-        break;
-      case JS_TELEMETRY_GC_MAX_PAUSE_MS:
-        Telemetry::Accumulate(Telemetry::GC_MAX_PAUSE_MS, sample);
-        break;
-      case JS_TELEMETRY_GC_MARK_MS:
-        Telemetry::Accumulate(Telemetry::GC_MARK_MS, sample);
-        break;
-      case JS_TELEMETRY_GC_SWEEP_MS:
-        Telemetry::Accumulate(Telemetry::GC_SWEEP_MS, sample);
-        break;
-      case JS_TELEMETRY_GC_COMPACT_MS:
-        Telemetry::Accumulate(Telemetry::GC_COMPACT_MS, sample);
-        break;
-      case JS_TELEMETRY_GC_MARK_ROOTS_MS:
-        Telemetry::Accumulate(Telemetry::GC_MARK_ROOTS_MS, sample);
-        break;
-      case JS_TELEMETRY_GC_MARK_GRAY_MS:
-        Telemetry::Accumulate(Telemetry::GC_MARK_GRAY_MS, sample);
-        break;
-      case JS_TELEMETRY_GC_SLICE_MS:
-        Telemetry::Accumulate(Telemetry::GC_SLICE_MS, sample);
-        break;
-      case JS_TELEMETRY_GC_SLOW_PHASE:
-        Telemetry::Accumulate(Telemetry::GC_SLOW_PHASE, sample);
-        break;
-      case JS_TELEMETRY_GC_MMU_50:
-        Telemetry::Accumulate(Telemetry::GC_MMU_50, sample);
-        break;
-      case JS_TELEMETRY_GC_RESET:
-        Telemetry::Accumulate(Telemetry::GC_RESET, sample);
-        break;
-      case JS_TELEMETRY_GC_RESET_REASON:
-        Telemetry::Accumulate(Telemetry::GC_RESET_REASON, sample);
-        break;
-      case JS_TELEMETRY_GC_INCREMENTAL_DISABLED:
-        Telemetry::Accumulate(Telemetry::GC_INCREMENTAL_DISABLED, sample);
-        break;
-      case JS_TELEMETRY_GC_NON_INCREMENTAL:
-        Telemetry::Accumulate(Telemetry::GC_NON_INCREMENTAL, sample);
-        break;
-      case JS_TELEMETRY_GC_NON_INCREMENTAL_REASON:
-        Telemetry::Accumulate(Telemetry::GC_NON_INCREMENTAL_REASON, sample);
-        break;
-      case JS_TELEMETRY_GC_SCC_SWEEP_TOTAL_MS:
-        Telemetry::Accumulate(Telemetry::GC_SCC_SWEEP_TOTAL_MS, sample);
-        break;
-      case JS_TELEMETRY_GC_SCC_SWEEP_MAX_PAUSE_MS:
-        Telemetry::Accumulate(Telemetry::GC_SCC_SWEEP_MAX_PAUSE_MS, sample);
-        break;
-      case JS_TELEMETRY_GC_MINOR_REASON:
-        Telemetry::Accumulate(Telemetry::GC_MINOR_REASON, sample);
-        break;
-      case JS_TELEMETRY_GC_MINOR_REASON_LONG:
-        Telemetry::Accumulate(Telemetry::GC_MINOR_REASON_LONG, sample);
-        break;
-      case JS_TELEMETRY_GC_MINOR_US:
-        Telemetry::Accumulate(Telemetry::GC_MINOR_US, sample);
-        break;
-      case JS_TELEMETRY_GC_NURSERY_BYTES:
-        Telemetry::Accumulate(Telemetry::GC_NURSERY_BYTES, sample);
-        break;
-      case JS_TELEMETRY_GC_PRETENURE_COUNT:
-        Telemetry::Accumulate(Telemetry::GC_PRETENURE_COUNT, sample);
-        break;
-      case JS_TELEMETRY_DEPRECATED_LANGUAGE_EXTENSIONS_IN_CONTENT:
-        Telemetry::Accumulate(Telemetry::JS_DEPRECATED_LANGUAGE_EXTENSIONS_IN_CONTENT, sample);
-        break;
-      case JS_TELEMETRY_DEPRECATED_LANGUAGE_EXTENSIONS_IN_ADDONS:
-        Telemetry::Accumulate(Telemetry::JS_DEPRECATED_LANGUAGE_EXTENSIONS_IN_ADDONS, sample);
-        break;
-      case JS_TELEMETRY_ADDON_EXCEPTIONS:
-        Telemetry::Accumulate(Telemetry::JS_TELEMETRY_ADDON_EXCEPTIONS, nsDependentCString(key), sample);
-        break;
-      case JS_TELEMETRY_AOT_USAGE:
-        Telemetry::Accumulate(Telemetry::JS_AOT_USAGE, sample);
-        break;
-      default:
-        MOZ_ASSERT_UNREACHABLE("Unexpected JS_TELEMETRY id");
-    }
+/* STUB */
 }
 
 static void

--- a/layout/base/nsDisplayList.cpp
+++ b/layout/base/nsDisplayList.cpp
@@ -7491,9 +7491,6 @@ PaintTelemetry::AutoRecordPaint::~AutoRecordPaint()
 
   double totalMs = (TimeStamp::Now() - mStart).ToMilliseconds();
 
-  // Record the total time.
-  Telemetry::Accumulate(Telemetry::CONTENT_PAINT_TIME, static_cast<uint32_t>(totalMs));
-
   // If the total time was >= 16ms, then it's likely we missed a frame due to
   // painting. In this case we'll gather some detailed metrics below.
   if (totalMs <= 16.0) {
@@ -7504,9 +7501,6 @@ PaintTelemetry::AutoRecordPaint::~AutoRecordPaint()
     MOZ_ASSERT(aDurationMs <= totalMs);
 
     uint32_t amount = static_cast<int32_t>((aDurationMs / totalMs) * 100.0);
-
-    nsDependentCString key(aKey);
-    Telemetry::Accumulate(Telemetry::CONTENT_LARGE_PAINT_PHASE_WEIGHT, key, amount);
   };
 
   double dlMs = sMetrics[Metric::DisplayList];

--- a/layout/base/nsDocumentViewer.cpp
+++ b/layout/base/nsDocumentViewer.cpp
@@ -1275,7 +1275,6 @@ nsDocumentViewer::PermitUnloadInternal(bool *aShouldPrompt,
 
       nsAutoSyncOperation sync(mDocument);
       mInPermitUnloadPrompt = true;
-      mozilla::Telemetry::Accumulate(mozilla::Telemetry::ONBEFOREUNLOAD_PROMPT_COUNT, 1);
       rv = prompt->ConfirmEx(title, message, buttonFlags,
                              leaveLabel, stayLabel, nullptr, nullptr,
                              &dummy, &buttonPressed);
@@ -1290,15 +1289,12 @@ nsDocumentViewer::PermitUnloadInternal(bool *aShouldPrompt,
       // XXX: Are there other cases where prompts can abort? Is it ok to
       //      prevent unloading the page in those cases?
       if (NS_FAILED(rv)) {
-        mozilla::Telemetry::Accumulate(mozilla::Telemetry::ONBEFOREUNLOAD_PROMPT_ACTION, 2);
         *aPermitUnload = false;
         return NS_OK;
       }
 
       // Button 0 == leave, button 1 == stay
       *aPermitUnload = (buttonPressed == 0);
-      mozilla::Telemetry::Accumulate(mozilla::Telemetry::ONBEFOREUNLOAD_PROMPT_ACTION,
-        (*aPermitUnload ? 1 : 0));
       // If the user decided to go ahead, make sure not to prompt the user again
       // by toggling the internal prompting bool to false:
       if (*aPermitUnload) {

--- a/layout/base/nsLayoutUtils.cpp
+++ b/layout/base/nsLayoutUtils.cpp
@@ -3569,8 +3569,6 @@ nsLayoutUtils::PaintFrame(nsRenderingContext* aRenderingContext, nsIFrame* aFram
   }
 
   builder.LeavePresShell(aFrame, &list);
-  Telemetry::AccumulateTimeDelta(Telemetry::PAINT_BUILD_DISPLAYLIST_TIME,
-                                 startBuildDisplayList);
 
   bool profilerNeedsDisplayList = profiler_feature_active("displaylistdump");
   bool consoleNeedsDisplayList = gfxUtils::DumpDisplayList() || gfxEnv::DumpPaint();
@@ -3651,8 +3649,6 @@ nsLayoutUtils::PaintFrame(nsRenderingContext* aRenderingContext, nsIFrame* aFram
   TimeStamp paintStart = TimeStamp::Now();
   RefPtr<LayerManager> layerManager
     = list.PaintRoot(&builder, aRenderingContext, flags);
-  Telemetry::AccumulateTimeDelta(Telemetry::PAINT_RASTERIZE_TIME,
-                                 paintStart);
 
   if (gfxPrefs::GfxLoggingPaintedPixelCountEnabled()) {
     TimeStamp now = TimeStamp::Now();

--- a/layout/base/nsRefreshDriver.cpp
+++ b/layout/base/nsRefreshDriver.cpp
@@ -526,10 +526,6 @@ private:
       if (XRE_IsParentProcess()) {
         TimeDuration vsyncLatency = TimeStamp::Now() - aVsyncTimestamp;
         uint32_t sample = (uint32_t)vsyncLatency.ToMilliseconds();
-        Telemetry::Accumulate(Telemetry::FX_REFRESH_DRIVER_CHROME_FRAME_DELAY_MS,
-                              sample);
-        Telemetry::Accumulate(Telemetry::FX_REFRESH_DRIVER_SYNC_SCROLL_FRAME_DELAY_MS,
-                              sample);
         RecordJank(sample);
       } else if (mVsyncRate != TimeDuration::Forever()) {
         TimeDuration contentDelay = (TimeStamp::Now() - mLastChildTick) - mVsyncRate;
@@ -539,10 +535,6 @@ private:
           contentDelay = TimeDuration::FromMilliseconds(0);
         }
         uint32_t sample = (uint32_t)contentDelay.ToMilliseconds();
-        Telemetry::Accumulate(Telemetry::FX_REFRESH_DRIVER_CONTENT_FRAME_DELAY_MS,
-                              sample);
-        Telemetry::Accumulate(Telemetry::FX_REFRESH_DRIVER_SYNC_SCROLL_FRAME_DELAY_MS,
-                              sample);
         RecordJank(sample);
       } else {
         // Request the vsync rate from the parent process. Might be a few vsyncs
@@ -2026,10 +2018,6 @@ nsRefreshDriver::Tick(int64_t aNowEpoch, TimeStamp aNowTime)
 
     notifyGC = true;
   }
-
-#ifndef ANDROID  /* bug 1142079 */
-  mozilla::Telemetry::AccumulateTimeDelta(mozilla::Telemetry::REFRESH_DRIVER_TICK, mTickStart);
-#endif
 
   nsTObserverArray<nsAPostRefreshObserver*>::ForwardIterator iter(mPostRefreshObservers);
   while (iter.HasMore()) {

--- a/layout/generic/nsSelection.cpp
+++ b/layout/generic/nsSelection.cpp
@@ -2201,8 +2201,6 @@ nsFrameSelection::CommonPageMove(bool aForward,
     return;
 
   // scroll one page
-  mozilla::Telemetry::Accumulate(mozilla::Telemetry::SCROLL_INPUT_METHODS,
-      (uint32_t) ScrollInputMethod::MainThreadScrollPage);
   aScrollableFrame->ScrollBy(nsIntPoint(0, aForward ? 1 : -1),
                              nsIScrollableFrame::PAGES,
                              nsIScrollableFrame::SMOOTH);
@@ -6200,11 +6198,6 @@ Selection::ScrollIntoView(SelectionRegion aRegion,
   }
   if (aFlags & Selection::SCROLL_OVERFLOW_HIDDEN) {
     flags |= nsIPresShell::SCROLL_OVERFLOW_HIDDEN;
-  }
-
-  if (aFlags & Selection::SCROLL_FOR_CARET_MOVE) {
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::SCROLL_INPUT_METHODS,
-        (uint32_t) ScrollInputMethod::MainThreadScrollCaretIntoView);
   }
 
   presShell->ScrollFrameRectIntoView(frame, rect, aVertical, aHorizontal,

--- a/layout/style/FontFaceSet.cpp
+++ b/layout/style/FontFaceSet.cpp
@@ -1762,17 +1762,9 @@ FontFaceSet::UserFontSet::RecordFontLoadDone(uint32_t aFontSize,
 {
   mDownloadCount++;
   mDownloadSize += aFontSize;
-  Telemetry::Accumulate(Telemetry::WEBFONT_SIZE, aFontSize / 1024);
 
   if (!mFontFaceSet) {
     return;
-  }
-
-  TimeStamp navStart = mFontFaceSet->GetNavigationStartTimeStamp();
-  TimeStamp zero;
-  if (navStart != zero) {
-    Telemetry::AccumulateTimeDelta(Telemetry::WEBFONT_DOWNLOAD_TIME_AFTER_START,
-                                   navStart, aDoneTime);
   }
 }
 

--- a/layout/style/nsFontFaceLoader.cpp
+++ b/layout/style/nsFontFaceLoader.cpp
@@ -205,7 +205,6 @@ nsFontFaceLoader::OnStreamComplete(nsIStreamLoader* aLoader,
   TimeStamp doneTime = TimeStamp::Now();
   TimeDuration downloadTime = doneTime - mStartTime;
   uint32_t downloadTimeMS = uint32_t(downloadTime.ToMilliseconds());
-  Telemetry::Accumulate(Telemetry::WEBFONT_DOWNLOAD_TIME, downloadTimeMS);
 
   if (GetFontDisplay() == NS_FONT_DISPLAY_FALLBACK) {
     uint32_t loadTimeout = GetFallbackDelay();

--- a/layout/xul/nsScrollbarButtonFrame.cpp
+++ b/layout/xul/nsScrollbarButtonFrame.cpp
@@ -171,9 +171,6 @@ nsScrollbarButtonFrame::HandleButtonPress(nsPresContext* aPresContext,
       return false;
     }
 
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::SCROLL_INPUT_METHODS,
-        (uint32_t) ScrollInputMethod::MainThreadScrollbarButtonClick);
-
     if (!m) {
       sb->MoveToNewPosition();
       if (!weakFrame.IsAlive()) {

--- a/layout/xul/nsSliderFrame.cpp
+++ b/layout/xul/nsSliderFrame.cpp
@@ -529,9 +529,6 @@ nsSliderFrame::HandleEvent(nsPresContext* aPresContext,
         return NS_OK;
       }
 
-      mozilla::Telemetry::Accumulate(mozilla::Telemetry::SCROLL_INPUT_METHODS,
-          (uint32_t) ScrollInputMethod::MainThreadScrollbarDrag);
-
       // take our current position and subtract the start location
       pos -= mDragStart;
       bool isMouseOutsideThumb = false;
@@ -597,9 +594,6 @@ nsSliderFrame::HandleEvent(nsPresContext* aPresContext,
     }
     nsSize thumbSize = thumbFrame->GetSize();
     nscoord thumbLength = isHorizontal ? thumbSize.width : thumbSize.height;
-
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::SCROLL_INPUT_METHODS,
-        (uint32_t) ScrollInputMethod::MainThreadScrollbarTrackClick);
 
     // set it
     nsWeakFrame weakFrame(this);

--- a/media/webrtc/signaling/src/media-conduit/AudioConduit.cpp
+++ b/media/webrtc/signaling/src/media-conduit/AudioConduit.cpp
@@ -706,15 +706,6 @@ WebrtcAudioConduit::GetAudioFrame(int16_t speechData[],
     if (GetAVStats(&jitter_buffer_delay_ms,
                    &playout_buffer_delay_ms,
                    &avsync_offset_ms)) {
-#if !defined(MOZILLA_EXTERNAL_LINKAGE)
-      if (avsync_offset_ms < 0) {
-        Telemetry::Accumulate(Telemetry::WEBRTC_AVSYNC_WHEN_VIDEO_LAGS_AUDIO_MS,
-                              -avsync_offset_ms);
-      } else {
-        Telemetry::Accumulate(Telemetry::WEBRTC_AVSYNC_WHEN_AUDIO_LAGS_VIDEO_MS,
-                              avsync_offset_ms);
-      }
-#endif
       CSFLogError(logTag,
                   "A/V sync: sync delta: %dms, audio jitter delay %dms, playout delay %dms",
                   avsync_offset_ms, jitter_buffer_delay_ms, playout_buffer_delay_ms);

--- a/media/webrtc/signaling/src/media-conduit/CodecStatistics.cpp
+++ b/media/webrtc/signaling/src/media-conduit/CodecStatistics.cpp
@@ -124,8 +124,6 @@ void VideoCodecStatistics::ReceiveStateChange(const int aChannel,
           TimeDuration timeDelta = TimeStamp::Now() - mReceiveFailureTime;
           CSFLogError(logTag, "Video error duration: %u ms",
                       static_cast<uint32_t>(timeDelta.ToMilliseconds()));
-          Telemetry::Accumulate(Telemetry::WEBRTC_VIDEO_ERROR_RECOVERY_MS,
-                                static_cast<uint32_t>(timeDelta.ToMilliseconds()));
 
           mRecoveredLosses++; // to calculate losses per minute
           mTotalLossTime += timeDelta;  // To calculate % time in recovery
@@ -147,16 +145,10 @@ void VideoCodecStatistics::EndOfCallStats()
     if (callDelta.ToSeconds() != 0) {
       uint32_t recovered_per_min = mRecoveredBeforeLoss/(callDelta.ToSeconds()/60);
       CSFLogError(logTag, "Video recovery before error per min %u", recovered_per_min);
-      Telemetry::Accumulate(Telemetry::WEBRTC_VIDEO_RECOVERY_BEFORE_ERROR_PER_MIN,
-                            recovered_per_min);
       uint32_t err_per_min = mRecoveredLosses/(callDelta.ToSeconds()/60);
       CSFLogError(logTag, "Video recovery after error per min %u", err_per_min);
-      Telemetry::Accumulate(Telemetry::WEBRTC_VIDEO_RECOVERY_AFTER_ERROR_PER_MIN,
-                            err_per_min);
       float percent = (mTotalLossTime.ToSeconds()*100)/callDelta.ToSeconds();
       CSFLogError(logTag, "Video error time percentage %f%%", percent);
-      Telemetry::Accumulate(Telemetry::WEBRTC_VIDEO_DECODE_ERROR_TIME_PERMILLE,
-                            static_cast<uint32_t>(percent*10));
     }
   }
 #endif

--- a/media/webrtc/signaling/src/peerconnection/PeerConnectionImpl.cpp
+++ b/media/webrtc/signaling/src/peerconnection/PeerConnectionImpl.cpp
@@ -2245,22 +2245,6 @@ PeerConnectionImpl::AddIceCandidate(const char* aCandidate, const char* aMid, un
 
   CSFLogDebug(logTag, "AddIceCandidate: %s", aCandidate);
 
-#if !defined(MOZILLA_EXTERNAL_LINKAGE)
-  // When remote candidates are added before our ICE ctx is up and running
-  // (the transition to New is async through STS, so this is not impossible),
-  // we won't record them as trickle candidates. Is this what we want?
-  if(!mIceStartTime.IsNull()) {
-    TimeDuration timeDelta = TimeStamp::Now() - mIceStartTime;
-    if (mIceConnectionState == PCImplIceConnectionState::Failed) {
-      Telemetry::Accumulate(Telemetry::WEBRTC_ICE_LATE_TRICKLE_ARRIVAL_TIME,
-                            timeDelta.ToMilliseconds());
-    } else {
-      Telemetry::Accumulate(Telemetry::WEBRTC_ICE_ON_TIME_TRICKLE_ARRIVAL_TIME,
-                            timeDelta.ToMilliseconds());
-    }
-  }
-#endif
-
   nsresult res = mJsepSession->AddRemoteIceCandidate(aCandidate, aMid, aLevel);
 
   if (NS_SUCCEEDED(res)) {
@@ -3011,49 +2995,7 @@ PeerConnectionImpl::PluginCrash(uint32_t aPluginID,
 void
 PeerConnectionImpl::RecordEndOfCallTelemetry() const
 {
-  if (!mJsepSession) {
-    return;
-  }
-
-#if !defined(MOZILLA_EXTERNAL_LINKAGE)
-  // Bitmask used for WEBRTC/LOOP_CALL_TYPE telemetry reporting
-  static const uint32_t kAudioTypeMask = 1;
-  static const uint32_t kVideoTypeMask = 2;
-  static const uint32_t kDataChannelTypeMask = 4;
-
-  // Report end-of-call Telemetry
-  if (mJsepSession->GetNegotiations() > 0) {
-    Telemetry::Accumulate(Telemetry::WEBRTC_RENEGOTIATIONS,
-                          mJsepSession->GetNegotiations()-1);
-  }
-  Telemetry::Accumulate(Telemetry::WEBRTC_MAX_VIDEO_SEND_TRACK,
-                        mMaxSending[SdpMediaSection::MediaType::kVideo]);
-  Telemetry::Accumulate(Telemetry::WEBRTC_MAX_VIDEO_RECEIVE_TRACK,
-                        mMaxReceiving[SdpMediaSection::MediaType::kVideo]);
-  Telemetry::Accumulate(Telemetry::WEBRTC_MAX_AUDIO_SEND_TRACK,
-                        mMaxSending[SdpMediaSection::MediaType::kAudio]);
-  Telemetry::Accumulate(Telemetry::WEBRTC_MAX_AUDIO_RECEIVE_TRACK,
-                        mMaxReceiving[SdpMediaSection::MediaType::kAudio]);
-  // DataChannels appear in both Sending and Receiving
-  Telemetry::Accumulate(Telemetry::WEBRTC_DATACHANNEL_NEGOTIATED,
-                        mMaxSending[SdpMediaSection::MediaType::kApplication]);
-  // Enumerated/bitmask: 1 = Audio, 2 = Video, 4 = DataChannel
-  // A/V = 3, A/V/D = 7, etc
-  uint32_t type = 0;
-  if (mMaxSending[SdpMediaSection::MediaType::kAudio] ||
-      mMaxReceiving[SdpMediaSection::MediaType::kAudio]) {
-    type = kAudioTypeMask;
-  }
-  if (mMaxSending[SdpMediaSection::MediaType::kVideo] ||
-      mMaxReceiving[SdpMediaSection::MediaType::kVideo]) {
-    type |= kVideoTypeMask;
-  }
-  if (mMaxSending[SdpMediaSection::MediaType::kApplication]) {
-    type |= kDataChannelTypeMask;
-  }
-  Telemetry::Accumulate(Telemetry::WEBRTC_CALL_TYPE,
-                        type);
-#endif
+  /* STUB */
 }
 
 nsresult
@@ -3108,13 +3050,6 @@ PeerConnectionImpl::ShutdownMedia()
     for (const auto& pair : info->GetMediaStreamTracks()) {
       pair.second->RemovePrincipalChangeObserver(this);
     }
-  }
-
-  // End of call to be recorded in Telemetry
-  if (!mStartTime.IsNull()){
-    TimeDuration timeDelta = TimeStamp::Now() - mStartTime;
-    Telemetry::Accumulate(Telemetry::WEBRTC_CALL_DURATION,
-                          timeDelta.ToSeconds());
   }
 #endif
 
@@ -3423,33 +3358,6 @@ void PeerConnectionImpl::IceConnectionStateChange(
     return;
   }
 
-#if !defined(MOZILLA_EXTERNAL_LINKAGE)
-  if (!isDone(mIceConnectionState) && isDone(domState)) {
-    // mIceStartTime can be null if going directly from New to Closed, in which
-    // case we don't count it as a success or a failure.
-    if (!mIceStartTime.IsNull()){
-      TimeDuration timeDelta = TimeStamp::Now() - mIceStartTime;
-      if (isSucceeded(domState)) {
-        Telemetry::Accumulate(Telemetry::WEBRTC_ICE_SUCCESS_TIME,
-                              timeDelta.ToMilliseconds());
-      } else if (isFailed(domState)) {
-        Telemetry::Accumulate(Telemetry::WEBRTC_ICE_FAILURE_TIME,
-                              timeDelta.ToMilliseconds());
-      }
-    }
-
-    if (isSucceeded(domState)) {
-      Telemetry::Accumulate(
-          Telemetry::WEBRTC_ICE_ADD_CANDIDATE_ERRORS_GIVEN_SUCCESS,
-          mAddCandidateErrorCount);
-    } else if (isFailed(domState)) {
-      Telemetry::Accumulate(
-          Telemetry::WEBRTC_ICE_ADD_CANDIDATE_ERRORS_GIVEN_FAILURE,
-          mAddCandidateErrorCount);
-    }
-  }
-#endif
-
   mIceConnectionState = domState;
 
   if (mIceConnectionState == PCImplIceConnectionState::Connected ||
@@ -3467,10 +3375,6 @@ void PeerConnectionImpl::IceConnectionStateChange(
       STAMP_TIMECARD(mTimeCard, "Ice state: new");
       break;
     case PCImplIceConnectionState::Checking:
-#if !defined(MOZILLA_EXTERNAL_LINKAGE)
-      // For telemetry
-      mIceStartTime = TimeStamp::Now();
-#endif
       STAMP_TIMECARD(mTimeCard, "Ice state: checking");
       break;
     case PCImplIceConnectionState::Connected:
@@ -4067,16 +3971,7 @@ PeerConnectionImpl::IceStreamReady(NrIceMediaStream *aStream)
 //Telemetry for when calls start
 void
 PeerConnectionImpl::startCallTelem() {
-  if (!mStartTime.IsNull()) {
-    return;
-  }
-
-  // Start time for calls
-  mStartTime = TimeStamp::Now();
-
-  // Increment session call counter
-  // If we want to track Loop calls independently here, we need two histograms.
-  Telemetry::Accumulate(Telemetry::WEBRTC_CALL_COUNT_2, 1);
+  /* STUB */
 }
 #endif
 

--- a/media/webrtc/signaling/src/peerconnection/WebrtcGlobalInformation.cpp
+++ b/media/webrtc/signaling/src/peerconnection/WebrtcGlobalInformation.cpp
@@ -1194,18 +1194,8 @@ static void GetStatsForLongTermStorage_s(
     rate_limit_bit_pattern |= 2;
   }
 
-  if (query->failed) {
-    Telemetry::Accumulate(
-        Telemetry::WEBRTC_STUN_RATE_LIMIT_EXCEEDED_BY_TYPE_GIVEN_FAILURE,
-        rate_limit_bit_pattern);
-  } else {
-    Telemetry::Accumulate(
-        Telemetry::WEBRTC_STUN_RATE_LIMIT_EXCEEDED_BY_TYPE_GIVEN_SUCCESS,
-        rate_limit_bit_pattern);
-  }
-
-  // Even if Telemetry::Accumulate is threadsafe, we still need to send the
-  // query back to main, since that is where it must be destroyed.
+  // We still need to send the query back to main, since that is where
+  // it must be destroyed.
   NS_DispatchToMainThread(
       WrapRunnableNM(
           &StoreLongTermICEStatisticsImpl_m,
@@ -1216,8 +1206,6 @@ static void GetStatsForLongTermStorage_s(
 
 void WebrtcGlobalInformation::StoreLongTermICEStatistics(
     PeerConnectionImpl& aPc) {
-  Telemetry::Accumulate(Telemetry::WEBRTC_ICE_FINAL_CONNECTION_STATE,
-                        static_cast<uint32_t>(aPc.IceConnectionState()));
 
   if (aPc.IceConnectionState() == PCImplIceConnectionState::New) {
     // ICE has not started; we won't have any remote candidates, so recording

--- a/modules/libjar/nsJARChannel.cpp
+++ b/modules/libjar/nsJARChannel.cpp
@@ -22,7 +22,6 @@
 #include "nsIFileURL.h"
 
 #include "mozilla/Preferences.h"
-#include "mozilla/Telemetry.h"
 #include "nsITabChild.h"
 #include "private/pprio.h"
 #include "nsInputStreamPump.h"
@@ -789,12 +788,6 @@ nsJARChannel::AsyncOpen(nsIStreamListener *listener, nsISupports *ctx)
         if (mBlockRemoteFiles) {
             mIsUnsafe = true;
             return NS_ERROR_UNSAFE_CONTENT_TYPE;
-        }
-
-        static bool reportedRemoteJAR = false;
-        if (!reportedRemoteJAR) {
-            reportedRemoteJAR = true;
-            Telemetry::Accumulate(Telemetry::REMOTE_JAR_PROTOCOL_USED, 1);
         }
 
         // kick off an async download of the base URI...

--- a/netwerk/base/BackgroundFileSaver.cpp
+++ b/netwerk/base/BackgroundFileSaver.cpp
@@ -798,8 +798,6 @@ BackgroundFileSaver::NotifySaveComplete()
   // during the session in a telemetry histogram, and we reset the maximum
   // thread counter for the next download session
   if (sThreadCount == 0) {
-    Telemetry::Accumulate(Telemetry::BACKGROUNDFILESAVER_THREAD_COUNT,
-                          sTelemetryMaxThreadCount);
     sTelemetryMaxThreadCount = 0;
   }
 

--- a/netwerk/base/nsNetUtil.cpp
+++ b/netwerk/base/nsNetUtil.cpp
@@ -2262,7 +2262,6 @@ NS_ShouldSecureUpgrade(nsIURI* aURI,
                             nsIScriptError::warningFlag, "CSP",
                             innerWindowId);
 
-        Telemetry::Accumulate(Telemetry::HTTP_SCHEME_UPGRADE, 4);
         aShouldUpgrade = true;
         return NS_OK;
       }
@@ -2285,17 +2284,10 @@ NS_ShouldSecureUpgrade(nsIURI* aURI,
     if (isStsHost) {
       LOG(("nsHttpChannel::Connect() STS permissions found\n"));
       if (aAllowSTS) {
-        Telemetry::Accumulate(Telemetry::HTTP_SCHEME_UPGRADE, 3);
         aShouldUpgrade = true;
         return NS_OK;
-      } else {
-        Telemetry::Accumulate(Telemetry::HTTP_SCHEME_UPGRADE, 2);
       }
-    } else {
-      Telemetry::Accumulate(Telemetry::HTTP_SCHEME_UPGRADE, 1);
     }
-  } else {
-    Telemetry::Accumulate(Telemetry::HTTP_SCHEME_UPGRADE, 0);
   }
   aShouldUpgrade = false;
   return NS_OK;

--- a/netwerk/base/nsSocketTransport2.cpp
+++ b/netwerk/base/nsSocketTransport2.cpp
@@ -1596,17 +1596,6 @@ nsSocketTransport::RecoverFromError()
 
     bool tryAgain = false;
 
-    if ((mState == STATE_CONNECTING) && mDNSRecord &&
-        mSocketTransportService->IsTelemetryEnabledAndNotSleepPhase()) {
-        if (mNetAddr.raw.family == AF_INET) {
-            Telemetry::Accumulate(Telemetry::IPV4_AND_IPV6_ADDRESS_CONNECTIVITY,
-                                  UNSUCCESSFUL_CONNECTING_TO_IPV4_ADDRESS);
-        } else if (mNetAddr.raw.family == AF_INET6) {
-            Telemetry::Accumulate(Telemetry::IPV4_AND_IPV6_ADDRESS_CONNECTIVITY,
-                                  UNSUCCESSFUL_CONNECTING_TO_IPV6_ADDRESS);
-        }
-    }
-
     if (mConnectionFlags & (DISABLE_IPV6 | DISABLE_IPV4) &&
         mCondition == NS_ERROR_UNKNOWN_HOST &&
         mState == STATE_RESOLVING &&
@@ -1996,18 +1985,6 @@ nsSocketTransport::OnSocketReady(PRFileDesc *fd, int16_t outFlags)
             // we are connected!
             //
             OnSocketConnected();
-
-            if (mSocketTransportService->IsTelemetryEnabledAndNotSleepPhase()) {
-                if (mNetAddr.raw.family == AF_INET) {
-                    Telemetry::Accumulate(
-                        Telemetry::IPV4_AND_IPV6_ADDRESS_CONNECTIVITY,
-                        SUCCESSFUL_CONNECTING_TO_IPV4_ADDRESS);
-                } else if (mNetAddr.raw.family == AF_INET6) {
-                    Telemetry::Accumulate(
-                        Telemetry::IPV4_AND_IPV6_ADDRESS_CONNECTIVITY,
-                        SUCCESSFUL_CONNECTING_TO_IPV6_ADDRESS);
-                }
-            }
         }
         else {
             PRErrorCode code = PR_GetError();
@@ -3201,28 +3178,7 @@ nsSocketTransport::SendPRBlockingTelemetry(PRIntervalTime aStart,
                                            Telemetry::ID aIDLinkChange,
                                            Telemetry::ID aIDOffline)
 {
-    PRIntervalTime now = PR_IntervalNow();
-    if (gIOService->IsNetTearingDown()) {
-        Telemetry::Accumulate(aIDShutdown,
-                              PR_IntervalToMilliseconds(now - aStart));
-
-    } else if (PR_IntervalToSeconds(now - gIOService->LastConnectivityChange())
-               < 60) {
-        Telemetry::Accumulate(aIDConnectivityChange,
-                              PR_IntervalToMilliseconds(now - aStart));
-    } else if (PR_IntervalToSeconds(now - gIOService->LastNetworkLinkChange())
-               < 60) {
-        Telemetry::Accumulate(aIDLinkChange,
-                              PR_IntervalToMilliseconds(now - aStart));
-
-    } else if (PR_IntervalToSeconds(now - gIOService->LastOfflineStateChange())
-               < 60) {
-        Telemetry::Accumulate(aIDOffline,
-                              PR_IntervalToMilliseconds(now - aStart));
-    } else {
-        Telemetry::Accumulate(aIDNormal,
-                              PR_IntervalToMilliseconds(now - aStart));
-    }
+  /* STUB */
 }
 
 } // namespace net

--- a/netwerk/base/nsSocketTransportService2.cpp
+++ b/netwerk/base/nsSocketTransportService2.cpp
@@ -219,7 +219,6 @@ nsSocketTransportService::CanAttachSocket()
     if (mTelemetryEnabledPref &&
         (((total >= 900) || !rv) && !reported900FDLimit)) {
         reported900FDLimit = true;
-        Telemetry::Accumulate(Telemetry::NETWORK_SESSION_AT_900FD, true);
     }
 
     return rv;
@@ -898,16 +897,6 @@ nsSocketTransportService::Run()
 
             DoPollIteration(&singlePollDuration);
 
-            if (mTelemetryEnabledPref && !pollCycleStart.IsNull()) {
-                Telemetry::Accumulate(Telemetry::STS_POLL_BLOCK_TIME,
-                                      singlePollDuration.ToMilliseconds());
-                Telemetry::AccumulateTimeDelta(
-                    Telemetry::STS_POLL_CYCLE,
-                    pollCycleStart + singlePollDuration,
-                    TimeStamp::NowLoRes());
-                pollDuration += singlePollDuration;
-            }
-
             mRawThread->HasPendingEvents(&pendingEvents);
             if (pendingEvents) {
                 if (!mServingPendingQueue) {
@@ -940,22 +929,6 @@ nsSocketTransportService::Run()
                          ((TimeStamp::NowLoRes() -
                            eventQueueStart).ToMilliseconds() <
                           mMaxTimePerPollIter));
-
-                if (mTelemetryEnabledPref && !mServingPendingQueue &&
-                    !startOfIteration.IsNull()) {
-                    Telemetry::AccumulateTimeDelta(
-                        Telemetry::STS_POLL_AND_EVENTS_CYCLE,
-                        startOfIteration + pollDuration,
-                        TimeStamp::NowLoRes());
-
-                    Telemetry::Accumulate(
-                        Telemetry::STS_NUMBER_OF_PENDING_EVENTS,
-                        numberOfPendingEvents);
-
-                    numberOfPendingEventsLastCycle += numberOfPendingEvents;
-                    numberOfPendingEvents = 0;
-                    pollDuration = 0;
-                }
             }
         } while (pendingEvents);
 
@@ -964,16 +937,6 @@ nsSocketTransportService::Run()
         {
             MutexAutoLock lock(mLock);
             if (mShuttingDown) {
-                if (mTelemetryEnabledPref &&
-                    !startOfCycleForLastCycleCalc.IsNull()) {
-                    Telemetry::Accumulate(
-                        Telemetry::STS_NUMBER_OF_PENDING_EVENTS_IN_THE_LAST_CYCLE,
-                        numberOfPendingEventsLastCycle);
-                    Telemetry::AccumulateTimeDelta(
-                        Telemetry::STS_POLL_AND_EVENT_THE_LAST_CYCLE,
-                        startOfCycleForLastCycleCalc,
-                        TimeStamp::NowLoRes());
-                }
                 break;
             }
             if (mGoingOffline) {
@@ -1141,11 +1104,6 @@ nsSocketTransportService::DoPollIteration(TimeDuration *pollDuration)
                     numberOfOnSocketReadyCalls++;
                 }
             }
-        }
-        if (mTelemetryEnabledPref) {
-            Telemetry::Accumulate(
-                Telemetry::STS_NUMBER_OF_ONSOCKETREADY_CALLS,
-                numberOfOnSocketReadyCalls);
         }
 
         //
@@ -1465,7 +1423,6 @@ nsSocketTransportService::ProbeMaxCount()
         if (pfd[index].fd)
             PR_Close(pfd[index].fd);
 
-    Telemetry::Accumulate(Telemetry::NETWORK_PROBE_MAXCOUNT, gMaxCount);
     SOCKET_LOG(("Socket Limit Test max was confirmed at %d\n", gMaxCount));
 }
 #endif // windows

--- a/netwerk/base/nsUDPSocket.cpp
+++ b/netwerk/base/nsUDPSocket.cpp
@@ -777,33 +777,6 @@ nsUDPSocket::CloseSocket()
       }
 
       PR_Close(mFD);
-
-      if (gSocketTransportService->IsTelemetryEnabledAndNotSleepPhase()) {
-        PRIntervalTime now = PR_IntervalNow();
-        if (gIOService->IsNetTearingDown()) {
-          Telemetry::Accumulate(Telemetry::PRCLOSE_UDP_BLOCKING_TIME_SHUTDOWN,
-                                PR_IntervalToMilliseconds(now - closeStarted));
-
-        } else if (PR_IntervalToSeconds(now - gIOService->LastConnectivityChange())
-                   < 60) {
-          Telemetry::Accumulate(Telemetry::PRCLOSE_UDP_BLOCKING_TIME_CONNECTIVITY_CHANGE,
-                                PR_IntervalToMilliseconds(now - closeStarted));
-
-        } else if (PR_IntervalToSeconds(now - gIOService->LastNetworkLinkChange())
-                   < 60) {
-          Telemetry::Accumulate(Telemetry::PRCLOSE_UDP_BLOCKING_TIME_LINK_CHANGE,
-                                PR_IntervalToMilliseconds(now - closeStarted));
-
-        } else if (PR_IntervalToSeconds(now - gIOService->LastOfflineStateChange())
-                   < 60) {
-          Telemetry::Accumulate(Telemetry::PRCLOSE_UDP_BLOCKING_TIME_OFFLINE,
-                                PR_IntervalToMilliseconds(now - closeStarted));
-
-        } else {
-          Telemetry::Accumulate(Telemetry::PRCLOSE_UDP_BLOCKING_TIME_NORMAL,
-                                PR_IntervalToMilliseconds(now - closeStarted));
-        }
-      }
     }
     mFD = nullptr;
   }

--- a/netwerk/cache/nsCacheService.cpp
+++ b/netwerk/cache/nsCacheService.cpp
@@ -2655,18 +2655,7 @@ nsCacheService::Lock(mozilla::Telemetry::ID mainThreadLockerID)
         generalID = mozilla::Telemetry::CACHE_SERVICE_LOCK_WAIT_2;
     }
 
-    TimeStamp start(TimeStamp::Now());
-
     nsCacheService::Lock();
-
-    TimeStamp stop(TimeStamp::Now());
-
-    // Telemetry isn't thread safe on its own, but this is OK because we're
-    // protecting it with the cache lock. 
-    if (lockerID != mozilla::Telemetry::HistogramCount) {
-        mozilla::Telemetry::AccumulateTimeDelta(lockerID, start, stop);
-    }
-    mozilla::Telemetry::AccumulateTimeDelta(generalID, start, stop);
 }
 
 void

--- a/netwerk/cache/nsDiskCacheMap.cpp
+++ b/netwerk/cache/nsDiskCacheMap.cpp
@@ -19,7 +19,6 @@
 
 #include "mozilla/MemoryReporting.h"
 #include "mozilla/Sprintf.h"
-#include "mozilla/Telemetry.h"
 #include <algorithm>
 
 using namespace mozilla;
@@ -181,9 +180,6 @@ nsDiskCacheMap::Open(nsIFile *  cacheDirectory,
         goto error_exit;
     }
     
-    Telemetry::Accumulate(Telemetry::HTTP_DISK_CACHE_OVERHEAD,
-                          (uint32_t)SizeOfExcludingThis(moz_malloc_size_of));
-
     *corruptInfo = nsDiskCache::kNotCorrupt;
     return NS_OK;
     

--- a/netwerk/cache2/CacheFile.cpp
+++ b/netwerk/cache2/CacheFile.cpp
@@ -14,7 +14,6 @@
 #include <algorithm>
 #include "nsComponentManagerUtils.h"
 #include "nsProxyRelease.h"
-#include "mozilla/Telemetry.h"
 
 // When CACHE_CHUNKS is defined we always cache unused chunks in mCacheChunks.
 // When it is not defined, we always release the chunks ASAP, i.e. we cache
@@ -1914,9 +1913,6 @@ CacheFile::RemoveInput(CacheFileInputStream *aInput, nsresult aStatus)
   // chunks that won't be used anymore.
   CleanUpCachedChunks();
 
-  Telemetry::Accumulate(Telemetry::NETWORK_CACHE_V2_INPUT_STREAM_STATUS,
-                        StatusToTelemetryEnum(aStatus));
-
   return NS_OK;
 }
 
@@ -1951,9 +1947,6 @@ CacheFile::RemoveOutput(CacheFileOutputStream *aOutput, nsresult aStatus)
 
   // Notify close listener as the last action
   aOutput->NotifyCloseListener();
-
-  Telemetry::Accumulate(Telemetry::NETWORK_CACHE_V2_OUTPUT_STREAM_STATUS,
-                        StatusToTelemetryEnum(aStatus));
 
   return NS_OK;
 }

--- a/netwerk/cache2/CacheFileIOManager.cpp
+++ b/netwerk/cache2/CacheFileIOManager.cpp
@@ -21,7 +21,6 @@
 #include "nsIObserverService.h"
 #include "nsICacheStorageVisitor.h"
 #include "nsISizeOf.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/DebugOnly.h"
 #include "mozilla/Services.h"
 #include "nsDirectoryServiceUtils.h"
@@ -3861,7 +3860,6 @@ CacheFileIOManager::CreateCacheTree()
     }
 #endif
 
-    Telemetry::Accumulate(Telemetry::NETWORK_CACHE_FS_TYPE, fsType);
     CacheObserver::SetCacheFSReported();
   }
 
@@ -3917,8 +3915,6 @@ CacheFileIOManager::OpenNSPRHandle(CacheFileHandle *aHandle, bool aCreate)
           uint32_t cacheUsage;
           if (NS_SUCCEEDED(CacheIndex::GetCacheSize(&cacheUsage))) {
             cacheUsage >>= 10;
-            Telemetry::Accumulate(Telemetry::NETWORK_CACHE_SIZE_FULL_FAT,
-                                  cacheUsage);
             sSizeReported = true;
           }
         }

--- a/netwerk/cache2/CacheFileMetadata.cpp
+++ b/netwerk/cache2/CacheFileMetadata.cpp
@@ -14,7 +14,6 @@
 #include "nsICacheEntry.h" // for nsICacheEntryMetaDataVisitor
 #include "../cache/nsCacheUtils.h"
 #include "nsIFile.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/DebugOnly.h"
 #include "prnetdb.h"
 
@@ -687,16 +686,6 @@ CacheFileMetadata::OnDataRead(CacheFileHandle *aHandle, char *aBuf,
     return NS_OK;
   }
 
-  if (mFirstRead) {
-    Telemetry::AccumulateTimeDelta(
-      Telemetry::NETWORK_CACHE_METADATA_FIRST_READ_TIME_MS, mReadStart);
-    Telemetry::Accumulate(
-      Telemetry::NETWORK_CACHE_METADATA_FIRST_READ_SIZE, mBufSize);
-  } else {
-    Telemetry::AccumulateTimeDelta(
-      Telemetry::NETWORK_CACHE_METADATA_SECOND_READ_TIME_MS, mReadStart);
-  }
-
   // check whether we have read all necessary data
   uint32_t realOffset = NetworkEndian::readUint32(mBuf + mBufSize -
                                                   sizeof(uint32_t));
@@ -775,9 +764,6 @@ CacheFileMetadata::OnDataRead(CacheFileHandle *aHandle, char *aBuf,
 
     return NS_OK;
   }
-
-  Telemetry::Accumulate(Telemetry::NETWORK_CACHE_METADATA_SIZE,
-                        size - realOffset);
 
   // We have all data according to offset information at the end of the entry.
   // Try to parse it.

--- a/netwerk/cache2/CacheFileUtils.cpp
+++ b/netwerk/cache2/CacheFileUtils.cpp
@@ -7,7 +7,6 @@
 #include "CacheFileUtils.h"
 #include "LoadContextInfo.h"
 #include "mozilla/Tokenizer.h"
-#include "mozilla/Telemetry.h"
 #include "nsCOMPtr.h"
 #include "nsAutoPtr.h"
 #include "nsString.h"
@@ -474,19 +473,6 @@ DetailedCacheHitTelemetry::AddRecord(ERecType aType, TimeStamp aLoadStart)
 
   StaticMutexAutoLock lock(sLock);
 
-  if (aType == MISS) {
-    mozilla::Telemetry::AccumulateTimeDelta(
-      mozilla::Telemetry::NETWORK_CACHE_V2_MISS_TIME_MS,
-      aLoadStart);
-  } else {
-    mozilla::Telemetry::AccumulateTimeDelta(
-      mozilla::Telemetry::NETWORK_CACHE_V2_HIT_TIME_MS,
-      aLoadStart);
-  }
-
-  Telemetry::Accumulate(Telemetry::NETWORK_CACHE_HIT_MISS_STAT_PER_CACHE_SIZE,
-                        hitMissValue);
-
   sHRStats[rangeIdx].AddRecord(aType);
   ++sRecordCnt;
 
@@ -505,8 +491,6 @@ DetailedCacheHitTelemetry::AddRecord(ERecType aType, TimeStamp aLoadStart)
       uint32_t bucketOffset = sHRStats[i].GetHitRateBucket(kHitRateBuckets) *
                               kNumOfRanges;
 
-      Telemetry::Accumulate(Telemetry::NETWORK_CACHE_HIT_RATE_PER_CACHE_SIZE,
-                            bucketOffset + i);
       sHRStats[i].Reset();
     }
   }

--- a/netwerk/cache2/CacheFileUtils.h
+++ b/netwerk/cache2/CacheFileUtils.h
@@ -138,7 +138,7 @@ private:
   // 10-%15%, ...
   static const uint32_t kHitRateBuckets = 20;
 
-  // Protects sRecordCnt, sHitStats and Telemetry::Accumulated() calls.
+  // Protects sRecordCnt and sHitStats calls.
   static StaticMutex sLock;
 
   // Counter of samples that is compared against kTotalSamplesReportLimit.

--- a/netwerk/cache2/CacheIOThread.cpp
+++ b/netwerk/cache2/CacheIOThread.cpp
@@ -62,8 +62,6 @@ void CacheIOTelemetry::Report(uint32_t aLevel, CacheIOTelemetry::size_type aLeng
 
   // 10 is number of buckets we have in each probe
   aLength = std::min<size_type>(aLength, 10);
-
-  Telemetry::Accumulate(telemetryID[aLevel], aLength - 1); // counted from 0
 }
 
 } // anon

--- a/netwerk/cache2/CacheIndex.cpp
+++ b/netwerk/cache2/CacheIndex.cpp
@@ -3757,7 +3757,6 @@ ReportHashSizeMatch(const SHA1Sum::Hash *aHash1, const SHA1Sum::Hash *aHash2)
       bitsDiff++;
 
       uint8_t hashSizeMatch = debruijn32[bitsDiff*0x076be629>>27] + (i<<5);
-      Telemetry::Accumulate(Telemetry::NETWORK_CACHE_HASH_STATS, hashSizeMatch);
 
       return;
     }

--- a/netwerk/cache2/CacheStorageService.cpp
+++ b/netwerk/cache2/CacheStorageService.cpp
@@ -2084,8 +2084,6 @@ CacheStorageService::TelemetryRecordEntryCreation(CacheEntry const* entry)
 
   mPurgeTimeStamps.Remove(key);
 
-  Telemetry::AccumulateTimeDelta(Telemetry::HTTP_CACHE_ENTRY_RELOAD_TIME,
-                                 timeStamp, TimeStamp::NowLoRes());
 }
 
 void
@@ -2112,9 +2110,6 @@ CacheStorageService::TelemetryRecordEntryRemoval(CacheEntry const* entry)
   TelemetryPrune(now);
   mPurgeTimeStamps.Put(key, now);
 
-  Telemetry::Accumulate(Telemetry::HTTP_CACHE_ENTRY_REUSE_COUNT, entry->UseCount());
-  Telemetry::AccumulateTimeDelta(Telemetry::HTTP_CACHE_ENTRY_ALIVE_TIME,
-                                 entry->LoadStart(), TimeStamp::NowLoRes());
 }
 
 // nsIMemoryReporter

--- a/netwerk/cache2/OldWrappers.cpp
+++ b/netwerk/cache2/OldWrappers.cpp
@@ -21,7 +21,6 @@
 #include "nsNetCID.h"
 #include "nsNetUtil.h"
 #include "nsProxyRelease.h"
-#include "mozilla/Telemetry.h"
 
 static NS_DEFINE_CID(kStreamTransportServiceCID,
                      NS_STREAMTRANSPORTSERVICE_CID);
@@ -791,24 +790,6 @@ _OldCacheLoad::Run()
     if (!mCallback) {
       LOG(("  duplicate call, bypassed"));
       return NS_OK;
-    }
-
-    if (NS_SUCCEEDED(mStatus)) {
-      if (mFlags & nsICacheStorage::OPEN_TRUNCATE) {
-        mozilla::Telemetry::AccumulateTimeDelta(
-          mozilla::Telemetry::NETWORK_CACHE_V1_TRUNCATE_TIME_MS,
-          mLoadStart);
-      }
-      else if (mNew) {
-        mozilla::Telemetry::AccumulateTimeDelta(
-          mozilla::Telemetry::NETWORK_CACHE_V1_MISS_TIME_MS,
-          mLoadStart);
-      }
-      else {
-        mozilla::Telemetry::AccumulateTimeDelta(
-          mozilla::Telemetry::NETWORK_CACHE_V1_HIT_TIME_MS,
-          mLoadStart);
-      }
     }
 
     if (!(mFlags & CHECK_MULTITHREADED))

--- a/netwerk/dns/nsHostResolver.cpp
+++ b/netwerk/dns/nsHostResolver.cpp
@@ -225,7 +225,6 @@ nsHostRecord::CopyExpirationTimesAndFlagsFrom(const nsHostRecord *aFromHostRecor
 
 nsHostRecord::~nsHostRecord()
 {
-    Telemetry::Accumulate(Telemetry::DNS_BLACKLIST_COUNT, mBlacklistedCount);
     delete addr_info;
     delete addr;
 }
@@ -775,7 +774,6 @@ nsHostResolver::ResolveHost(const char            *host,
                      LOG_HOST(host, netInterface)));
                 // put reference to host record on stack...
                 result = he->rec;
-                Telemetry::Accumulate(Telemetry::DNS_LOOKUP_METHOD2, METHOD_HIT);
 
                 // For entries that are in the grace period
                 // or all cached negative entries, use the cache but start a new
@@ -785,8 +783,6 @@ nsHostResolver::ResolveHost(const char            *host,
                 if (he->rec->negative) {
                     LOG(("  Negative cache entry for host [%s%s%s].\n",
                          LOG_HOST(host, netInterface)));
-                    Telemetry::Accumulate(Telemetry::DNS_LOOKUP_METHOD2,
-                                          METHOD_NEGATIVE_HIT);
                     status = NS_ERROR_UNKNOWN_HOST;
                 }
             }
@@ -794,8 +790,6 @@ nsHostResolver::ResolveHost(const char            *host,
             // go ahead and use it.
             else if (he->rec->addr) {
                 LOG(("  Using cached address for IP Literal [%s].\n", host));
-                Telemetry::Accumulate(Telemetry::DNS_LOOKUP_METHOD2,
-                                      METHOD_LITERAL);
                 result = he->rec;
             }
             // try parsing the host name as an IP address literal to short
@@ -808,8 +802,6 @@ nsHostResolver::ResolveHost(const char            *host,
                 he->rec->addr = new NetAddr();
                 PRNetAddrToNetAddr(&tempAddr, he->rec->addr);
                 // put reference to host record on stack...
-                Telemetry::Accumulate(Telemetry::DNS_LOOKUP_METHOD2,
-                                      METHOD_LITERAL);
                 result = he->rec;
             }
             else if (mPendingCount >= MAX_NON_PRIORITY_REQUESTS &&
@@ -819,8 +811,6 @@ nsHostResolver::ResolveHost(const char            *host,
                      "host [%s%s%s].\n",
                      IsMediumPriority(flags) ? "medium" : "low",
                      LOG_HOST(host, netInterface)));
-                Telemetry::Accumulate(Telemetry::DNS_LOOKUP_METHOD2,
-                                      METHOD_OVERFLOW);
                 // This is a lower priority request and we are swamped, so refuse it.
                 rv = NS_ERROR_DNS_LOOKUP_QUEUE_FULL;
             }
@@ -885,8 +875,6 @@ nsHostResolver::ResolveHost(const char            *host,
                             if (he->rec->negative) {
                                 status = NS_ERROR_UNKNOWN_HOST;
                             }
-                            Telemetry::Accumulate(Telemetry::DNS_LOOKUP_METHOD2,
-                                                  METHOD_HIT);
                             ConditionallyRefreshRecord(he->rec, host);
                         }
                         // For AF_INET6, a new lookup means another AF_UNSPEC
@@ -900,8 +888,6 @@ nsHostResolver::ResolveHost(const char            *host,
                             result = he->rec;
                             he->rec->negative = true;
                             status = NS_ERROR_UNKNOWN_HOST;
-                            Telemetry::Accumulate(Telemetry::DNS_LOOKUP_METHOD2,
-                                                  METHOD_NEGATIVE_HIT);
                         }
                     }
                 }
@@ -915,8 +901,6 @@ nsHostResolver::ResolveHost(const char            *host,
                     PR_APPEND_LINK(callback, &he->rec->callbacks);
                     he->rec->flags = flags;
                     rv = IssueLookup(he->rec);
-                    Telemetry::Accumulate(Telemetry::DNS_LOOKUP_METHOD2,
-                                          METHOD_NETWORK_FIRST);
                     if (NS_FAILED(rv)) {
                         PR_REMOVE_AND_INIT_LINK(callback);
                     }
@@ -933,8 +917,6 @@ nsHostResolver::ResolveHost(const char            *host,
 
                 PR_APPEND_LINK(callback, &he->rec->callbacks);
                 if (he->rec->onQueue) {
-                    Telemetry::Accumulate(Telemetry::DNS_LOOKUP_METHOD2,
-                                          METHOD_NETWORK_SHARED);
 
                     // Consider the case where we are on a pending queue of
                     // lower priority than the request is being made at.
@@ -1085,13 +1067,6 @@ nsHostResolver::ConditionallyRefreshRecord(nsHostRecord *rec, const char *host)
         LOG(("  Using %s cache entry for host [%s] but starting async renewal.",
             rec->negative ? "negative" :"positive", host));
         IssueLookup(rec);
-
-        if (!rec->negative) {
-            // negative entries are constantly being refreshed, only
-            // track positive grace period induced renewals
-            Telemetry::Accumulate(Telemetry::DNS_LOOKUP_METHOD2,
-                METHOD_RENEWAL);
-        }
     }
     return NS_OK;
 }
@@ -1326,13 +1301,6 @@ nsHostResolver::OnLookupComplete(nsHostRecord* rec, nsresult status, AddrInfo* n
                 PR_REMOVE_AND_INIT_LINK(head);
                 mDB.Remove((nsHostKey *) head);
 
-                if (!head->negative) {
-                    // record the age of the entry upon eviction.
-                    TimeDuration age = TimeStamp::NowLoRes() - head->mValidStart;
-                    Telemetry::Accumulate(Telemetry::DNS_CLEANUP_AGE,
-                                          static_cast<uint32_t>(age.ToSeconds() / 60));
-                }
-
                 // release reference to rec owned by mEvictionQ
                 NS_RELEASE(head);
             }
@@ -1466,32 +1434,6 @@ nsHostResolver::ThreadFunc(void *arg)
                                  getTtl);
         }
 #endif
-
-        {   // obtain lock to check shutdown and manage inter-module telemetry
-            MutexAutoLock lock(resolver->mLock);
-
-            if (!resolver->mShutdown) {
-                TimeDuration elapsed = TimeStamp::Now() - startTime;
-                uint32_t millis = static_cast<uint32_t>(elapsed.ToMilliseconds());
-
-                if (NS_SUCCEEDED(status)) {
-                    Telemetry::ID histogramID;
-                    if (!rec->addr_info_gencnt) {
-                        // Time for initial lookup.
-                        histogramID = Telemetry::DNS_LOOKUP_TIME;
-                    } else if (!getTtl) {
-                        // Time for renewal; categorized by expiration strategy.
-                        histogramID = Telemetry::DNS_RENEWAL_TIME;
-                    } else {
-                        // Time to get TTL; categorized by expiration strategy.
-                        histogramID = Telemetry::DNS_RENEWAL_TIME_FOR_TTL;
-                    }
-                    Telemetry::Accumulate(histogramID, millis);
-                } else {
-                    Telemetry::Accumulate(Telemetry::DNS_FAILED_LOOKUP_TIME, millis);
-                }
-            }
-        }
 
         // OnLookupComplete may release "rec", long before we lose it.
         LOG(("DNS lookup thread - lookup completed for host [%s%s%s]: %s.\n",

--- a/netwerk/protocol/http/ASpdySession.cpp
+++ b/netwerk/protocol/http/ASpdySession.cpp
@@ -45,8 +45,6 @@ ASpdySession::NewSpdySession(uint32_t version,
   // from a list provided in the SERVER HELLO filtered by our acceptable
   // versions, so there is no risk of the server ignoring our prefs.
 
-  Telemetry::Accumulate(Telemetry::SPDY_VERSION2, version);
-
   return new Http2Session(aTransport, version, attemptingEarlyData);
 }
 

--- a/netwerk/protocol/http/Http2Compression.cpp
+++ b/netwerk/protocol/http/Http2Compression.cpp
@@ -292,12 +292,6 @@ Http2BaseCompressor::Http2BaseCompressor()
 
 Http2BaseCompressor::~Http2BaseCompressor()
 {
-  if (mPeakSize) {
-    Telemetry::Accumulate(mPeakSizeID, mPeakSize);
-  }
-  if (mPeakCount) {
-    Telemetry::Accumulate(mPeakCountID, mPeakCount);
-  }
   UnregisterStrongMemoryReporter(mDynamicReporter);
   mDynamicReporter->mCompressor = nullptr;
   mDynamicReporter = nullptr;
@@ -335,16 +329,6 @@ Http2BaseCompressor::MakeRoom(uint32_t amount, const char *direction)
     ++countEvicted;
     bytesEvicted += mHeaderTable[index]->Size();
     mHeaderTable.RemoveElement();
-  }
-
-  if (!strcmp(direction, "decompressor")) {
-    Telemetry::Accumulate(Telemetry::HPACK_ELEMENTS_EVICTED_DECOMPRESSOR, countEvicted);
-    Telemetry::Accumulate(Telemetry::HPACK_BYTES_EVICTED_DECOMPRESSOR, bytesEvicted);
-    Telemetry::Accumulate(Telemetry::HPACK_BYTES_EVICTED_RATIO_DECOMPRESSOR, (uint32_t)((100.0 * (double)bytesEvicted) / (double)amount));
-  } else {
-    Telemetry::Accumulate(Telemetry::HPACK_ELEMENTS_EVICTED_COMPRESSOR, countEvicted);
-    Telemetry::Accumulate(Telemetry::HPACK_BYTES_EVICTED_COMPRESSOR, bytesEvicted);
-    Telemetry::Accumulate(Telemetry::HPACK_BYTES_EVICTED_RATIO_COMPRESSOR, (uint32_t)((100.0 * (double)bytesEvicted) / (double)amount));
   }
 }
 

--- a/netwerk/protocol/http/Http2Session.cpp
+++ b/netwerk/protocol/http/Http2Session.cpp
@@ -168,13 +168,6 @@ Http2Session::~Http2Session()
         this, mDownstreamState));
 
   Shutdown();
-
-  Telemetry::Accumulate(Telemetry::SPDY_PARALLEL_STREAMS, mConcurrentHighWater);
-  Telemetry::Accumulate(Telemetry::SPDY_REQUEST_PER_CONN, (mNextStreamID - 1) / 2);
-  Telemetry::Accumulate(Telemetry::SPDY_SERVER_INITIATED_STREAMS,
-                        mServerPushedResources);
-  Telemetry::Accumulate(Telemetry::SPDY_GOAWAY_LOCAL, mClientGoAwayReason);
-  Telemetry::Accumulate(Telemetry::SPDY_GOAWAY_PEER, mPeerGoAwayReason);
 }
 
 void
@@ -1508,13 +1501,11 @@ Http2Session::RecvSettings(Http2Session *self)
 
     case SETTINGS_TYPE_MAX_CONCURRENT:
       self->mMaxConcurrent = value;
-      Telemetry::Accumulate(Telemetry::SPDY_SETTINGS_MAX_STREAMS, value);
       self->ProcessPending();
       break;
 
     case SETTINGS_TYPE_INITIAL_WINDOW:
       {
-        Telemetry::Accumulate(Telemetry::SPDY_SETTINGS_IW, value >> 10);
         int32_t delta = value - self->mServerInitialStreamWindow;
         self->mServerInitialStreamWindow = value;
 
@@ -2494,8 +2485,6 @@ Http2Session::ReadyToProcessDataFrame(enum internalStateType newState)
              newState == DISCARDING_DATA_FRAME_PADDING);
   ChangeDownstreamState(newState);
 
-  Telemetry::Accumulate(Telemetry::SPDY_CHUNK_RECVD,
-                        mInputFrameDataSize >> 10);
   mLastDataReadEpoch = mLastReadEpoch;
 
   if (!mInputFrameID) {

--- a/netwerk/protocol/http/Http2Stream.cpp
+++ b/netwerk/protocol/http/Http2Stream.cpp
@@ -21,7 +21,6 @@
 #include "Http2Push.h"
 #include "TunnelUtils.h"
 
-#include "mozilla/Telemetry.h"
 #include "nsAlgorithm.h"
 #include "nsHttp.h"
 #include "nsHttpHandler.h"
@@ -658,8 +657,6 @@ Http2Stream::GenerateOpen()
     outputOffset += frameLen;
   }
 
-  Telemetry::Accumulate(Telemetry::SPDY_SYN_SIZE, compressedData.Length());
-
   // The size of the input headers is approximate
   uint32_t ratio =
     compressedData.Length() * 100 /
@@ -667,7 +664,6 @@ Http2Stream::GenerateOpen()
      mFlatHttpRequestHeaders.Length());
 
   mFlatHttpRequestHeaders.Truncate();
-  Telemetry::Accumulate(Telemetry::SPDY_SYN_RATIO, ratio);
   return NS_OK;
 }
 
@@ -1023,13 +1019,6 @@ Http2Stream::ConvertResponseHeaders(Http2Decompressor *decompressor,
     // 8.1.1 of h2 disallows 101.. throw PROTOCOL_ERROR on stream
     LOG3(("Http2Stream::ConvertResponseHeaders %p Error - status == 101\n", this));
     return NS_ERROR_ILLEGAL_VALUE;
-  }
-
-  if (aHeadersIn.Length() && aHeadersOut.Length()) {
-    Telemetry::Accumulate(Telemetry::SPDY_SYN_REPLY_SIZE, aHeadersIn.Length());
-    uint32_t ratio =
-      aHeadersIn.Length() * 100 / aHeadersOut.Length();
-    Telemetry::Accumulate(Telemetry::SPDY_SYN_REPLY_RATIO, ratio);
   }
 
   // The decoding went ok. Now we can customize and clean up.

--- a/netwerk/protocol/http/HttpBaseChannel.cpp
+++ b/netwerk/protocol/http/HttpBaseChannel.cpp
@@ -49,7 +49,6 @@
 #include "LoadInfo.h"
 #include "nsNullPrincipal.h"
 #include "nsISSLSocketControl.h"
-#include "mozilla/Telemetry.h"
 #include "nsIURL.h"
 #include "nsIConsoleService.h"
 #include "mozilla/BinarySearch.h"
@@ -1006,7 +1005,6 @@ HttpBaseChannel::DoApplyContentConversions(nsIStreamListener* aNextListener,
         } else if (from.Equals("br")) {
           mode = 3;
         }
-        Telemetry::Accumulate(Telemetry::HTTP_CONTENT_ENCODING, mode);
       }
       nextListener = converter;
     }

--- a/netwerk/protocol/http/nsHttpChannelAuthProvider.cpp
+++ b/netwerk/protocol/http/nsHttpChannelAuthProvider.cpp
@@ -867,24 +867,6 @@ nsHttpChannelAuthProvider::GetCredentialsForChallenge(const char *challenge,
             else if (authFlags & nsIHttpAuthenticator::IDENTITY_ENCRYPTED)
                 level = nsIAuthPrompt2::LEVEL_PW_ENCRYPTED;
 
-            // Collect statistics on how frequently the various types of HTTP
-            // authentication are used over SSL and non-SSL connections.
-            if (gHttpHandler->IsTelemetryEnabled()) {
-              if (NS_LITERAL_CSTRING("basic").LowerCaseEqualsASCII(authType)) {
-                Telemetry::Accumulate(Telemetry::HTTP_AUTH_TYPE_STATS,
-                  UsingSSL() ? HTTP_AUTH_BASIC_SECURE : HTTP_AUTH_BASIC_INSECURE);
-              } else if (NS_LITERAL_CSTRING("digest").LowerCaseEqualsASCII(authType)) {
-                Telemetry::Accumulate(Telemetry::HTTP_AUTH_TYPE_STATS,
-                  UsingSSL() ? HTTP_AUTH_DIGEST_SECURE : HTTP_AUTH_DIGEST_INSECURE);
-              } else if (NS_LITERAL_CSTRING("ntlm").LowerCaseEqualsASCII(authType)) {
-                Telemetry::Accumulate(Telemetry::HTTP_AUTH_TYPE_STATS,
-                  UsingSSL() ? HTTP_AUTH_NTLM_SECURE : HTTP_AUTH_NTLM_INSECURE);
-              } else if (NS_LITERAL_CSTRING("negotiate").LowerCaseEqualsASCII(authType)) {
-                Telemetry::Accumulate(Telemetry::HTTP_AUTH_TYPE_STATS,
-                  UsingSSL() ? HTTP_AUTH_NEGOTIATE_SECURE : HTTP_AUTH_NEGOTIATE_INSECURE);
-              }
-            }
-
             // Depending on the pref setting, the authentication dialog may be
             // blocked for all sub-resources, blocked for cross-origin
             // sub-resources, or always allowed for sub-resources.
@@ -988,22 +970,6 @@ nsHttpChannelAuthProvider::BlockPrompt()
             if (!NS_SecurityCompareURIs(topURI, mURI, true)) {
                 mCrossOrigin = true;
             }
-        }
-    }
-
-    if (gHttpHandler->IsTelemetryEnabled()) {
-        if (topDoc) {
-            Telemetry::Accumulate(Telemetry::HTTP_AUTH_DIALOG_STATS,
-                                  HTTP_AUTH_DIALOG_TOP_LEVEL_DOC);
-        } else if (xhr) {
-            Telemetry::Accumulate(Telemetry::HTTP_AUTH_DIALOG_STATS,
-                                  HTTP_AUTH_DIALOG_XHR);
-        } else if (!mCrossOrigin) {
-            Telemetry::Accumulate(Telemetry::HTTP_AUTH_DIALOG_STATS,
-                                  HTTP_AUTH_DIALOG_SAME_ORIGIN_SUBRESOURCE);
-        } else {
-            Telemetry::Accumulate(Telemetry::HTTP_AUTH_DIALOG_STATS,
-                                  HTTP_AUTH_DIALOG_CROSS_ORIGIN_SUBRESOURCE);
         }
     }
 

--- a/netwerk/protocol/http/nsHttpConnectionMgr.cpp
+++ b/netwerk/protocol/http/nsHttpConnectionMgr.cpp
@@ -23,7 +23,6 @@
 #include "mozilla/net/DNS.h"
 #include "nsISocketTransport.h"
 #include "nsISSLSocketControl.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/net/DashboardTypes.h"
 #include "NullHttpTransaction.h"
 #include "nsIDNSRecord.h"
@@ -847,7 +846,6 @@ nsHttpConnectionMgr::GetSpdyPreferredEnt(nsConnectionEntry *aOriginalEntry)
              "with %s connections. rv=%x isJoined=%d",
              preferred->mConnInfo->Origin(), aOriginalEntry->mConnInfo->Origin(),
              rv, isJoined));
-        Telemetry::Accumulate(Telemetry::SPDY_NPN_JOIN, false);
         return nullptr;
     }
 
@@ -857,7 +855,6 @@ nsHttpConnectionMgr::GetSpdyPreferredEnt(nsConnectionEntry *aOriginalEntry)
          "so %s will be coalesced with %s",
          preferred->mConnInfo->Origin(), aOriginalEntry->mConnInfo->Origin(),
          aOriginalEntry->mConnInfo->Origin(), preferred->mConnInfo->Origin()));
-    Telemetry::Accumulate(Telemetry::SPDY_NPN_JOIN, true);
     return preferred;
 }
 
@@ -1835,16 +1832,7 @@ nsHttpConnectionMgr::BuildPipeline(nsConnectionEntry *ent,
 void
 nsHttpConnectionMgr::ReportProxyTelemetry(nsConnectionEntry *ent)
 {
-    enum { PROXY_NONE = 1, PROXY_HTTP = 2, PROXY_SOCKS = 3, PROXY_HTTPS = 4 };
-
-    if (!ent->mConnInfo->UsingProxy())
-        Telemetry::Accumulate(Telemetry::HTTP_PROXY_TYPE, PROXY_NONE);
-    else if (ent->mConnInfo->UsingHttpsProxy())
-        Telemetry::Accumulate(Telemetry::HTTP_PROXY_TYPE, PROXY_HTTPS);
-    else if (ent->mConnInfo->UsingHttpProxy())
-        Telemetry::Accumulate(Telemetry::HTTP_PROXY_TYPE, PROXY_HTTP);
-    else
-        Telemetry::Accumulate(Telemetry::HTTP_PROXY_TYPE, PROXY_SOCKS);
+  /* STUB */
 }
 
 nsresult
@@ -3107,8 +3095,6 @@ nsHalfOpenSocket::SetupStreams(nsISocketTransport **transport,
     rv = socketTransport->SetSecurityCallbacks(this);
     NS_ENSURE_SUCCESS(rv, rv);
 
-    Telemetry::Accumulate(Telemetry::HTTP_CONNECTION_ENTRY_CACHE_HIT_1,
-                          mEnt->mUsedForConnection);
     mEnt->mUsedForConnection = true;
 
     nsCOMPtr<nsIOutputStream> sout;

--- a/netwerk/protocol/http/nsHttpHandler.cpp
+++ b/netwerk/protocol/http/nsHttpHandler.cpp
@@ -58,7 +58,6 @@
 #include "mozilla/net/NeckoChild.h"
 #include "mozilla/net/NeckoParent.h"
 #include "mozilla/ipc/URIUtils.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/Unused.h"
 #include "mozilla/BasePrincipal.h"
 
@@ -2182,11 +2181,6 @@ nsHttpHandler::Observe(nsISupports *subject,
         // depend on this value.
         mSessionStartTime = NowInSeconds();
 
-        if (!mDoNotTrackEnabled) {
-            Telemetry::Accumulate(Telemetry::DNT_USAGE, 2);
-        } else {
-            Telemetry::Accumulate(Telemetry::DNT_USAGE, 1);
-        }
     } else if (!strcmp(topic, "profile-change-net-restore")) {
         // initialize connection manager
         InitConnectionMgr();

--- a/netwerk/protocol/websocket/WebSocketChannel.cpp
+++ b/netwerk/protocol/websocket/WebSocketChannel.cpp
@@ -55,7 +55,6 @@
 #include "nsNetUtil.h"
 #include "nsINode.h"
 #include "mozilla/StaticMutex.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/TimeStamp.h"
 #include "nsSocketTransportService2.h"
 
@@ -2989,7 +2988,6 @@ WebSocketChannel::ReportConnectionTelemetry()
     (didProxy ? (1 << 0) : 0);
 
   LOG(("WebSocketChannel::ReportConnectionTelemetry() %p %d", this, value));
-  Telemetry::Accumulate(Telemetry::WEBSOCKETS_HANDSHAKE_TYPE, value);
 }
 
 // nsIDNSListener

--- a/netwerk/system/linux/nsNotifyAddrListener_Linux.cpp
+++ b/netwerk/system/linux/nsNotifyAddrListener_Linux.cpp
@@ -24,7 +24,6 @@
 #include "mozilla/Services.h"
 #include "mozilla/SHA1.h"
 #include "mozilla/Sprintf.h"
-#include "mozilla/Telemetry.h"
 
 /* a shorter name that better explains what it does */
 #define EINTR_RETRY(x) MOZ_TEMP_FAILURE_RETRY(x)
@@ -176,12 +175,10 @@ void nsNotifyAddrListener::calculateNetworkId(void)
                                 LOG(("networkid: id %s\n", output.get()));
                                 if (mNetworkId != output) {
                                     // new id
-                                    Telemetry::Accumulate(Telemetry::NETWORK_ID, 1);
                                     mNetworkId = output;
                                 }
                                 else {
                                     // same id
-                                    Telemetry::Accumulate(Telemetry::NETWORK_ID, 2);
                                 }
                                 found = true;
                                 break;
@@ -195,7 +192,6 @@ void nsNotifyAddrListener::calculateNetworkId(void)
     } /* if (froute) */
     if (!found) {
         // no id
-        Telemetry::Accumulate(Telemetry::NETWORK_ID, 0);
     }
 }
 

--- a/netwerk/system/mac/nsNetworkLinkService.mm
+++ b/netwerk/system/mac/nsNetworkLinkService.mm
@@ -24,7 +24,6 @@
 #include "mozilla/Preferences.h"
 #include "mozilla/SHA1.h"
 #include "mozilla/Base64.h"
-#include "mozilla/Telemetry.h"
 #include "nsNetworkLinkService.h"
 
 #import <Cocoa/Cocoa.h>
@@ -274,19 +273,16 @@ void nsNetworkLinkService::calculateNetworkId(void)
             LOG(("networkid: id %s\n", output.get()));
             if (mNetworkId != output) {
                 // new id
-                Telemetry::Accumulate(Telemetry::NETWORK_ID, 1);
                 mNetworkId = output;
             }
             else {
                 // same id
-                Telemetry::Accumulate(Telemetry::NETWORK_ID, 2);
             }
             found = true;
         }
     }
     if (!found) {
         // no id
-        Telemetry::Accumulate(Telemetry::NETWORK_ID, 0);
     }
 }
 

--- a/netwerk/system/win32/nsNotifyAddrListener.cpp
+++ b/netwerk/system/win32/nsNotifyAddrListener.cpp
@@ -35,7 +35,6 @@
 #include "mozilla/Preferences.h"
 #include "mozilla/SHA1.h"
 #include "mozilla/Base64.h"
-#include "mozilla/Telemetry.h"
 
 #include <iptypes.h>
 #include <iphlpapi.h>
@@ -218,12 +217,10 @@ bool nsNotifyAddrListener::findMac(char *gateway)
                     LOG(("networkid: id %s\n", output.get()));
                     if (mNetworkId != output) {
                         // new id
-                        Telemetry::Accumulate(Telemetry::NETWORK_ID, 1);
                         mNetworkId = output;
                     }
                     else {
                         // same id
-                        Telemetry::Accumulate(Telemetry::NETWORK_ID, 2);
                     }
                     found = true;
                     break;
@@ -290,7 +287,6 @@ void nsNotifyAddrListener::calculateNetworkId(void)
     }
     if (!found) {
         // no id
-        Telemetry::Accumulate(Telemetry::NETWORK_ID, 0);
     }
 }
 

--- a/security/manager/ssl/DataStorage.cpp
+++ b/security/manager/ssl/DataStorage.cpp
@@ -276,9 +276,6 @@ DataStorage::Reader::Run()
         }
       }
     } while (true);
-
-    Telemetry::Accumulate(Telemetry::DATA_STORAGE_ENTRIES,
-                          mDataStorage->mPersistentDataTable.Count());
   }
 
   return NS_OK;

--- a/security/manager/ssl/nsKeygenHandler.cpp
+++ b/security/manager/ssl/nsKeygenHandler.cpp
@@ -399,48 +399,7 @@ loser:
 void
 GatherKeygenTelemetry(uint32_t keyGenMechanism, int keysize, char* curve)
 {
-  if (keyGenMechanism == CKM_RSA_PKCS_KEY_PAIR_GEN) {
-    if (keysize > 8196 || keysize < 0) {
-      return;
-    }
-
-    nsCString telemetryValue("rsa");
-    telemetryValue.AppendPrintf("%d", keysize);
-    mozilla::Telemetry::Accumulate(
-        mozilla::Telemetry::KEYGEN_GENERATED_KEY_TYPE, telemetryValue);
-  } else if (keyGenMechanism == CKM_EC_KEY_PAIR_GEN) {
-    nsCString secp384r1 = NS_LITERAL_CSTRING("secp384r1");
-    nsCString secp256r1 = NS_LITERAL_CSTRING("secp256r1");
-
-    mozilla::UniqueSECItem decoded = DecodeECParams(curve);
-    if (!decoded) {
-      switch (keysize) {
-        case 2048:
-          mozilla::Telemetry::Accumulate(
-              mozilla::Telemetry::KEYGEN_GENERATED_KEY_TYPE, secp384r1);
-          break;
-        case 1024:
-        case 512:
-          mozilla::Telemetry::Accumulate(
-              mozilla::Telemetry::KEYGEN_GENERATED_KEY_TYPE, secp256r1);
-          break;
-      }
-    } else {
-      if (secp384r1.EqualsIgnoreCase(curve, secp384r1.Length())) {
-          mozilla::Telemetry::Accumulate(
-              mozilla::Telemetry::KEYGEN_GENERATED_KEY_TYPE, secp384r1);
-      } else if (secp256r1.EqualsIgnoreCase(curve, secp256r1.Length())) {
-          mozilla::Telemetry::Accumulate(
-              mozilla::Telemetry::KEYGEN_GENERATED_KEY_TYPE, secp256r1);
-      } else {
-        mozilla::Telemetry::Accumulate(
-            mozilla::Telemetry::KEYGEN_GENERATED_KEY_TYPE, NS_LITERAL_CSTRING("other_ec"));
-      }
-    }
-  } else {
-    MOZ_CRASH("Unknown keygen algorithm");
-    return;
-  }
+/* STUB */
 }
 
 nsresult

--- a/security/manager/ssl/nsNSSComponent.cpp
+++ b/security/manager/ssl/nsNSSComponent.cpp
@@ -805,29 +805,22 @@ nsNSSComponent::MaybeEnableFamilySafetyCompatibility()
   if (familySafetyMode > 2) {
     familySafetyMode = 0;
   }
-  Telemetry::Accumulate(Telemetry::FAMILY_SAFETY, familySafetyMode);
   if (familySafetyMode == 0) {
     return;
   }
   bool familySafetyEnabled;
   nsresult rv = AccountHasFamilySafetyEnabled(familySafetyEnabled);
   if (NS_FAILED(rv)) {
-    Telemetry::Accumulate(Telemetry::FAMILY_SAFETY, 3);
     return;
   }
   if (!familySafetyEnabled) {
-    Telemetry::Accumulate(Telemetry::FAMILY_SAFETY, 4);
     return;
   }
-  Telemetry::Accumulate(Telemetry::FAMILY_SAFETY, 5);
   if (familySafetyMode == 2) {
     rv = LoadFamilySafetyRoot();
     if (NS_FAILED(rv)) {
-      Telemetry::Accumulate(Telemetry::FAMILY_SAFETY, 6);
       MOZ_LOG(gPIPNSSLog, LogLevel::Debug,
               ("failed to load Family Safety root"));
-    } else {
-      Telemetry::Accumulate(Telemetry::FAMILY_SAFETY, 7);
     }
   }
 #endif // XP_WIN
@@ -1580,13 +1573,6 @@ void nsNSSComponent::setValidationOptions(bool isInitialSetting,
   bool ocspRequired = ocspEnabled &&
     Preferences::GetBool("security.OCSP.require", false);
 
-  // We measure the setting of the pref at startup only to minimize noise by
-  // addons that may muck with the settings, though it probably doesn't matter.
-  if (isInitialSetting) {
-    Telemetry::Accumulate(Telemetry::CERT_OCSP_ENABLED, ocspEnabled);
-    Telemetry::Accumulate(Telemetry::CERT_OCSP_REQUIRED, ocspRequired);
-  }
-
   bool ocspStaplingEnabled = Preferences::GetBool("security.ssl.enable_ocsp_stapling",
                                                   true);
   PublicSSLState()->SetOCSPStaplingEnabled(ocspStaplingEnabled);
@@ -1978,9 +1964,6 @@ nsNSSComponent::InitializeNSS()
     return NS_ERROR_FAILURE;
   }
 
-  if (PK11_IsFIPS()) {
-    Telemetry::Accumulate(Telemetry::FIPS_ENABLED, true);
-  }
   MOZ_LOG(gPIPNSSLog, LogLevel::Debug, ("NSS Initialization done\n"));
   return NS_OK;
 }

--- a/security/manager/ssl/nsNTLMAuthModule.cpp
+++ b/security/manager/ssl/nsNTLMAuthModule.cpp
@@ -1009,11 +1009,6 @@ nsNTLMAuthModule::Init(const char      *serviceName,
 
   static bool sTelemetrySent = false;
   if (!sTelemetrySent) {
-      mozilla::Telemetry::Accumulate(
-          mozilla::Telemetry::NTLM_MODULE_USED_2,
-          serviceFlags & nsIAuthModule::REQ_PROXY_AUTH
-              ? NTLM_MODULE_GENERIC_PROXY
-              : NTLM_MODULE_GENERIC_DIRECT);
       sTelemetrySent = true;
   }
 

--- a/security/manager/ssl/nsPKCS11Slot.cpp
+++ b/security/manager/ssl/nsPKCS11Slot.cpp
@@ -541,10 +541,6 @@ nsPKCS11ModuleDB::ToggleFIPSMode()
     return NS_ERROR_FAILURE;
   }
 
-  if (PK11_IsFIPS()) {
-    Telemetry::Accumulate(Telemetry::FIPS_ENABLED, true);
-  }
-
   return NS_OK;
 }
 

--- a/storage/mozStorageAsyncStatementExecution.cpp
+++ b/storage/mozStorageAsyncStatementExecution.cpp
@@ -235,14 +235,12 @@ AsyncExecuteStatements::executeStatement(sqlite3_stmt *aStatement)
     // Stop if we have no more results.
     if (rc == SQLITE_DONE)
     {
-      Telemetry::Accumulate(Telemetry::MOZ_STORAGE_ASYNC_REQUESTS_SUCCESS, true);
       return false;
     }
 
     // If we got results, we can return now.
     if (rc == SQLITE_ROW)
     {
-      Telemetry::Accumulate(Telemetry::MOZ_STORAGE_ASYNC_REQUESTS_SUCCESS, true);
       return true;
     }
 
@@ -258,7 +256,6 @@ AsyncExecuteStatements::executeStatement(sqlite3_stmt *aStatement)
 
     // Set an error state.
     mState = ERROR;
-    Telemetry::Accumulate(Telemetry::MOZ_STORAGE_ASYNC_REQUESTS_SUCCESS, false);
 
     // Construct the error message before giving up the mutex (which we cannot
     // hold during the call to notifyError).

--- a/toolkit/components/alerts/nsAlertsService.cpp
+++ b/toolkit/components/alerts/nsAlertsService.cpp
@@ -6,7 +6,6 @@
 #include "mozilla/dom/ContentChild.h"
 #include "mozilla/dom/PermissionMessageUtils.h"
 #include "mozilla/Preferences.h"
-#include "mozilla/Telemetry.h"
 #include "nsXULAppAPI.h"
 
 #include "nsAlertsService.h"
@@ -292,9 +291,6 @@ NS_IMETHODIMP nsAlertsService::SetManualDoNotDisturb(bool aDoNotDisturb)
   NS_ENSURE_TRUE(alertsDND, NS_ERROR_NOT_IMPLEMENTED);
 
   nsresult rv = alertsDND->SetManualDoNotDisturb(aDoNotDisturb);
-  if (NS_SUCCEEDED(rv)) {
-    Telemetry::Accumulate(Telemetry::ALERTS_SERVICE_DND_ENABLED, 1);
-  }
   return rv;
 #endif
 }

--- a/toolkit/components/perfmonitoring/nsPerformanceStats.cpp
+++ b/toolkit/components/perfmonitoring/nsPerformanceStats.cpp
@@ -27,7 +27,6 @@
 #include "mozilla/ArrayUtils.h"
 #include "mozilla/EventStateManager.h"
 #include "mozilla/Services.h"
-#include "mozilla/Telemetry.h"
 
 #if defined(XP_WIN)
 #include <processthreadsapi.h>
@@ -957,22 +956,7 @@ nsPerformanceStatsService::SetJankAlertBufferingDelay(uint32_t value) {
 nsresult
 nsPerformanceStatsService::UpdateTelemetry()
 {
-  // Promote everything to floating-point explicitly before dividing.
-  const double processStayed = mProcessStayed;
-  const double processMoved = mProcessMoved;
-
-  if (processStayed <= 0 || processMoved <= 0 || processStayed + processMoved <= 0) {
-    // Overflow/underflow/nothing to report
-    return NS_OK;
-  }
-
-  const double proportion = (100 * processStayed) / (processStayed + processMoved);
-  if (proportion < 0 || proportion > 100) {
-    // Overflow/underflow
-    return NS_OK;
-  }
-
-  mozilla::Telemetry::Accumulate(mozilla::Telemetry::PERF_MONITORING_TEST_CPU_RESCHEDULING_PROPORTION_MOVED, (uint32_t)proportion);
+  /* STUB */
   return NS_OK;
 }
 

--- a/toolkit/components/places/Database.cpp
+++ b/toolkit/components/places/Database.cpp
@@ -615,9 +615,6 @@ Database::BackupAndReplaceDatabaseFile(nsCOMPtr<mozIStorageService>& aStorage)
         // Set up a pref to try replacing the database at the next startup.
         Preferences::SetBool(PREF_FORCE_DATABASE_REPLACEMENT, true);
       }
-      // Report the corruption through telemetry.
-      Telemetry::Accumulate(Telemetry::PLACES_DATABASE_CORRUPTION_HANDLING_STAGE,
-                            static_cast<int8_t>(stage));
     });
 
     // Close database connection if open.

--- a/toolkit/components/places/FaviconHelpers.cpp
+++ b/toolkit/components/places/FaviconHelpers.cpp
@@ -14,7 +14,6 @@
 #include "nsNavHistory.h"
 #include "nsFaviconService.h"
 #include "mozilla/storage.h"
-#include "mozilla/Telemetry.h"
 #include "nsNetUtil.h"
 #include "nsPrintfCString.h"
 #include "nsStreamUtils.h"
@@ -580,33 +579,6 @@ AsyncFetchAndSetIconForPage::OnStopRequest(nsIRequest* aRequest,
   }
 
   mIcon.expiration = GetExpirationTimeFromChannel(channel);
-
-  // Telemetry probes to measure the favicon file sizes for each different file type.
-  // This allow us to measure common file sizes while also observing each type popularity.
-  if (mIcon.mimeType.EqualsLiteral("image/png")) {
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::PLACES_FAVICON_PNG_SIZES, mIcon.data.Length());
-  }
-  else if (mIcon.mimeType.EqualsLiteral("image/x-icon") ||
-           mIcon.mimeType.EqualsLiteral("image/vnd.microsoft.icon")) {
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::PLACES_FAVICON_ICO_SIZES, mIcon.data.Length());
-  }
-  else if (mIcon.mimeType.EqualsLiteral("image/jpeg") ||
-           mIcon.mimeType.EqualsLiteral("image/pjpeg")) {
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::PLACES_FAVICON_JPEG_SIZES, mIcon.data.Length());
-  }
-  else if (mIcon.mimeType.EqualsLiteral("image/gif")) {
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::PLACES_FAVICON_GIF_SIZES, mIcon.data.Length());
-  }
-  else if (mIcon.mimeType.EqualsLiteral("image/bmp") ||
-           mIcon.mimeType.EqualsLiteral("image/x-windows-bmp")) {
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::PLACES_FAVICON_BMP_SIZES, mIcon.data.Length());
-  }
-  else if (mIcon.mimeType.EqualsLiteral("image/svg+xml")) {
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::PLACES_FAVICON_SVG_SIZES, mIcon.data.Length());
-  }
-  else {
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::PLACES_FAVICON_OTHER_SIZES, mIcon.data.Length());
-  }
 
   rv = OptimizeIconSize(mIcon, favicons);
   NS_ENSURE_SUCCESS(rv, rv);

--- a/toolkit/components/places/Helpers.cpp
+++ b/toolkit/components/places/Helpers.cpp
@@ -385,9 +385,7 @@ AsyncStatementCallbackNotifier::HandleCompletion(uint16_t aReason)
 NS_IMETHODIMP
 AsyncStatementTelemetryTimer::HandleCompletion(uint16_t aReason)
 {
-  if (aReason == mozIStorageStatementCallback::REASON_FINISHED) {
-    Telemetry::AccumulateTimeDelta(mHistogramId, mStart);
-  }
+  /* STUB */
   return NS_OK;
 }
 

--- a/toolkit/components/startup/nsAppStartup.cpp
+++ b/toolkit/components/startup/nsAppStartup.cpp
@@ -758,11 +758,6 @@ nsAppStartup::GetStartupInfo(JSContext* aCx, JS::MutableHandle<JS::Value> aRetva
 
     procTime = TimeStamp::ProcessCreation(error);
 
-    if (error) {
-      Telemetry::Accumulate(Telemetry::STARTUP_MEASUREMENT_ERRORS,
-        StartupTimeline::PROCESS_CREATION);
-    }
-
     StartupTimeline::Record(StartupTimeline::PROCESS_CREATION, procTime);
   }
 
@@ -777,8 +772,6 @@ nsAppStartup::GetStartupInfo(JSContext* aCx, JS::MutableHandle<JS::Value> aRetva
       // Always define main to aid with bug 689256.
       stamp = procTime;
       MOZ_ASSERT(!stamp.IsNull());
-      Telemetry::Accumulate(Telemetry::STARTUP_MEASUREMENT_ERRORS,
-        StartupTimeline::MAIN);
     }
 
     if (!stamp.IsNull()) {
@@ -787,8 +780,6 @@ nsAppStartup::GetStartupInfo(JSContext* aCx, JS::MutableHandle<JS::Value> aRetva
           / PR_USEC_PER_MSEC;
         JS::Rooted<JSObject*> date(aCx, JS::NewDateObject(aCx, JS::TimeClip(prStamp)));
         JS_DefineProperty(aCx, obj, StartupTimeline::Describe(ev), date, JSPROP_ENUMERATE);
-      } else {
-        Telemetry::Accumulate(Telemetry::STARTUP_MEASUREMENT_ERRORS, ev);
       }
     }
   }
@@ -886,9 +877,6 @@ nsAppStartup::TrackStartupCrashBegin(bool *aIsSafeModeNecessary)
   // sanity check that the pref set at last success is not greater than the current time
   if (PR_Now() / PR_USEC_PER_SEC <= lastSuccessfulStartup)
     return NS_ERROR_FAILURE;
-
-  // The last startup was a crash so include it in the count regardless of when it happened.
-  Telemetry::Accumulate(Telemetry::STARTUP_CRASH_DETECTED, true);
 
   if (inSafeMode) {
     GetAutomaticSafeModeNecessary(aIsSafeModeNecessary);

--- a/toolkit/components/url-classifier/Classifier.cpp
+++ b/toolkit/components/url-classifier/Classifier.cpp
@@ -15,7 +15,6 @@
 #include "nsNetCID.h"
 #include "nsPrintfCString.h"
 #include "nsThreadUtils.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/Logging.h"
 #include "mozilla/SyncRunnable.h"
 #include "mozilla/Base64.h"
@@ -498,9 +497,6 @@ Classifier::Check(const nsACString& aSpec,
         matchingStatistics |= PrefixMatch::eMatchV2Prefix;
       }
     }
-
-    Telemetry::Accumulate(Telemetry::URLCLASSIFIER_PREFIX_MATCH,
-                          static_cast<uint8_t>(matchingStatistics));
   }
 
   return NS_OK;

--- a/toolkit/components/url-classifier/LookupCache.cpp
+++ b/toolkit/components/url-classifier/LookupCache.cpp
@@ -6,7 +6,6 @@
 #include "LookupCache.h"
 #include "HashStore.h"
 #include "nsISeekableStream.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/Logging.h"
 #include "nsNetUtil.h"
 #include "prprf.h"
@@ -451,9 +450,6 @@ nsresult
 LookupCacheV2::Build(AddPrefixArray& aAddPrefixes,
                      AddCompleteArray& aAddCompletes)
 {
-  Telemetry::Accumulate(Telemetry::URLCLASSIFIER_LC_COMPLETIONS,
-                        static_cast<uint32_t>(aAddCompletes.Length()));
-
   mUpdateCompletions.Clear();
   mUpdateCompletions.SetCapacity(aAddCompletes.Length());
   for (uint32_t i = 0; i < aAddCompletes.Length(); i++) {
@@ -461,9 +457,6 @@ LookupCacheV2::Build(AddPrefixArray& aAddPrefixes,
   }
   aAddCompletes.Clear();
   mUpdateCompletions.Sort();
-
-  Telemetry::Accumulate(Telemetry::URLCLASSIFIER_LC_PREFIXES,
-                        static_cast<uint32_t>(aAddPrefixes.Length()));
 
   nsresult rv = ConstructPrefixSet(aAddPrefixes);
   NS_ENSURE_SUCCESS(rv, rv);

--- a/toolkit/components/url-classifier/LookupCacheV4.cpp
+++ b/toolkit/components/url-classifier/LookupCacheV4.cpp
@@ -144,9 +144,6 @@ LookupCacheV4::LoadFromFile(nsIFile* aFile)
   }
 
   rv = VerifyChecksum(checksum);
-  Telemetry::Accumulate(Telemetry::URLCLASSIFIER_VLPS_LOAD_CORRUPT,
-                        rv == NS_ERROR_FILE_CORRUPTED);
-
   return rv;
 }
 
@@ -231,8 +228,6 @@ LookupCacheV4::ApplyUpdate(TableUpdateV4* aTableUpdate,
     if (!isOldMapEmpty && !isAddMapEmpty) {
       if (smallestOldPrefix == smallestAddPrefix) {
         LOG(("Add prefix should not exist in the original prefix set."));
-        Telemetry::Accumulate(Telemetry::URLCLASSIFIER_UPDATE_ERROR_TYPE,
-                              DUPLICATE_PREFIX);
         return NS_ERROR_FAILURE;
       }
 
@@ -274,15 +269,11 @@ LookupCacheV4::ApplyUpdate(TableUpdateV4* aTableUpdate,
   // the number of original prefix plus add prefix.
   if (index <= 0) {
     LOG(("There are still prefixes remaining after reaching maximum runs."));
-    Telemetry::Accumulate(Telemetry::URLCLASSIFIER_UPDATE_ERROR_TYPE,
-                          INFINITE_LOOP);
     return NS_ERROR_FAILURE;
   }
 
   if (removalIndex < removalArray.Length()) {
     LOG(("There are still prefixes to remove after exhausting the old PrefixSet."));
-    Telemetry::Accumulate(Telemetry::URLCLASSIFIER_UPDATE_ERROR_TYPE,
-                          WRONG_REMOVAL_INDICES);
     return NS_ERROR_FAILURE;
   }
 
@@ -290,8 +281,6 @@ LookupCacheV4::ApplyUpdate(TableUpdateV4* aTableUpdate,
   crypto->Finish(false, checksum);
   if (aTableUpdate->Checksum().IsEmpty()) {
     LOG(("Update checksum missing."));
-    Telemetry::Accumulate(Telemetry::URLCLASSIFIER_UPDATE_ERROR_TYPE,
-                          MISSING_CHECKSUM);
 
     // Generate our own checksum to tableUpdate to ensure there is always
     // checksum in .metadata
@@ -300,8 +289,6 @@ LookupCacheV4::ApplyUpdate(TableUpdateV4* aTableUpdate,
 
   } else if (aTableUpdate->Checksum() != checksum){
     LOG(("Checksum mismatch after applying partial update"));
-    Telemetry::Accumulate(Telemetry::URLCLASSIFIER_UPDATE_ERROR_TYPE,
-                          CHECKSUM_MISMATCH);
     return NS_ERROR_FAILURE;
   }
 

--- a/toolkit/components/url-classifier/nsUrlClassifierDBService.cpp
+++ b/toolkit/components/url-classifier/nsUrlClassifierDBService.cpp
@@ -37,7 +37,6 @@
 #include "mozilla/Mutex.h"
 #include "mozilla/Preferences.h"
 #include "mozilla/TimeStamp.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/Logging.h"
 #include "prprf.h"
 #include "prnetdb.h"
@@ -320,9 +319,6 @@ nsUrlClassifierDBServiceWorker::HandlePendingLookups()
       MutexAutoUnlock unlock(mPendingLookupLock);
       DoLookup(lookup.mKey, lookup.mTables, lookup.mCallback);
     }
-    double lookupTime = (TimeStamp::Now() - lookup.mStartTime).ToMilliseconds();
-    Telemetry::Accumulate(Telemetry::URLCLASSIFIER_LOOKUP_TIME,
-                          static_cast<uint32_t>(lookupTime));
   }
 
   return NS_OK;

--- a/toolkit/components/url-classifier/nsUrlClassifierStreamUpdater.cpp
+++ b/toolkit/components/url-classifier/nsUrlClassifierStreamUpdater.cpp
@@ -646,9 +646,6 @@ nsUrlClassifierStreamUpdater::OnStartRequest(nsIRequest *request,
     if (NS_FAILED(status)) {
       // Assume we're overloading the server and trigger backoff.
       downloadError = true;
-      mozilla::Telemetry::Accumulate(mozilla::Telemetry::URLCLASSIFIER_UPDATE_REMOTE_STATUS,
-                                     15 /* unknown response code */);
-
     } else {
       bool succeeded = false;
       rv = httpChannel->GetRequestSucceeded(&succeeded);
@@ -657,8 +654,6 @@ nsUrlClassifierStreamUpdater::OnStartRequest(nsIRequest *request,
       uint32_t requestStatus;
       rv = httpChannel->GetResponseStatus(&requestStatus);
       NS_ENSURE_SUCCESS(rv, rv);
-      mozilla::Telemetry::Accumulate(mozilla::Telemetry::URLCLASSIFIER_UPDATE_REMOTE_STATUS,
-                                     HTTPStatusToBucket(requestStatus));
       LOG(("nsUrlClassifierStreamUpdater::OnStartRequest %s (%d)", succeeded ?
            "succeeded" : "failed", requestStatus));
       if (!succeeded) {

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -4338,11 +4338,6 @@ mozilla::BrowserTabsRemoteAutostart()
 
   gBrowserTabsRemoteStatus = status;
 
-  mozilla::Telemetry::Accumulate(mozilla::Telemetry::E10S_STATUS, status);
-  if (prefEnabled) {
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::E10S_BLOCKED_FROM_RUNNING,
-                                    !gBrowserTabsRemoteAutostart);
-  }
   return gBrowserTabsRemoteAutostart;
 }
 

--- a/toolkit/xre/nsXREDirProvider.cpp
+++ b/toolkit/xre/nsXREDirProvider.cpp
@@ -953,27 +953,6 @@ nsXREDirProvider::DoStartup()
       else
         mode = 2;
     }
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::SAFE_MODE_USAGE, mode);
-
-    // Telemetry about number of profiles.
-    nsCOMPtr<nsIToolkitProfileService> profileService =
-      do_GetService("@mozilla.org/toolkit/profile-service;1");
-    if (profileService) {
-      nsCOMPtr<nsISimpleEnumerator> profiles;
-      rv = profileService->GetProfiles(getter_AddRefs(profiles));
-      if (NS_WARN_IF(NS_FAILED(rv))) {
-        return rv;
-      }
-
-      uint32_t count = 0;
-      nsCOMPtr<nsISupports> profile;
-      while (NS_SUCCEEDED(profiles->GetNext(getter_AddRefs(profile)))) {
-        ++count;
-      }
-
-      mozilla::Telemetry::Accumulate(mozilla::Telemetry::NUMBER_OF_PROFILES,
-                                     count);
-    }
 
     obsSvc->NotifyObservers(nullptr, "profile-initial-state", nullptr);
   }

--- a/widget/android/fennec/Telemetry.h
+++ b/widget/android/fennec/Telemetry.h
@@ -44,7 +44,6 @@ public:
     AddHistogram(jni::String::Param aName, int32_t aValue)
     {
         MOZ_ASSERT(aName);
-        mozilla::Telemetry::Accumulate(aName->ToCString().get(), aValue);
     }
 
     static void
@@ -52,8 +51,6 @@ public:
                       int32_t aValue)
     {
         MOZ_ASSERT(aName && aKey);
-        mozilla::Telemetry::Accumulate(aName->ToCString().get(),
-                                       aKey->ToCString(), aValue);
     }
 
     static void

--- a/widget/windows/nsLookAndFeel.cpp
+++ b/widget/windows/nsLookAndFeel.cpp
@@ -11,7 +11,6 @@
 #include "nsUXThemeConstants.h"
 #include "gfxFont.h"
 #include "WinUtils.h"
-#include "mozilla/Telemetry.h"
 #include "mozilla/WindowsVersion.h"
 #include "gfxFontConstants.h"
 
@@ -65,8 +64,6 @@ nsLookAndFeel::nsLookAndFeel()
   : nsXPLookAndFeel()
   , mUseAccessibilityTheme(0)
 {
-  mozilla::Telemetry::Accumulate(mozilla::Telemetry::TOUCH_ENABLED_DEVICE,
-                                 WinUtils::IsTouchDeviceSupportPresent());
 }
 
 nsLookAndFeel::~nsLookAndFeel()

--- a/widget/windows/nsWindow.cpp
+++ b/widget/windows/nsWindow.cpp
@@ -4232,10 +4232,6 @@ nsWindow::DispatchMouseEvent(EventMessage aEventMessage, WPARAM wParam,
   }
 
   if (WinUtils::GetIsMouseFromTouch(aEventMessage)) {
-    if (aEventMessage == eMouseDown) {
-      Telemetry::Accumulate(Telemetry::FX_TOUCH_USED, 1);
-    }
-
     if (mTouchWindow) {
       // If mTouchWindow is true, then we must have APZ enabled and be
       // feeding it raw touch events. In that case we don't need to
@@ -6750,8 +6746,6 @@ bool nsWindow::OnGesture(WPARAM wParam, LPARAM lParam)
     bool endFeedback = true;
 
     if (mGesture.PanDeltaToPixelScroll(wheelEvent)) {
-      mozilla::Telemetry::Accumulate(mozilla::Telemetry::SCROLL_INPUT_METHODS,
-          (uint32_t) ScrollInputMethod::MainThreadTouch);
       DispatchEvent(&wheelEvent, status);
     }
 

--- a/xpcom/base/CycleCollectedJSContext.cpp
+++ b/xpcom/base/CycleCollectedJSContext.cpp
@@ -1547,9 +1547,6 @@ IncrementalFinalizeRunnable::Run()
     }
   }
 
-  uint32_t duration = (uint32_t)((TimeStamp::Now() - start).ToMilliseconds());
-  Telemetry::Accumulate(Telemetry::DEFERRED_FINALIZE_ASYNC, duration);
-
   return NS_OK;
 }
 

--- a/xpcom/base/nsCycleCollector.cpp
+++ b/xpcom/base/nsCycleCollector.cpp
@@ -528,15 +528,6 @@ public:
 #define CC_GRAPH_ASSERT(b)
 #endif
 
-#define CC_TELEMETRY(_name, _value)                                            \
-    PR_BEGIN_MACRO                                                             \
-    if (NS_IsMainThread()) {                                                   \
-      Telemetry::Accumulate(Telemetry::CYCLE_COLLECTOR##_name, _value);        \
-    } else {                                                                   \
-      Telemetry::Accumulate(Telemetry::CYCLE_COLLECTOR_WORKER##_name, _value); \
-    }                                                                          \
-    PR_END_MACRO
-
 enum NodeColor { black, white, grey };
 
 // This structure should be kept as small as possible; we may expect
@@ -2966,7 +2957,6 @@ nsCycleCollector::ScanWeakMaps()
 
   if (failed) {
     MOZ_ASSERT(false, "Ran out of memory in ScanWeakMaps");
-    CC_TELEMETRY(_OOM, true);
   }
 }
 
@@ -3109,7 +3099,6 @@ nsCycleCollector::ScanIncrementalRoots()
 
   if (failed) {
     NS_ASSERTION(false, "Ran out of memory in ScanIncrementalRoots");
-    CC_TELEMETRY(_OOM, true);
   }
 }
 
@@ -3171,7 +3160,6 @@ nsCycleCollector::ScanBlackNodes()
 
   if (failed) {
     NS_ASSERTION(false, "Ran out of memory in ScanBlackNodes");
-    CC_TELEMETRY(_OOM, true);
   }
 }
 
@@ -3501,7 +3489,6 @@ nsCycleCollector::FixGrayBits(bool aForceGC, TimeLog& aTimeLog)
 
     bool needGC = !mJSContext->AreGCGrayBitsValid();
     // Only do a telemetry ping for non-shutdown CCs.
-    CC_TELEMETRY(_NEED_GC, needGC);
     if (!needGC) {
       return;
     }
@@ -3553,10 +3540,6 @@ nsCycleCollector::CleanupAfterCollection()
   printf(".\ncc: \n");
 #endif
 
-  CC_TELEMETRY( , interval);
-  CC_TELEMETRY(_VISITED_REF_COUNTED, mResults.mVisitedRefCounted);
-  CC_TELEMETRY(_VISITED_GCED, mResults.mVisitedGCed);
-  CC_TELEMETRY(_COLLECTED, mWhiteNodeCount);
   timeLog.Checkpoint("CleanupAfterCollection::telemetry");
 
   if (mJSContext) {

--- a/xpcom/threads/HangMonitor.cpp
+++ b/xpcom/threads/HangMonitor.cpp
@@ -249,8 +249,6 @@ NotifyActivity(ActivityType aActivityType)
 
   // If we have UI activity we should reset the timer and report it
   if (aActivityType == kUIActivity) {
-    mozilla::Telemetry::Accumulate(mozilla::Telemetry::EVENTLOOP_UI_ACTIVITY_EXP_MS,
-                                     cumulativeUILagMS);
     cumulativeUILagMS = 0;
   }
 


### PR DESCRIPTION
This creates a number of stubs and leaves some surrounding code that may be irrelevant (eg. recorded time stamps, status variables).
Stub resolution/removal should be a follow-up to this.

Because of the pervasive nature of almost 800 calls, also in hot paths, this will very likely noticeably improve performance of everything building on UXP.

Asking for review because this is a huge commit and I may have made some mistakes. Verification that this still builds on Linux is also important before merging.

Tag #21