### PR TITLE
[GCC] Add -Wno-noexcept-type to the js build flags

### DIFF
--- a/build/moz.configure/warnings.configure
+++ b/build/moz.configure/warnings.configure
@@ -109,6 +109,14 @@ check_and_add_gcc_warning('-Wno-error=multistatement-macros')
 check_and_add_gcc_warning('-Wno-format',
                           when=depends(target)(lambda t: t.kernel == 'WINNT'))
 
+# Disable a warning with GCC 7+.
+# We are far from using C++17 and the impact of the warning will be
+# limited to a potential public ABI.
+# Currently only affecting js/
+check_and_add_gcc_warning('-Wno-noexcept-type', cxx_compiler,
+                          when=depends(build_project)
+                          (lambda build_project: build_project == 'js'))
+
 # Please keep these last in this file
 add_old_configure_assignment('_WARNINGS_CFLAGS', warnings_cflags)
 add_old_configure_assignment('_WARNINGS_CXXFLAGS', warnings_cxxflags)


### PR DESCRIPTION
Just what it says in the tin.

Silences a couple compiler warnings when using GCC 7 and higher.

Tag #457 