### PR TITLE
backport mozbug 1350090: Turn off the spammy warning that goes off every time we create an about:blank content viewer; r=mystor

### DIFF
--- a/extensions/cookie/nsPermissionManager.cpp
+++ b/extensions/cookie/nsPermissionManager.cpp
@@ -107,7 +107,11 @@ nsresult
 GetOriginFromPrincipal(nsIPrincipal* aPrincipal, nsACString& aOrigin)
 {
   nsresult rv = aPrincipal->GetOriginNoSuffix(aOrigin);
-  NS_ENSURE_SUCCESS(rv, rv);
+  // The principal may belong to the about:blank content viewer, so this can be
+  // expected to fail.
+  if (NS_FAILED(rv)) {
+    return rv;
+  }
 
   nsAutoCString suffix;
   rv = aPrincipal->GetOriginSuffix(suffix);


### PR DESCRIPTION
During a debug session, log spam appears because we are trying to get the origin out of a principal for about:blank, which will throw, which is expected.

Ref: WARNING: NS_ENSURE_SUCCESS(rv, rv) failed with result 0x80004005: file extensions/cookie/nsPermissionManager.cpp, line 90 - [mozbug 1350090](https://bugzilla.mozilla.org/show_bug.cgi?id=1350090) 