### PR TITLE
Skip notifications for background tabs when restoring a session in Pale Moon and Basilisk

### DIFF
--- a/application/basilisk/base/content/tabbrowser.xml
+++ b/application/basilisk/base/content/tabbrowser.xml
@@ -2101,6 +2101,7 @@
             var aRelatedBrowser;
             var aOriginPrincipal;
             var aOpener;
+            var aSkipBackgroundNotify;
             if (arguments.length == 2 &&
                 typeof arguments[1] == "object" &&
                 !(arguments[1] instanceof Ci.nsIURI)) {
@@ -2123,6 +2124,7 @@
               aRelatedBrowser       = params.relatedBrowser;
               aOriginPrincipal      = params.originPrincipal;
               aOpener               = params.opener;
+              aSkipBackgroundNotify = params.skipBackgroundNotify;
             }
 
             // if we're adding tabs, we're past interrupt mode, ditch the owner
@@ -2151,6 +2153,11 @@
 
             t.setAttribute("crop", "end");
             t.setAttribute("onerror", "this.removeAttribute('image');");
+
+            if (aSkipBackgroundNotify) {
+              t.setAttribute("skipbackgroundnotify", true);
+            }
+
             t.className = "tabbrowser-tab";
 
             this.tabContainer._unlockTabSizing();
@@ -5932,7 +5939,11 @@
             this._fillTrailingGap();
             this._handleTabSelect();
           } else {
-            this._notifyBackgroundTab(tab);
+            if (tab.hasAttribute("skipbackgroundnotify")) {
+              tab.removeAttribute("skipbackgroundnotify");
+            } else {
+              this._notifyBackgroundTab(tab);
+            }
           }
 
           // XXXmano: this is a temporary workaround for bug 345399

--- a/application/basilisk/components/sessionstore/SessionStore.jsm
+++ b/application/basilisk/components/sessionstore/SessionStore.jsm
@@ -3113,7 +3113,8 @@ var SessionStoreInternal = {
                                 tabbrowser.addTab("about:blank",
                                                   {skipAnimation: true,
                                                    forceNotRemote,
-                                                   userContextId});
+                                                   userContextId,
+                                                   skipBackgroundNotify: true});
 
       // If we inserted a new tab because the userContextId didn't match with the
       // open tab, even though `t < openTabCount`, we need to remove that open tab

--- a/application/basilisk/components/sessionstore/TabAttributes.jsm
+++ b/application/basilisk/components/sessionstore/TabAttributes.jsm
@@ -14,7 +14,10 @@ this.EXPORTED_SYMBOLS = ["TabAttributes"];
 // 'pending' is used internal by sessionstore and managed accordingly.
 // 'iconLoadingPrincipal' is same as 'image' that it should be handled by
 //                        using the gBrowser.getIcon()/setIcon() methods.
-const ATTRIBUTES_TO_SKIP = new Set(["image", "muted", "pending", "iconLoadingPrincipal"]);
+// 'skipbackgroundnotify' is used internal by tabbrowser.xml.
+const ATTRIBUTES_TO_SKIP = new Set(["image", "muted", "pending",
+                                    "iconLoadingPrincipal",
+                                    "skipbackgroundnotify"]);
 
 // A set of tab attributes to persist. We will read a given list of tab
 // attributes when collecting tab data and will re-set those attributes when

--- a/application/palemoon/base/content/tabbrowser.xml
+++ b/application/palemoon/base/content/tabbrowser.xml
@@ -1429,6 +1429,7 @@
             var aRelatedToCurrent;
             var aSkipAnimation;
             var aOriginPrincipal;
+            var aSkipBackgroundNotify;
             if (arguments.length == 2 &&
                 typeof arguments[1] == "object" &&
                 !(arguments[1] instanceof Ci.nsIURI)) {
@@ -1444,6 +1445,7 @@
               aRelatedToCurrent     = params.relatedToCurrent;
               aSkipAnimation        = params.skipAnimation;
               aOriginPrincipal      = params.originPrincipal;
+              aSkipBackgroundNotify = params.skipBackgroundNotify;
             }
 
             // if we're adding tabs, we're past interrupt mode, ditch the owner
@@ -1467,6 +1469,11 @@
             t.setAttribute("crop", "end");
             t.setAttribute("validate", "never"); //PMed
             t.setAttribute("onerror", "this.removeAttribute('image');");
+
+            if (aSkipBackgroundNotify) {
+              t.setAttribute("skipbackgroundnotify", true);
+            }
+
             t.className = "tabbrowser-tab";
 
             this.tabContainer._unlockTabSizing();
@@ -4143,7 +4150,11 @@
             this._fillTrailingGap();
             this._handleTabSelect();
           } else {
-            this._notifyBackgroundTab(tab);
+            if (tab.hasAttribute("skipbackgroundnotify")) {
+              tab.removeAttribute("skipbackgroundnotify");
+            } else {
+              this._notifyBackgroundTab(tab);
+            }
           }
 
           // XXXmano: this is a temporary workaround for bug 345399

--- a/application/palemoon/components/sessionstore/SessionStore.jsm
+++ b/application/palemoon/components/sessionstore/SessionStore.jsm
@@ -2739,7 +2739,9 @@ var SessionStoreInternal = {
     for (var t = 0; t < newTabCount; t++) {
       tabs.push(t < openTabCount ?
                 tabbrowser.tabs[t] :
-                tabbrowser.addTab("about:blank", {skipAnimation: true}));
+                tabbrowser.addTab("about:blank",
+                                  {skipAnimation: true,
+                                   skipBackgroundNotify: true}));
       // when resuming at startup: add additionally requested pages to the end
       if (!aOverwriteTabs && root._firstTabs) {
         tabbrowser.moveTabTo(tabs[t], t);
@@ -4684,7 +4686,8 @@ var TabAttributes = {
   // 'image' should not be accessed directly but handled by using the
   //         gBrowser.getIcon()/setIcon() methods.
   // 'pending' is used internal by sessionstore and managed accordingly.
-  _skipAttrs: new Set(["image", "pending"]),
+  // 'skipbackgroundnotify' is used internal by tabbrowser.xml.
+  _skipAttrs: new Set(["image", "pending", "skipbackgroundnotify"]),
 
   persist: function (name) {
     if (this._attrs.has(name) || this._skipAttrs.has(name)) {


### PR DESCRIPTION
Add `skipBackgroundNotify` option to `tabbrowser.addTab()` and use it in `SessionStore.jsm` for both Pale Moon and Basilisk.

Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1342849.

Resolves #769.