### PR TITLE
[PALEMOON] Focus and select the first non-collapsed text element in the bookmark properties dialog

### DIFF
--- a/application/palemoon/components/places/content/editBookmarkOverlay.js
+++ b/application/palemoon/components/places/content/editBookmarkOverlay.js
@@ -222,6 +222,11 @@ var gEditItemOverlay = {
     }
 
     let focusElement = () => {
+      let elt = document.querySelector("textbox:not([collapsed=true])");
+      if (elt) {
+        elt.focus();
+        elt.select();
+      }
       this._initialized = true;
     };
 


### PR DESCRIPTION
This resolves #861.

As a positive side effect, this will also focus the search field when the library window opens.