### PR TITLE
Several WebM/VPX fixes

### DIFF
--- a/dom/media/MediaData.h
+++ b/dom/media/MediaData.h
@@ -14,6 +14,7 @@
 #include "nsIMemoryReporter.h"
 #include "SharedBuffer.h"
 #include "mozilla/RefPtr.h"
+#include "mozilla/Span.h"
 #include "mozilla/UniquePtr.h"
 #include "mozilla/UniquePtrExtensions.h"
 #include "nsTArray.h"
@@ -631,6 +632,8 @@ public:
   {
     return sizeof(*this) + mBuffer.ComputedSizeOfExcludingThis();
   }
+  // Access the buffer as a Span.
+  operator Span<const uint8_t>() { return MakeSpan(Data(), Size()); }
 
   const CryptoSample& mCrypto;
   RefPtr<MediaByteBuffer> mExtraData;

--- a/dom/media/platforms/agnostic/VPXDecoder.cpp
+++ b/dom/media/platforms/agnostic/VPXDecoder.cpp
@@ -101,17 +101,10 @@ MediaResult
 VPXDecoder::DoDecode(MediaRawData* aSample)
 {
   MOZ_ASSERT(mTaskQueue->IsCurrentThreadIn());
+
 #if defined(DEBUG)
-  vpx_codec_stream_info_t si;
-  PodZero(&si);
-  si.sz = sizeof(si);
-  if (mCodec == Codec::VP8) {
-    vpx_codec_peek_stream_info(vpx_codec_vp8_dx(), aSample->Data(), aSample->Size(), &si);
-  } else if (mCodec == Codec::VP9) {
-    vpx_codec_peek_stream_info(vpx_codec_vp9_dx(), aSample->Data(), aSample->Size(), &si);
-  }
-  NS_ASSERTION(bool(si.is_kf) == aSample->mKeyframe,
-               "VPX Decode Keyframe error sample->mKeyframe and si.si_kf out of sync");
+  NS_ASSERTION(IsKeyframe(*aSample, mCodec) == aSample->mKeyframe,
+               "VPX Decode Keyframe error sample->mKeyframe and sample data out of sync");
 #endif
 
   if (vpx_codec_err_t r = vpx_codec_decode(&mVPX, aSample->Data(), aSample->Size(), nullptr, 0)) {
@@ -247,6 +240,42 @@ bool
 VPXDecoder::IsVP9(const nsACString& aMimeType)
 {
   return IsVPX(aMimeType, VPXDecoder::VP9);
+}
+
+/* static */
+bool
+VPXDecoder::IsKeyframe(Span<const uint8_t> aBuffer, Codec aCodec)
+{
+  vpx_codec_stream_info_t si;
+  PodZero(&si);
+  si.sz = sizeof(si);
+
+  if (aCodec == Codec::VP8) {
+    vpx_codec_peek_stream_info(vpx_codec_vp8_dx(), aBuffer.Elements(), aBuffer.Length(), &si);
+    return bool(si.is_kf);
+  } else if (aCodec == Codec::VP9) {
+    vpx_codec_peek_stream_info(vpx_codec_vp9_dx(), aBuffer.Elements(), aBuffer.Length(), &si);
+    return bool(si.is_kf);
+  }
+
+  return false;
+}
+
+/* static */
+nsIntSize
+VPXDecoder::GetFrameSize(Span<const uint8_t> aBuffer, Codec aCodec)
+{
+  vpx_codec_stream_info_t si;
+  PodZero(&si);
+  si.sz = sizeof(si);
+
+  if (aCodec == Codec::VP8) {
+    vpx_codec_peek_stream_info(vpx_codec_vp8_dx(), aBuffer.Elements(), aBuffer.Length(), &si);
+  } else if (aCodec == Codec::VP9) {
+    vpx_codec_peek_stream_info(vpx_codec_vp9_dx(), aBuffer.Elements(), aBuffer.Length(), &si);
+  }
+
+  return nsIntSize(si.w, si.h);
 }
 
 } // namespace mozilla

--- a/dom/media/platforms/agnostic/VPXDecoder.cpp
+++ b/dom/media/platforms/agnostic/VPXDecoder.cpp
@@ -22,7 +22,7 @@ namespace mozilla {
 using namespace gfx;
 using namespace layers;
 
-static int MimeTypeToCodec(const nsACString& aMimeType)
+static VPXDecoder::Codec MimeTypeToCodec(const nsACString& aMimeType)
 {
   if (aMimeType.EqualsLiteral("video/webm; codecs=vp8")) {
     return VPXDecoder::Codec::VP8;
@@ -31,7 +31,7 @@ static int MimeTypeToCodec(const nsACString& aMimeType)
   } else if (aMimeType.EqualsLiteral("video/vp9")) {
     return VPXDecoder::Codec::VP9;
   }
-  return -1;
+  return VPXDecoder::Codec::Unknown;
 }
 
 VPXDecoder::VPXDecoder(const CreateDecoderParams& aParams)

--- a/dom/media/platforms/agnostic/VPXDecoder.h
+++ b/dom/media/platforms/agnostic/VPXDecoder.h
@@ -36,7 +36,8 @@ public:
 
   enum Codec: uint8_t {
     VP8 = 1 << 0,
-    VP9 = 1 << 1
+    VP9 = 1 << 1,
+    Unknown = 1 << 7,
   };
 
   // Return true if aMimeType is a one of the strings used by our demuxers to
@@ -61,7 +62,7 @@ private:
 
   const VideoInfo& mInfo;
 
-  const int mCodec;
+  const Codec mCodec;
 };
 
 } // namespace mozilla

