### PR TITLE
Use a separate process to generate thumbnails only when multi-process mode is enabled

### DIFF
--- a/toolkit/components/thumbnails/BackgroundPageThumbs.jsm
+++ b/toolkit/components/thumbnails/BackgroundPageThumbs.jsm
@@ -206,8 +206,12 @@ const BackgroundPageThumbs = {
 
     let browser = this._parentWin.document.createElementNS(XUL_NS, "browser");
     browser.setAttribute("type", "content");
-    browser.setAttribute("remote", "true");
     browser.setAttribute("disableglobalhistory", "true");
+
+    if (Services.prefs.getPrefType("browser.tabs.remote") == Services.prefs.PREF_BOOL &&
+        Services.prefs.getBoolPref("browser.tabs.remote")) {
+      browser.setAttribute("remote", "true");
+    }
 
     if (Services.prefs.getBoolPref(ABOUT_NEWTAB_SEGREGATION_PREF)) {
       // Use the private container for thumbnails.


### PR DESCRIPTION
This resolves #856.