### PR TITLE
gfx: add pref for enabling APZ without e10s

### DIFF
--- a/gfx/thebes/gfxPlatform.cpp
+++ b/gfx/thebes/gfxPlatform.cpp
@@ -2380,13 +2380,13 @@ gfxPlatform::AsyncPanZoomEnabled()
 {
 #if !defined(MOZ_WIDGET_ANDROID) && !defined(MOZ_WIDGET_UIKIT)
   // For XUL applications (everything but Firefox on Android) we only want
-  // to use APZ when E10S is enabled. If we ever get input events off the
-  // main thread we can consider relaxing this requirement.
-  if (!BrowserTabsRemoteAutostart()) {
+  // to use APZ when E10S is enabled or when the user explicitly enable it.
+  if (BrowserTabsRemoteAutostart() || gfxPrefs::APZDesktopEnabled()) {
+    return gfxPrefs::AsyncPanZoomEnabledDoNotUseDirectly();
+  } else {
     return false;
   }
-#endif
-#ifdef MOZ_WIDGET_ANDROID
+#elif defined(MOZ_WIDGET_ANDROID)
   return true;
 #else
   return gfxPrefs::AsyncPanZoomEnabledDoNotUseDirectly();

--- a/gfx/thebes/gfxPrefs.h
+++ b/gfx/thebes/gfxPrefs.h
@@ -310,6 +310,7 @@ private:
   DECL_GFX_PREF(Live, "apz.y_stationary_size_multiplier",      APZYStationarySizeMultiplier, float, 3.5f);
   DECL_GFX_PREF(Live, "apz.zoom_animation_duration_ms",        APZZoomAnimationDuration, int32_t, 250);
   DECL_GFX_PREF(Live, "apz.scale_repaint_delay_ms",            APZScaleRepaintDelay, int32_t, 500);
+  DECL_GFX_PREF(Once, "apz.desktop.enabled",                   APZDesktopEnabled, bool, false);
 
   DECL_GFX_PREF(Live, "browser.ui.zoom.force-user-scalable",   ForceUserScalable, bool, false);
   DECL_GFX_PREF(Live, "browser.viewport.desktopWidth",         DesktopViewportWidth, int32_t, 980);

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -705,6 +705,10 @@ pref("apz.y_skate_size_multiplier", "1.5");
 pref("apz.y_stationary_size_multiplier", "1.5");
 #endif
 
+#if !defined(MOZ_WIDGET_ANDROID) && !defined(MOZ_WIDGET_UIKIT)
+pref("apz.desktop.enabled", false);
+#endif
+
 #ifdef XP_MACOSX
 // Whether to run in native HiDPI mode on machines with "Retina"/HiDPI display;
 //   <= 0 : hidpi mode disabled, display will just use pixel-based upscaling


### PR DESCRIPTION
Resolves #345 

Tested on Linux with Basilisk. It might need a better pref name, but I this is the best I can came up with.