### PR TITLE
Pale Moon: Remove message manager property from tabbrowser.xml

### DIFF
--- a/application/palemoon/base/content/tabbrowser.xml
+++ b/application/palemoon/base/content/tabbrowser.xml
@@ -2950,19 +2950,6 @@
                 onget="return this.mCurrentBrowser.docShell"
                 readonly="true"/>
 
-      <property name="messageManager"
-                readonly="true">
-        <getter>
-          <![CDATA[
-            let frameLoader = this.mCurrentBrowser.frameLoader;
-            if (!frameLoader) {
-              return null;
-            }
-            return frameLoader.messageManager;
-          ]]>
-        </getter>
-      </property>
-
       <property name="webNavigation"
                 onget="return this.mCurrentBrowser.webNavigation"
                 readonly="true"/>


### PR DESCRIPTION
This removes the `messageManager` property from Pale Moon's `tabbrowser.xml`.

It also seems to solve the first point of #817 on my side (focus is not switched to the tab of the notification's origin).

Please add `Verification Needed` tag as I've not tested this on any other platform.