### PR TITLE
Show hidden left border of search button on about:newtab page

### DIFF
--- a/application/palemoon/base/content/newtab/newTab.css
+++ b/application/palemoon/base/content/newtab/newTab.css
@@ -301,7 +301,6 @@ input[type=button] {
   color: black;
   border-color: hsla(220,54%,20%,.15) hsla(220,54%,20%,.17) hsla(220,54%,20%,.2);
   border-radius: 0 2px 2px 0;
-  border-inline-start: 1px solid transparent;
   box-shadow: 0 0 2px hsla(0,0%,100%,.5) inset,
               0 1px 0 hsla(0,0%,100%,.2);
   cursor: pointer;


### PR DESCRIPTION
**Before:**

<img width="641" alt="screen shot 2018-10-16 at 7 49 01 pm" src="https://user-images.githubusercontent.com/29352104/47387399-c8944e80-d6fe-11e8-9c3b-650f2f01fbde.png">


**After:**

<img width="631" alt="screen shot 2018-10-16 at 7 50 32 pm" src="https://user-images.githubusercontent.com/29352104/47387400-c8944e80-d6fe-11e8-964d-22b953b31731.png">
