### PR TITLE
[PALEMOON] Use message manager to detect full-screen HTML5 video in S4E module

### DIFF
--- a/application/palemoon/components/statusbar/Status.jsm
+++ b/application/palemoon/components/statusbar/Status.jsm
@@ -35,7 +35,7 @@ S4EStatusService.prototype =
   _defaultStatus:          { val: "", type: "" },
 
   _isFullScreen:           false,
-  _isFullScreenVideo:      false,
+  _isVideo:                false,
 
   _statusText:             { val: "", type: "" },
   _noUpdate:               false,
@@ -222,18 +222,10 @@ S4EStatusService.prototype =
     }
   },
 
-  updateFullScreen: function()
+  setFullScreenState: function(isFullScreen, isVideo)
   {
-    this._isFullScreen = this._window.fullScreen;
-    this._isFullScreenVideo = false;
-    if(this._isFullScreen)
-    {
-      let fsEl = this._window.content.document.mozFullScreenElement;
-      if(fsEl && (fsEl.nodeName == "VIDEO" || fsEl.getElementsByTagName("VIDEO").length > 0))
-      {
-        this._isFullScreenVideo = true;
-      }
-    }
+    this._isFullScreen = isFullScreen;
+    this._isVideo = isFullScreen && isVideo;
 
     this.clearStatusField();
     this.updateStatusField(true);
@@ -305,7 +297,7 @@ S4EStatusService.prototype =
 
     let label = null;
 
-    if(this._isFullScreen && this._service.advancedStatusDetectFullScreen)
+    if(this._isFullScreen)
     {
       switch(location)
       {
@@ -330,7 +322,7 @@ S4EStatusService.prototype =
         break;
       case 3: // Popup
       default:
-        if(this._isFullScreenVideo && this._service.advancedStatusDetectVideo)
+        if(this._isVideo)
         {
           return;
         }

--- a/application/palemoon/components/statusbar/content-thunk.js
+++ b/application/palemoon/components/statusbar/content-thunk.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+function handleVideoDetect(message)
+{
+  let isVideo = false;
+
+  let fsEl = content.document.mozFullScreenElement;
+  if(fsEl)
+  {
+    isVideo = (
+      fsEl.nodeName == "VIDEO"
+      || (fsEl.nodeName == "IFRAME" && fsEl.contentDocument && fsEl.contentDocument.getElementsByTagName("VIDEO").length > 0)
+      || fsEl.getElementsByTagName("VIDEO").length > 0
+    );
+  }
+
+  sendAsyncMessage("status4evar@caligonstudios.com:video-detect-answer", {isVideo: isVideo});
+}
+
+addMessageListener("status4evar@caligonstudios.com:video-detect", handleVideoDetect);
+

--- a/application/palemoon/components/statusbar/moz.build
+++ b/application/palemoon/components/statusbar/moz.build
@@ -16,6 +16,7 @@ EXTRA_COMPONENTS += [
 ]
 
 EXTRA_JS_MODULES.statusbar = [
+    'content-thunk.js',
     'Downloads.jsm',
     'Progress.jsm',
     'Status.jsm',


### PR DESCRIPTION
Since UXP loads documents asynchronously, we can no longer directly check `document.mozFullScreenElement` when detecting full-screen HTML5 video in S4E module.

This PR resolves this by using message manager, but only when `status4evar.advanced.status.detectFullScreen` is enabled (`false` by default).

Based on [S4E#30](https://github.com/SparkyBluefang/S4E/issues/30), resolves #803.