### PR TITLE
[Pale Moon] Fix missing icon for Sync notifications

### DIFF
--- a/application/palemoon/base/content/sync/notification.xml
+++ b/application/palemoon/base/content/sync/notification.xml
@@ -88,7 +88,7 @@
                            tooltiptext="&closeNotification.tooltip;"
                            oncommand="document.getBindingParent(this).close()"/>
         <xul:hbox anonid="details" align="center" flex="1">
-          <xul:image anonid="messageImage" class="messageImage" xbl:inherits="src=image"/>
+          <xul:image anonid="messageImage" class="messageImage" xbl:inherits="src=image,type"/>
           <xul:description anonid="messageText" class="messageText" xbl:inherits="xbl:text=label"/>
 
           <!-- The children are the buttons defined by the notification. -->


### PR DESCRIPTION
This change makes the `messageImage` element of Pale Moon's sync notification widget inherit the `type` attribute.

Please add the `Verification Needed` tag as I've only tested this on a Windows machine.

This resolves #868.