### PR TITLE
[PALEMOON] Restore strings mistakenly removed from downloads.properties

### DIFF
--- a/application/palemoon/locales/en-US/chrome/browser/downloads/downloads.properties
+++ b/application/palemoon/locales/en-US/chrome/browser/downloads/downloads.properties
@@ -67,6 +67,9 @@ shortTimeLeftDays=%1$Sd
 statusSeparator=%1$S \u2014 %2$S
 statusSeparatorBeforeNumber=%1$S \u2014  %2$S
 
+fileExecutableSecurityWarning="%S" is an executable file. Executable files may contain viruses or other malicious code that could harm your computer. Use caution when opening this file. Are you sure you want to launch "%S"?
+fileExecutableSecurityWarningTitle=Open Executable File?
+
 # LOCALIZATION NOTE (otherDownloads2):
 # This is displayed in an item at the bottom of the Downloads Panel when
 # there are more downloads than can fit in the list in the panel. Use a


### PR DESCRIPTION
Restore strings mistakenly removed by [8be0c16be614d54183ee3d4877e2243cb9e468c8], resolves #780.