--- a/dom/media/platforms/agnostic/VPXDecoder.h
+++ b/dom/media/platforms/agnostic/VPXDecoder.h
@@ -7,6 +7,7 @@
 #define VPXDecoder_h_
 
 #include "PlatformDecoderModule.h"
+#include "mozilla/Span.h"
 
 #include <stdint.h>
 #define VPX_DONT_DEFINE_STDINT_TYPES
@@ -46,6 +47,12 @@ public:
   static bool IsVPX(const nsACString& aMimeType, uint8_t aCodecMask=VP8|VP9);
   static bool IsVP8(const nsACString& aMimeType);
   static bool IsVP9(const nsACString& aMimeType);
+
+  // Return true if a sample is a keyframe for the specified codec.
+  static bool IsKeyframe(Span<const uint8_t> aBuffer, Codec aCodec);
+
+  // Return the frame dimensions for a sample for the specified codec.
+  static nsIntSize GetFrameSize(Span<const uint8_t> aBuffer, Codec aCodec);
 
 private:
   void ProcessDecode(MediaRawData* aSample);

--- a/dom/media/webm/WebMDemuxer.cpp
+++ b/dom/media/webm/WebMDemuxer.cpp
@@ -9,6 +9,7 @@
 #include "AbstractMediaDecoder.h"
 #include "MediaResource.h"
 #include "OpusDecoder.h"
+#include "VPXDecoder.h"
 #include "WebMDemuxer.h"
 #include "WebMBufferedParser.h"
 #include "gfx2DGlue.h"
@@ -24,11 +25,8 @@
 #include "mozilla/Sprintf.h"
 
 #include <algorithm>
+#include <numeric>
 #include <stdint.h>
-
-#define VPX_DONT_DEFINE_STDINT_TYPES
-#include "vpx/vp8dx.h"
-#include "vpx/vpx_decoder.h"
 
 #define WEBM_DEBUG(arg, ...) MOZ_LOG(gMediaDemuxerLog, mozilla::LogLevel::Debug, ("WebMDemuxer(%p)::%s: " arg, this, __func__, ##__VA_ARGS__))
 extern mozilla::LazyLogModule gMediaDemuxerLog;
