### PR TITLE
Issue #795 - Make nsIUserInfo component optional

### DIFF
--- a/build/moz.configure/old.configure
+++ b/build/moz.configure/old.configure
@@ -243,6 +243,7 @@ def old_configure_options(*options):
     '--enable-universalchardet',
     '--enable-updater',
     '--enable-url-classifier',
+    '--enable-userinfo',
     '--enable-valgrind',
     '--enable-verify-mar',
     '--enable-webrtc',

--- a/old-configure.in
+++ b/old-configure.in
@@ -2247,6 +2247,7 @@ MOZ_PLACES=1
 MOZ_SERVICES_HEALTHREPORT=1
 MOZ_SERVICES_SYNC=1
 MOZ_SERVICES_CLOUDSYNC=1
+MOZ_USERINFO=1
 
 case "$target_os" in
     mingw*)
@@ -4585,6 +4586,20 @@ if test -n "$MOZ_DEVTOOLS"; then
 fi
 
 AC_SUBST(MOZ_DEVTOOLS)
+
+dnl ========================================================
+dnl = Disable nsUserInfo
+dnl ========================================================
+MOZ_ARG_DISABLE_BOOL(userinfo,
+[  --disable-userinfo         Disable nsUserInfo (default=enabled)],
+    MOZ_USERINFO=,
+    MOZ_USERINFO=1)
+
+if test -n "$MOZ_USERINFO"; then
+    AC_DEFINE(MOZ_USERINFO)
+fi
+
+AC_SUBST(MOZ_USERINFO)
 
 dnl ========================================================
 dnl = Define default location for MOZILLA_FIVE_HOME

--- a/toolkit/components/build/nsToolkitCompsModule.cpp
+++ b/toolkit/components/build/nsToolkitCompsModule.cpp
@@ -5,7 +5,9 @@
 #include "mozilla/ModuleUtils.h"
 #include "nsAppStartup.h"
 #include "nsNetCID.h"
+#ifdef MOZ_USERINFO
 #include "nsUserInfo.h"
+#endif
 #include "nsToolkitCompsCID.h"
 #include "nsFindService.h"
 #if defined(MOZ_UPDATER) && !defined(MOZ_WIDGET_ANDROID)
@@ -76,7 +78,9 @@ NS_GENERIC_FACTORY_CONSTRUCTOR_INIT(nsPerformanceStatsService, Init)
 NS_GENERIC_FACTORY_CONSTRUCTOR(nsTerminator)
 #endif
 
+#if defined(MOZ_USERINFO)
 NS_GENERIC_FACTORY_CONSTRUCTOR(nsUserInfo)
+#endif // defined (MOZ_USERINFO)
 NS_GENERIC_FACTORY_CONSTRUCTOR(nsFindService)
 
 #if !defined(MOZ_DISABLE_PARENTAL_CONTROLS)
@@ -141,7 +145,9 @@ NS_DEFINE_NAMED_CID(NS_TOOLKIT_PERFORMANCESTATSSERVICE_CID);
 #if defined(MOZ_HAS_TERMINATOR)
 NS_DEFINE_NAMED_CID(NS_TOOLKIT_TERMINATOR_CID);
 #endif
+#if defined(MOZ_USERINFO)
 NS_DEFINE_NAMED_CID(NS_USERINFO_CID);
+#endif // defined (MOZ_USERINFO)
 NS_DEFINE_NAMED_CID(ALERT_NOTIFICATION_CID);
 NS_DEFINE_NAMED_CID(NS_ALERTSSERVICE_CID);
 #if !defined(MOZ_DISABLE_PARENTAL_CONTROLS)
@@ -179,7 +185,9 @@ static const Module::CIDEntry kToolkitCIDs[] = {
 #if defined(MOZ_HAS_PERFSTATS)
   { &kNS_TOOLKIT_PERFORMANCESTATSSERVICE_CID, false, nullptr, nsPerformanceStatsServiceConstructor },
 #endif // defined (MOZ_HAS_PERFSTATS)
+#if defined(MOZ_USERINFO)
   { &kNS_USERINFO_CID, false, nullptr, nsUserInfoConstructor },
+#endif // defined (MOZ_USERINFO)
   { &kALERT_NOTIFICATION_CID, false, nullptr, AlertNotificationConstructor },
   { &kNS_ALERTSSERVICE_CID, false, nullptr, nsAlertsServiceConstructor },
 #if !defined(MOZ_DISABLE_PARENTAL_CONTROLS)
@@ -219,7 +227,9 @@ static const Module::ContractIDEntry kToolkitContracts[] = {
 #if defined(MOZ_HAS_PERFSTATS)
   { NS_TOOLKIT_PERFORMANCESTATSSERVICE_CONTRACTID, &kNS_TOOLKIT_PERFORMANCESTATSSERVICE_CID },
 #endif // defined (MOZ_HAS_PERFSTATS)
+#if defined(MOZ_USERINFO)
   { NS_USERINFO_CONTRACTID, &kNS_USERINFO_CID },
+#endif // defined(MOZ_USERINFO)
   { ALERT_NOTIFICATION_CONTRACTID, &kALERT_NOTIFICATION_CID },
   { NS_ALERTSERVICE_CONTRACTID, &kNS_ALERTSSERVICE_CID },
 #if !defined(MOZ_DISABLE_PARENTAL_CONTROLS)

--- a/toolkit/components/startup/moz.build
+++ b/toolkit/components/startup/moz.build
@@ -18,19 +18,14 @@ UNIFIED_SOURCES += [
     'StartupTimeline.cpp',
 ]
 
-if CONFIG['OS_ARCH'] == 'WINNT':
-    # This file cannot be built in unified mode because of name clashes with Windows headers.
-    SOURCES += [
-        'nsUserInfoWin.cpp',
-    ]
-elif CONFIG['MOZ_WIDGET_TOOLKIT'] == 'cocoa':
-    UNIFIED_SOURCES += [
-        'nsUserInfoMac.mm',
-    ]
-else:
-    UNIFIED_SOURCES += [
-        'nsUserInfoUnix.cpp',
-    ]
+if CONFIG['MOZ_USERINFO']:
+    if CONFIG['OS_ARCH'] == 'WINNT':
+        # This file cannot be built in unified mode because of name clashes with Windows headers.
+        SOURCES += ['nsUserInfoWin.cpp']
+    elif CONFIG['MOZ_WIDGET_TOOLKIT'] == 'cocoa':
+        UNIFIED_SOURCES += ['nsUserInfoMac.mm']
+    else:
+        UNIFIED_SOURCES += ['nsUserInfoUnix.cpp']
 
 FINAL_LIBRARY = 'xul'
 

--- a/toolkit/components/startup/public/moz.build
+++ b/toolkit/components/startup/public/moz.build
@@ -4,10 +4,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-XPIDL_SOURCES += [
-    'nsIAppStartup.idl',
-    'nsIUserInfo.idl',
-]
+XPIDL_SOURCES += ['nsIAppStartup.idl']
+
+if CONFIG['MOZ_USERINFO']:
+    XPIDL_SOURCES += ['nsIUserInfo.idl']
 
 XPIDL_MODULE = 'appstartup'
 


### PR DESCRIPTION
This allows the nsIUserinfo component to be disabled with --disable-userinfo in mozconfig
at build time, but leaves it on by default to avoid any compatibility issues in existing
applications. (Take II, tested on PaleMoon with clean tree with and without the preference)