### PR TITLE
Fix more -Wclass-memaccess warnings (part 3)

### DIFF
--- a/js/src/vm/ArrayBufferObject.h
+++ b/js/src/vm/ArrayBufferObject.h
@@ -457,8 +457,8 @@ ClampDoubleToUint8(const double x);
 struct uint8_clamped {
     uint8_t val;
 
-    uint8_clamped() { }
-    uint8_clamped(const uint8_clamped& other) : val(other.val) { }
+    uint8_clamped() = default;
+    uint8_clamped(const uint8_clamped& other) = default;
 
     // invoke our assignment helpers for constructor conversion
     explicit uint8_clamped(uint8_t x)    { *this = x; }
@@ -469,10 +469,7 @@ struct uint8_clamped {
     explicit uint8_clamped(int32_t x)    { *this = x; }
     explicit uint8_clamped(double x)     { *this = x; }
 
-    uint8_clamped& operator=(const uint8_clamped& x) {
-        val = x.val;
-        return *this;
-    }
+    uint8_clamped& operator=(const uint8_clamped& x) = default;
 
     uint8_clamped& operator=(uint8_t x) {
         val = x;

--- a/js/src/vm/TypeInference.cpp
+++ b/js/src/vm/TypeInference.cpp
@@ -12,6 +12,8 @@
 #include "mozilla/SizePrintfMacros.h"
 #include "mozilla/Sprintf.h"
 
+#include <new>
+
 #include "jsapi.h"
 #include "jscntxt.h"
 #include "jsgc.h"
@@ -859,10 +861,8 @@ TypeSet::IsTypeAboutToBeFinalized(TypeSet::Type* v)
 }
 
 bool
-TypeSet::clone(LifoAlloc* alloc, TemporaryTypeSet* result) const
+TypeSet::cloneIntoUninitialized(LifoAlloc* alloc, TemporaryTypeSet* result) const
 {
-    MOZ_ASSERT(result->empty());
-
     unsigned objectCount = baseObjectCount();
     unsigned capacity = (objectCount >= 2) ? TypeHashSet::Capacity(objectCount) : 0;
 
@@ -874,15 +874,15 @@ TypeSet::clone(LifoAlloc* alloc, TemporaryTypeSet* result) const
         PodCopy(newSet, objectSet, capacity);
     }
 
-    new(result) TemporaryTypeSet(flags, capacity ? newSet : objectSet);
+    new (result) TemporaryTypeSet(flags, capacity ? newSet : objectSet);
     return true;
 }
 
 TemporaryTypeSet*
 TypeSet::clone(LifoAlloc* alloc) const
 {
-    TemporaryTypeSet* res = alloc->new_<TemporaryTypeSet>();
-    if (!res || !clone(alloc, res))
+    TemporaryTypeSet* res = alloc->pod_malloc<TemporaryTypeSet>();
+    if (!res || !cloneIntoUninitialized(alloc, res))
         return nullptr;
     return res;
 }
@@ -1150,10 +1150,9 @@ TypeScript::FreezeTypeSets(CompilerConstraintList* constraints, JSScript* script
     TemporaryTypeSet* types = alloc->newArrayUninitialized<TemporaryTypeSet>(count);
     if (!types)
         return false;
-    PodZero(types, count);
 
     for (size_t i = 0; i < count; i++) {
-        if (!existing[i].clone(alloc, &types[i]))
+        if (!existing[i].cloneIntoUninitialized(alloc, &types[i]))
             return false;
     }
 

--- a/js/src/vm/TypeInference.h
+++ b/js/src/vm/TypeInference.h
@@ -498,7 +498,10 @@ class TypeSet
 
     // Clone a type set into an arbitrary allocator.
     TemporaryTypeSet* clone(LifoAlloc* alloc) const;
-    bool clone(LifoAlloc* alloc, TemporaryTypeSet* result) const;
+
+    // |*result| is not even partly initialized when this function is called:
+    // this function placement-new's its contents into existence.
+    bool cloneIntoUninitialized(LifoAlloc* alloc, TemporaryTypeSet* result) const;
 
     // Create a new TemporaryTypeSet where undefined and/or null has been filtered out.
     TemporaryTypeSet* filter(LifoAlloc* alloc, bool filterUndefined, bool filterNull) const;

--- a/js/src/vm/TypedArrayCommon.h
+++ b/js/src/vm/TypedArrayCommon.h
@@ -11,7 +11,8 @@
 
 #include "mozilla/Assertions.h"
 #include "mozilla/FloatingPoint.h"
-#include "mozilla/PodOperations.h"
+
+#include <algorithm>
 
 #include "jsarray.h"
 #include "jscntxt.h"
@@ -245,12 +246,24 @@ class UnsharedOps
 
     template<typename T>
     static void podCopy(SharedMem<T*> dest, SharedMem<T*> src, size_t nelem) {
-        mozilla::PodCopy(dest.unwrapUnshared(), src.unwrapUnshared(), nelem);
+        // std::copy_n better matches the argument values/types of this
+        // function, but as noted below it allows the input/output ranges to
+        // overlap.  std::copy does not, so use it so the compiler has extra
+        // ability to optimize.
+        const auto* first = src.unwrapUnshared();
+        const auto* last = first + nelem;
+        auto* result = dest.unwrapUnshared();
+        std::copy(first, last, result);
     }
 
     template<typename T>
-    static void podMove(SharedMem<T*> dest, SharedMem<T*> src, size_t nelem) {
-        mozilla::PodMove(dest.unwrapUnshared(), src.unwrapUnshared(), nelem);
+    static void podMove(SharedMem<T*> dest, SharedMem<T*> src, size_t n) {
+        // std::copy_n copies from |src| to |dest| starting from |src|, so
+        // input/output ranges *may* permissibly overlap, as this function
+        // allows.
+        const auto* start = src.unwrapUnshared();
+        auto* result = dest.unwrapUnshared();
+        std::copy_n(start, n, result);
     }
 
     static SharedMem<void*> extract(TypedArrayObject* obj) {


### PR DESCRIPTION
More fixes similar to the ones in #754 & #767 . This patch set fixes another 10 or so compiler warnings with GCC 8.

Tested with GCC 7.3 & 8.1. No issues or problems seen after using both builds for several hours each.

Tag #457