### PR TITLE
fix naming of getStartupChanges function

### DIFF
--- a/toolkit/mozapps/extensions/AddonManager.jsm
+++ b/toolkit/mozapps/extensions/AddonManager.jsm
@@ -2842,7 +2842,7 @@ this.AddonManager = {
    *         The type of startup change to get
    * @return An array of add-on IDs
    */
-  getStartupChangesAM_ge: function(aType) {
+  getStartupChanges: function(aType) {
     if (!(aType in AddonManagerInternal.startupChanges))
       return [];
     return AddonManagerInternal.startupChanges[aType].slice(0);


### PR DESCRIPTION
Fixes the error reported by @JustOff at #839. I still have no idea how did I miss this obvious issue. Sorry.