@@ -636,22 +634,25 @@ WebMDemuxer::GetNextPacket(TrackInfo::TrackType aType, MediaRawDataQueue *aSampl
         // Packet is encrypted, can't peek, use packet info
         isKeyframe = nestegg_packet_has_keyframe(holder->Packet()) == NESTEGG_PACKET_HAS_KEYFRAME_TRUE;
       } else {
-        vpx_codec_stream_info_t si;
-        PodZero(&si);
-        si.sz = sizeof(si);
+        auto sample = MakeSpan(data, length);
         switch (mVideoCodec) {
         case NESTEGG_CODEC_VP8:
-          vpx_codec_peek_stream_info(vpx_codec_vp8_dx(), data, length, &si);
+          isKeyframe = VPXDecoder::IsKeyframe(sample, VPXDecoder::Codec::VP8);
           break;
         case NESTEGG_CODEC_VP9:
-          vpx_codec_peek_stream_info(vpx_codec_vp9_dx(), data, length, &si);
+          isKeyframe = VPXDecoder::IsKeyframe(sample, VPXDecoder::Codec::VP9);
           break;
+        default:
+          NS_WARNING("Cannot detect keyframes in unknown WebM video codec");
+          return NS_ERROR_FAILURE;
         }
-        isKeyframe = si.is_kf;
         if (isKeyframe) {
-          // We only look for resolution changes on keyframes for both VP8 and
-          // VP9. Other resolution changes are invalid.
-          auto dimensions = nsIntSize(si.w, si.h);
+          // For both VP8 and VP9, we only look for resolution changes
+          // on keyframes. Other resolution changes are invalid.
+          auto codec = mVideoCodec == NESTEGG_CODEC_VP8
+                       ? VPXDecoder::Codec::VP8
+                       : VPXDecoder::Codec::VP9;
+          auto dimensions = VPXDecoder::GetFrameSize(sample, codec);
           if (mLastSeenFrameSize.isSome()
               && (dimensions != mLastSeenFrameSize.value())) {
             mInfo.mVideo.mDisplay = dimensions;

--- a/dom/media/webm/WebMDemuxer.cpp
+++ b/dom/media/webm/WebMDemuxer.cpp
@@ -963,6 +963,10 @@ WebMTrackDemuxer::Seek(media::TimeUnit aTime)
   mParent->SeekInternal(mType, aTime);
   nsresult rv = mParent->GetNextPacket(mType, &mSamples);
   if (NS_FAILED(rv)) {
+    if (rv == NS_ERROR_DOM_MEDIA_END_OF_STREAM) {
+      // Ignore the error for now, the next GetSample will be rejected with EOS.
+      return SeekPromise::CreateAndResolve(media::TimeUnit(), __func__);
+    }
     return SeekPromise::CreateAndReject(rv, __func__);
   }
   mNeedKeyframe = true;

--- a/dom/media/webm/WebMDemuxer.cpp
+++ b/dom/media/webm/WebMDemuxer.cpp
@@ -651,14 +651,13 @@ WebMDemuxer::GetNextPacket(TrackInfo::TrackType aType, MediaRawDataQueue *aSampl
         if (isKeyframe) {
           // We only look for resolution changes on keyframes for both VP8 and
           // VP9. Other resolution changes are invalid.
-          if (mLastSeenFrameWidth.isSome() && mLastSeenFrameHeight.isSome() &&
-            (si.w != mLastSeenFrameWidth.value() ||
-              si.h != mLastSeenFrameHeight.value())) {
-            mInfo.mVideo.mDisplay = nsIntSize(si.w, si.h);
+          auto dimensions = nsIntSize(si.w, si.h);
+          if (mLastSeenFrameSize.isSome()
+              && (dimensions != mLastSeenFrameSize.value())) {
+            mInfo.mVideo.mDisplay = dimensions;
             mSharedVideoTrackInfo = new SharedTrackInfo(mInfo.mVideo, ++sStreamSourceID);
           }
-          mLastSeenFrameWidth = Some(si.w);
-          mLastSeenFrameHeight = Some(si.h);
+          mLastSeenFrameSize = Some(dimensions);
         }
       }
     }

--- a/dom/media/webm/WebMDemuxer.h
+++ b/dom/media/webm/WebMDemuxer.h
@@ -111,7 +111,8 @@ public:
   bool GetOffsetForTime(uint64_t aTime, int64_t* aOffset);
 
   // Demux next WebM packet and append samples to MediaRawDataQueue
-  bool GetNextPacket(TrackInfo::TrackType aType, MediaRawDataQueue *aSamples);
+  nsresult GetNextPacket(TrackInfo::TrackType aType,
+                         MediaRawDataQueue *aSamples);
 
   nsresult Reset(TrackInfo::TrackType aType);
 
@@ -175,11 +176,13 @@ private:
   // Read a packet from the nestegg file. Returns nullptr if all packets for
   // the particular track have been read. Pass TrackInfo::kVideoTrack or
   // TrackInfo::kVideoTrack to indicate the type of the packet we want to read.
-  RefPtr<NesteggPacketHolder> NextPacket(TrackInfo::TrackType aType);
+  nsresult NextPacket(TrackInfo::TrackType aType,
+                      RefPtr<NesteggPacketHolder>& aPacket);
 
   // Internal method that demuxes the next packet from the stream. The caller
   // is responsible for making sure it doesn't get lost.
-  RefPtr<NesteggPacketHolder> DemuxPacket(TrackInfo::TrackType aType);
+  nsresult DemuxPacket(TrackInfo::TrackType aType,
+                       RefPtr<NesteggPacketHolder>& aPacket);
 
   // libnestegg audio and video context for webm container.
   // Access on reader's thread only.
@@ -275,7 +278,7 @@ private:
   ~WebMTrackDemuxer();
   void UpdateSamples(nsTArray<RefPtr<MediaRawData>>& aSamples);
   void SetNextKeyFrameTime();
-  RefPtr<MediaRawData> NextSample ();
+  nsresult NextSample(RefPtr<MediaRawData>& aData);
   RefPtr<WebMDemuxer> mParent;
   TrackInfo::TrackType mType;
   UniquePtr<TrackInfo> mInfo;

--- a/dom/media/webm/WebMDemuxer.h
+++ b/dom/media/webm/WebMDemuxer.h
@@ -237,8 +237,7 @@ private:
   int64_t mLastWebMBlockOffset;
   const bool mIsMediaSource;
 
-  Maybe<uint32_t> mLastSeenFrameWidth;
-  Maybe<uint32_t> mLastSeenFrameHeight;
+  Maybe<nsIntSize> mLastSeenFrameSize;
   // This will be populated only if a resolution change occurs, otherwise it
   // will be left as null so the original metadata is used
   RefPtr<SharedTrackInfo> mSharedVideoTrackInfo;


### PR DESCRIPTION
This PR fixes/simplifies several things related to WebM and VPX playback:

- Correctly differentiate between a genuine EOS and an error when playing back WebM files.
- Simplify some logic when decoding WebM files.
- Add some new helper functions to WebMDemuxer instead of calling libvpx directly which will simplify adding other decoders (e.g. AV1) in the future.

Additionally, this PR adds code that begins using mozilla:Span that was added in #816.

I've tested this on Linux fairly extensively today and it all appears to be working as intended. Will wait for verification on Windows and will then push this out to unstable to cook a bit longer.

Resolves #829