### PR TITLE
[ffmpeg] Always allocate memory to pass extradata

### DIFF
--- a/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
+++ b/dom/media/platforms/ffmpeg/FFmpegDataDecoder.cpp
@@ -69,12 +69,21 @@ FFmpegDataDecoder<LIBAV_VER>::InitDecoder()
     mCodecContext->extradata_size = mExtraData->Length();
     // FFmpeg may use SIMD instructions to access the data which reads the
     // data in 32 bytes block. Must ensure we have enough data to read.
+    uint32_t padding_size =
 #if LIBAVCODEC_VERSION_MAJOR >= 58
-    mExtraData->AppendElements(AV_INPUT_BUFFER_PADDING_SIZE);
+      AV_INPUT_BUFFER_PADDING_SIZE;
 #else
-    mExtraData->AppendElements(FF_INPUT_BUFFER_PADDING_SIZE);
+      FF_INPUT_BUFFER_PADDING_SIZE;
 #endif
-    mCodecContext->extradata = mExtraData->Elements();
+    mCodecContext->extradata = static_cast<uint8_t*>(
+      mLib->av_malloc(mExtraData->Length() + padding_size));
+    if (!mCodecContext->extradata) {
+      return MediaResult(NS_ERROR_OUT_OF_MEMORY,
+                        RESULT_DETAIL("Couldn't init ffmpeg extradata"));
+    }
+    memcpy(mCodecContext->extradata,
+           mExtraData->Elements(),
+           mExtraData->Length());
   } else {
     mCodecContext->extradata_size = 0;
   }
@@ -165,6 +174,9 @@ FFmpegDataDecoder<LIBAV_VER>::ProcessShutdown()
   StaticMutexAutoLock mon(sMonitor);
 
   if (mCodecContext) {
+    if (mCodecContext->extradata) {
+      mLib->av_freep(&mCodecContext->extradata);
+    }
     mLib->avcodec_close(mCodecContext);
     mLib->av_freep(&mCodecContext);
 #if LIBAVCODEC_VERSION_MAJOR >= 55


### PR DESCRIPTION
Despite wording of the documentation to the contrary, we can't provide a static pointer to an immutable object.

This is a followup to #322. Apparently at some point during the FFmpeg 4.0 release cycle, extradata is now assumed to be allocated by libav allocators, even if the context is a decoding one. Because of this change Mozilla-based browsers can sometimes crash when playing AAC audio. Despite their documentation saying otherwise, the FFmpeg developers do not intend to change this behavior, and recently notified Mozilla about the change in behavior.

This PR is a port of Mozilla's patch to address this issue. I've tested H.264 playback on Youtube, YouTube live, Twitch, and played back many of the AAC samples on https://www2.iis.fraunhofer.de/AAC/.