### PR TITLE
Silence the -Wuninitialized warning in mozjemalloc

### DIFF
--- a/memory/mozjemalloc/moz.build
+++ b/memory/mozjemalloc/moz.build
@@ -37,7 +37,10 @@ LOCAL_INCLUDES += [
 ]
 
 if CONFIG['GNU_CC']:
-    CFLAGS += ['-Wno-unused'] # too many annoying warnings from mfbt/ headers
+     # too many annoying warnings from mfbt/ headers
+     # also too many false positives from functions generated through rb_wrab from rb.h.
+    CFLAGS += ['-Wno-unused',
+               '-Wno-uninitialized']
 
 if CONFIG['_MSC_VER']:
     CFLAGS += ['-wd4273'] # inconsistent dll linkage (bug 558163)


### PR DESCRIPTION
This PR silences around a dozen compiler warnings with GCC 7+

Tag #457 