### PR TITLE
Don't use NS_ENSURE_SUCCESS where it causes useless logspam.

### DIFF
--- a/netwerk/base/nsIOService.cpp
+++ b/netwerk/base/nsIOService.cpp
@@ -789,7 +789,9 @@ nsIOService::NewChannelFromURIWithProxyFlagsInternal(nsIURI* aURI,
         // creating a new channel by calling NewChannel().
         if (NS_FAILED(rv)) {
             rv = handler->NewChannel(aURI, getter_AddRefs(channel));
-            NS_ENSURE_SUCCESS(rv, rv);
+            if (NS_FAILED(rv)) {
+                return rv;
+            }
             // The protocol handler does not implement NewChannel2, so
             // maybe we need to wrap the channel (see comment in MaybeWrap
             // function).

--- a/netwerk/base/nsNetUtilInlines.h
+++ b/netwerk/base/nsNetUtilInlines.h
@@ -224,7 +224,9 @@ NS_NewChannelInternal(nsIChannel           **outChannel,
          aUri,
          aLoadInfo,
          getter_AddRefs(channel));
-  NS_ENSURE_SUCCESS(rv, rv);
+  if (NS_FAILED(rv)) {
+    return rv;
+  }
 
   if (aLoadGroup) {
     rv = channel->SetLoadGroup(aLoadGroup);


### PR DESCRIPTION
Log spam fix. Suppresses 1,100 instances of NS_ENSURE_SUCCESS(rv, rv) failed with result 0x80520012 emitted from netwerk/base/nsIOService.cpp during linux64 debug testing. Backports [m-c 1333174](https://bugzilla.mozilla.org/show_bug.cgi?id=1333174).