### PR TITLE
Use SessionStore.promiseInitialized() to avoid race condition in "about:home"

### DIFF
--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -2423,11 +2423,12 @@ function BrowserOnAboutPageLoad(doc) {
   if (doc.documentURI.toLowerCase() == "about:home") {
     if (!PrivateBrowsingUtils.isWindowPrivate(window)) {
       let wrapper = {};
-      Components.utils.import("resource:///modules/sessionstore/SessionStore.jsm", wrapper);
+      Cu.import("resource:///modules/sessionstore/SessionStore.jsm", wrapper);
       let ss = wrapper.SessionStore;
       ss.promiseInitialized.then(function() {
-        if (ss.canRestoreLastSession)
+        if (ss.canRestoreLastSession) {
           doc.getElementById("launcher").setAttribute("session", "true");
+        }
       }).then(null, function onError(x) {
         Cu.reportError("Error in SessionStore init while processing 'about:home': " + x);
       });

--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -2421,11 +2421,17 @@ function BrowserOnAboutPageLoad(doc) {
   /* === about:home === */
 
   if (doc.documentURI.toLowerCase() == "about:home") {
-    let ss = Components.classes["@mozilla.org/browser/sessionstore;1"].
-             getService(Components.interfaces.nsISessionStore);
-    if (ss.canRestoreLastSession &&
-        !PrivateBrowsingUtils.isWindowPrivate(window))
-      doc.getElementById("launcher").setAttribute("session", "true");
+    if (!PrivateBrowsingUtils.isWindowPrivate(window)) {
+      let wrapper = {};
+      Components.utils.import("resource:///modules/sessionstore/SessionStore.jsm", wrapper);
+      let ss = wrapper.SessionStore;
+      ss.promiseInitialized.then(function() {
+        if (ss.canRestoreLastSession)
+          doc.getElementById("launcher").setAttribute("session", "true");
+      }).then(null, function onError(x) {
+        Cu.reportError("Error in SessionStore init while processing 'about:home': " + x);
+      });
+    }
 
     // Inject search engine and snippets URL.
     let docElt = doc.documentElement;


### PR DESCRIPTION
This ensures that SessionStore is initialized before checking whether the last session can be restored.

Backported from Basilisk, resolves #772.