### PR TITLE
backport mozbug 1444532 - fix a leak in SHA256 in nsHttpConnectionInfo.cpp r=mayhemer

### DIFF
--- a/netwerk/protocol/http/nsHttpConnectionInfo.cpp
+++ b/netwerk/protocol/http/nsHttpConnectionInfo.cpp
@@ -15,32 +15,26 @@
 
 #include "nsHttpConnectionInfo.h"
 #include "mozilla/net/DNS.h"
-#include "prnetdb.h"
-#include "nsICryptoHash.h"
 #include "nsComponentManagerUtils.h"
+#include "nsICryptoHash.h"
 #include "nsIProtocolProxyService.h"
+#include "nsNetCID.h"
+#include "prnetdb.h"
 
 static nsresult
 SHA256(const char* aPlainText, nsAutoCString& aResult)
 {
-  static nsICryptoHash* hasher = nullptr;
   nsresult rv;
-  if (!hasher) {
-    rv = CallCreateInstance("@mozilla.org/security/hash;1", &hasher);
-    if (NS_FAILED(rv)) {
-      LOG(("nsHttpDigestAuth: no crypto hash!\n"));
-      return rv;
-    }
+  nsCOMPtr<nsICryptoHash> hasher = do_CreateInstance(NS_CRYPTO_HASH_CONTRACTID, &rv);
+  if (NS_FAILED(rv)) {
+    LOG(("nsHttpDigestAuth: no crypto hash!\n"));
+    return rv;
   }
-
   rv = hasher->Init(nsICryptoHash::SHA256);
   NS_ENSURE_SUCCESS(rv, rv);
-
   rv = hasher->Update((unsigned char*) aPlainText, strlen(aPlainText));
   NS_ENSURE_SUCCESS(rv, rv);
-
-  rv = hasher->Finish(false, aResult);
-  return rv;
+  return hasher->Finish(false, aResult);
 }
 
 namespace mozilla {


### PR DESCRIPTION
The original code (from bug 1200802) declared an XPCOM object as a static bare pointer,
which for future reference is probably never the right thing to do. It might have worked if
it was cleared before shutdown but it never was.