### PR TITLE
Remove window.sizeToContent() from commonDialog.js, as it's useless and leads to overflow in the basic auth dialog

### DIFF
--- a/toolkit/components/prompts/content/commonDialog.js
+++ b/toolkit/components/prompts/content/commonDialog.js
@@ -50,8 +50,6 @@ function commonDialogOnLoad() {
 
     Dialog = new CommonDialog(args, ui);
     Dialog.onLoad(dialog);
-    // resize the window to the content
-    window.sizeToContent();
     window.getAttention();
 }
 


### PR DESCRIPTION
This reverts the change introduced in [bug 1230462](https://bugzilla.mozilla.org/show_bug.cgi?id=1230462), considering that [the benefit of using it has never been confirmed](https://bugzilla.mozilla.org/show_bug.cgi?id=1230462#c87), but leads to an obvious regression.

This resolves #785.