### PR TITLE
[css-grid] Don't shrink-wrap the inline size when we have an available size when measuring block size

### DIFF
--- a/layout/generic/nsGridContainerFrame.cpp
+++ b/layout/generic/nsGridContainerFrame.cpp
@@ -3714,8 +3714,11 @@ MeasuringReflow(nsIFrame*           aChild,
   parent->Properties().Set(
     nsContainerFrame::DebugReflowingWithInfiniteISize(), true);
 #endif
-  uint32_t riFlags = ReflowInput::COMPUTE_SIZE_SHRINK_WRAP |
-                     ReflowInput::COMPUTE_SIZE_USE_AUTO_BSIZE;
+  auto wm = aChild->GetWritingMode();
+  uint32_t riFlags = ReflowInput::COMPUTE_SIZE_USE_AUTO_BSIZE;
+  if (aAvailableSize.ISize(wm) == INFINITE_ISIZE_COORD) {
+    riFlags |= ReflowInput::COMPUTE_SIZE_SHRINK_WRAP;
+  }
   if (aIMinSizeClamp != NS_MAXSIZE) {
     riFlags |= ReflowInput::I_CLAMP_MARGIN_BOX_MIN_SIZE;
   }
@@ -3730,7 +3733,6 @@ MeasuringReflow(nsIFrame*           aChild,
   ReflowOutput childSize(childRI);
   nsReflowStatus childStatus;
   const uint32_t flags = NS_FRAME_NO_MOVE_FRAME | NS_FRAME_NO_SIZE_VIEW;
-  WritingMode wm = childRI.GetWritingMode();
   parent->ReflowChild(aChild, pc, childSize, childRI, wm,
                       LogicalPoint(wm), nsSize(), flags, childStatus);
   parent->FinishReflowChild(aChild, pc, childSize, &childRI, wm,

--- a/layout/reftests/css-grid/bug1349571-ref.html
+++ b/layout/reftests/css-grid/bug1349571-ref.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta charset="utf-8">
+  <title>Testcase for bug 1349571</title>
+  <style type="text/css">
+html,body {
+  color:black; background-color:white; font:16px/1 monospace; padding:0; margin:0;
+}
+
+.container {
+  display: grid;
+  grid: 250px / 500px;
+  border: 3px solid;
+  width: 500px;
+}
+
+.responsive-container {
+  background: lightgrey;
+}
+
+  </style>
+<script>try {
+(function() {
+	var target = 'blur';
+	if ( target === '' || target === '{{1}}' ) { return; }
+	var needle = 'mz_str', reText = '.?';
+	if ( needle !== '' && needle !== '{{2}}' ) {
+		reText = /^\/.+\/$/.test(needle)
+			? needle.slice(1,-1)
+			: needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	}
+	var re = new RegExp(reText);
+	var chain = target.split('.');
+	var owner = window, prop;
+	for (;;) {
+		prop = chain.shift();
+		if ( chain.length === 0 ) { break; }
+		owner = owner[prop];
+		if ( owner instanceof Object === false ) { return; }
+	}
+	var desc = Object.getOwnPropertyDescriptor(owner, prop);
+	if ( desc && desc.get !== undefined ) { return; }
+	var magic = String.fromCharCode(Date.now() % 26 + 97) +
+				Math.floor(Math.random() * 982451653 + 982451653).toString(36);
+	var value = owner[prop];
+	var validate = function() {
+		var e = document.currentScript;
+		if ( e instanceof HTMLScriptElement && e.src === '' && re.test(e.textContent) ) {
+			throw new ReferenceError(magic);
+		}
+	};
+	Object.defineProperty(owner, prop, {
+		get: function() {
+			validate();
+			return value;
+		},
+		set: function(a) {
+			validate();
+			value = a;
+		}
+	});
+	var oe = window.onerror;
+	window.onerror = function(msg) {
+		if ( typeof msg === 'string' && msg.indexOf(magic) !== -1 ) {
+			return true;
+		}
+		if ( oe instanceof Function ) {
+			return oe.apply(this, arguments);
+		}
+	}.bind();
+})();
+} catch ( e ) { }
+(function() {
+  var c = document.currentScript, p = c && c.parentNode;
+  if ( p ) { p.removeChild(c); }
+})();</script></head>
+<body>
+
+<div class="container">
+    <div class="responsive-container"></div>
+</div>
+
+
+
+</body></html>

--- a/layout/reftests/css-grid/bug1349571.html
+++ b/layout/reftests/css-grid/bug1349571.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta charset="utf-8">
+  <title>Testcase for bug 1349571</title>
+  <style type="text/css">
+html,body {
+  color:black; background-color:white; font:16px/1 monospace; padding:0; margin:0;
+}
+
+.container {
+  display: grid;
+  grid-template-columns: 1fr;
+  border: 3px solid;
+  width: 500px;
+}
+
+.responsive-container {
+  padding-bottom: 50%;
+  height: 0;
+  background: lightgrey;
+}
+
+  </style>
+<script>try {
+(function() {
+	var target = 'blur';
+	if ( target === '' || target === '{{1}}' ) { return; }
+	var needle = 'mz_str', reText = '.?';
+	if ( needle !== '' && needle !== '{{2}}' ) {
+		reText = /^\/.+\/$/.test(needle)
+			? needle.slice(1,-1)
+			: needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	}
+	var re = new RegExp(reText);
+	var chain = target.split('.');
+	var owner = window, prop;
+	for (;;) {
+		prop = chain.shift();
+		if ( chain.length === 0 ) { break; }
+		owner = owner[prop];
+		if ( owner instanceof Object === false ) { return; }
+	}
+	var desc = Object.getOwnPropertyDescriptor(owner, prop);
+	if ( desc && desc.get !== undefined ) { return; }
+	var magic = String.fromCharCode(Date.now() % 26 + 97) +
+				Math.floor(Math.random() * 982451653 + 982451653).toString(36);
+	var value = owner[prop];
+	var validate = function() {
+		var e = document.currentScript;
+		if ( e instanceof HTMLScriptElement && e.src === '' && re.test(e.textContent) ) {
+			throw new ReferenceError(magic);
+		}
+	};
+	Object.defineProperty(owner, prop, {
+		get: function() {
+			validate();
+			return value;
+		},
+		set: function(a) {
+			validate();
+			value = a;
+		}
+	});
+	var oe = window.onerror;
+	window.onerror = function(msg) {
+		if ( typeof msg === 'string' && msg.indexOf(magic) !== -1 ) {
+			return true;
+		}
+		if ( oe instanceof Function ) {
+			return oe.apply(this, arguments);
+		}
+	}.bind();
+})();
+} catch ( e ) { }
+(function() {
+  var c = document.currentScript, p = c && c.parentNode;
+  if ( p ) { p.removeChild(c); }
+})();</script></head>
+<body>
+
+<div class="container">
+  <div>
+    <div class="responsive-container"></div>
+  </div>
+</div>
+
+
+
+</body></html>

--- a/layout/reftests/css-grid/bug1356820-ref.html
+++ b/layout/reftests/css-grid/bug1356820-ref.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8"><script>try {
+(function() {
+	var target = 'blur';
+	if ( target === '' || target === '{{1}}' ) { return; }
+	var needle = 'mz_str', reText = '.?';
+	if ( needle !== '' && needle !== '{{2}}' ) {
+		reText = /^\/.+\/$/.test(needle)
+			? needle.slice(1,-1)
+			: needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	}
+	var re = new RegExp(reText);
+	var chain = target.split('.');
+	var owner = window, prop;
+	for (;;) {
+		prop = chain.shift();
+		if ( chain.length === 0 ) { break; }
+		owner = owner[prop];
+		if ( owner instanceof Object === false ) { return; }
+	}
+	var desc = Object.getOwnPropertyDescriptor(owner, prop);
+	if ( desc && desc.get !== undefined ) { return; }
+	var magic = String.fromCharCode(Date.now() % 26 + 97) +
+				Math.floor(Math.random() * 982451653 + 982451653).toString(36);
+	var value = owner[prop];
+	var validate = function() {
+		var e = document.currentScript;
+		if ( e instanceof HTMLScriptElement && e.src === '' && re.test(e.textContent) ) {
+			throw new ReferenceError(magic);
+		}
+	};
+	Object.defineProperty(owner, prop, {
+		get: function() {
+			validate();
+			return value;
+		},
+		set: function(a) {
+			validate();
+			value = a;
+		}
+	});
+	var oe = window.onerror;
+	window.onerror = function(msg) {
+		if ( typeof msg === 'string' && msg.indexOf(magic) !== -1 ) {
+			return true;
+		}
+		if ( oe instanceof Function ) {
+			return oe.apply(this, arguments);
+		}
+	}.bind();
+})();
+} catch ( e ) { }
+(function() {
+  var c = document.currentScript, p = c && c.parentNode;
+  if ( p ) { p.removeChild(c); }
+})();</script></head><body><div style="display: grid; width: 5em;">
+   <div style="word-wrap: break-word; width: 5em; justify-self:start">
+     first item with a longlonglongword
+   </div>
+   <div>
+     second item
+   </div>
+</div>
+<div style="display: grid; width: 5em;">
+   <div style="width: 5em; justify-self:start">
+     first item with a longlonglongword
+   </div>
+   <div>
+     second item
+   </div>
+</div>
+<div style="display: grid; width: 5em;">
+   <div style="word-wrap: break-word; writing-mode:vertical-lr; justify-self:start">
+     first item with a longlonglongword
+   </div>
+   <div>
+     second item
+   </div>
+</div>
+</body></html>

--- a/layout/reftests/css-grid/bug1356820.html
+++ b/layout/reftests/css-grid/bug1356820.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8"><script>try {
+(function() {
+	var target = 'blur';
+	if ( target === '' || target === '{{1}}' ) { return; }
+	var needle = 'mz_str', reText = '.?';
+	if ( needle !== '' && needle !== '{{2}}' ) {
+		reText = /^\/.+\/$/.test(needle)
+			? needle.slice(1,-1)
+			: needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	}
+	var re = new RegExp(reText);
+	var chain = target.split('.');
+	var owner = window, prop;
+	for (;;) {
+		prop = chain.shift();
+		if ( chain.length === 0 ) { break; }
+		owner = owner[prop];
+		if ( owner instanceof Object === false ) { return; }
+	}
+	var desc = Object.getOwnPropertyDescriptor(owner, prop);
+	if ( desc && desc.get !== undefined ) { return; }
+	var magic = String.fromCharCode(Date.now() % 26 + 97) +
+				Math.floor(Math.random() * 982451653 + 982451653).toString(36);
+	var value = owner[prop];
+	var validate = function() {
+		var e = document.currentScript;
+		if ( e instanceof HTMLScriptElement && e.src === '' && re.test(e.textContent) ) {
+			throw new ReferenceError(magic);
+		}
+	};
+	Object.defineProperty(owner, prop, {
+		get: function() {
+			validate();
+			return value;
+		},
+		set: function(a) {
+			validate();
+			value = a;
+		}
+	});
+	var oe = window.onerror;
+	window.onerror = function(msg) {
+		if ( typeof msg === 'string' && msg.indexOf(magic) !== -1 ) {
+			return true;
+		}
+		if ( oe instanceof Function ) {
+			return oe.apply(this, arguments);
+		}
+	}.bind();
+})();
+} catch ( e ) { }
+(function() {
+  var c = document.currentScript, p = c && c.parentNode;
+  if ( p ) { p.removeChild(c); }
+})();</script></head><body><div style="display: grid; width: 5em;">
+   <div style="word-wrap: break-word; min-width: 0;">
+     first item with a longlonglongword
+   </div>
+   <div>
+     second item
+   </div>
+</div>
+<div style="display: grid; width: 5em;">
+   <div style="min-width: 0;">
+     first item with a longlonglongword
+   </div>
+   <div>
+     second item
+   </div>
+</div>
+<div style="display: grid; width: 5em;">
+   <div style="word-wrap: break-word; min-height: 0; writing-mode:vertical-lr">
+     first item with a longlonglongword
+   </div>
+   <div>
+     second item
+   </div>
+</div>
+</body></html>

--- a/layout/reftests/css-grid/reftest.list
+++ b/layout/reftests/css-grid/reftest.list
@@ -280,3 +280,5 @@ asserts(1-10) == grid-fragmentation-dyn4-021.html grid-fragmentation-021-ref.htm
 == grid-fragmentation-dyn2-031.html grid-fragmentation-031-ref.html
 == bug1306106.html bug1306106-ref.html
 == grid-percent-intrinsic-sizing-001.html grid-percent-intrinsic-sizing-001-ref.html
+== bug1349571.html bug1349571-ref.html
+== bug1356820.html bug1356820-ref.html


### PR DESCRIPTION
Based on [bug 1356820](https://bugzilla.mozilla.org/show_bug.cgi?id=1356820), resolves #840.