### PR TITLE
[BASILISK] Protect against nsIPrincipal.origin throwing for about:blank iframes and custom protocol urls

### DIFF
--- a/application/basilisk/components/sessionstore/SessionStorage.jsm
+++ b/application/basilisk/components/sessionstore/SessionStorage.jsm
@@ -74,7 +74,14 @@ var SessionStorageInternal = {
 
       // Get the origin of the current history entry
       // and use that as a key for the per-principal storage data.
-      let origin = principal.origin;
+      let origin;
+      try {
+        // The origin getter may throw for about:blank iframes as of bug 1340710,
+        // but we should ignore them anyway. The same goes for custom protocols.
+        origin = principal.origin;
+      } catch (e) {
+        return;
+      }
       if (visitedOrigins.has(origin)) {
         // Don't read a host twice.
         return;


### PR DESCRIPTION
This protects `SessionStorage.jsm` against `nsIPrincipal.origin` throwing; based on [bug 1344595](https://bugzilla.mozilla.org/show_bug.cgi?id=1344595).

Currently it happens with custom protocol urls (for example `caa:` from [Classic Add-ons Archive](https://github.com/JustOff/ca-archive)), but will also apply if we decide to implement [bug 1340710](https://bugzilla.mozilla.org/show_bug.cgi?id=1340710).

The issue was not created as it's a small minor one-file change.