### PR TITLE
Add support for AV1 in MP4 container

### DIFF
--- a/dom/media/fmp4/MP4Decoder.cpp
+++ b/dom/media/fmp4/MP4Decoder.cpp
@@ -139,6 +139,14 @@ MP4Decoder::CanHandleMediaType(const MediaContentType& aType,
             NS_LITERAL_CSTRING("audio/flac"), aType));
         continue;
       }
+#ifdef MOZ_AV1
+      if (IsAV1CodecString(codec)) {
+        trackInfos.AppendElement(
+          CreateTrackInfoWithMIMETypeAndContentTypeExtraParameters(
+            NS_LITERAL_CSTRING("video/av1"), aType));
+        continue;
+      }
+#endif
       // Note: Only accept H.264 in a video content type, not in an audio
       // content type.
       if (IsWhitelistedH264Codec(codec) && isMP4Video) {

--- a/media/libstagefright/frameworks/av/include/media/stagefright/MediaDefs.h
+++ b/media/libstagefright/frameworks/av/include/media/stagefright/MediaDefs.h
@@ -25,6 +25,7 @@ extern const char *MEDIA_MIMETYPE_IMAGE_JPEG;
 extern const char *MEDIA_MIMETYPE_VIDEO_VP6;
 extern const char *MEDIA_MIMETYPE_VIDEO_VP8;
 extern const char *MEDIA_MIMETYPE_VIDEO_VP9;
+extern const char *MEDIA_MIMETYPE_VIDEO_AV1;
 extern const char *MEDIA_MIMETYPE_VIDEO_AVC;
 extern const char *MEDIA_MIMETYPE_VIDEO_MPEG4;
 extern const char *MEDIA_MIMETYPE_VIDEO_H263;

--- a/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
+++ b/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
@@ -269,6 +269,9 @@ static const char *FourCC2MIME(uint32_t fourcc) {
         case FOURCC('V', 'P', '6', 'F'):
             return MEDIA_MIMETYPE_VIDEO_VP6;
 
+        case FOURCC('a', 'v', '0', '1'):
+            return MEDIA_MIMETYPE_VIDEO_AV1;
+
         default:
             ALOGE("Unknown MIME type %08x", fourcc);
             return NULL;

--- a/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
+++ b/media/libstagefright/frameworks/av/media/libstagefright/MPEG4Extractor.cpp
@@ -270,6 +270,7 @@ static const char *FourCC2MIME(uint32_t fourcc) {
             return MEDIA_MIMETYPE_VIDEO_VP6;
 
         case FOURCC('a', 'v', '0', '1'):
+        case FOURCC('.', 'a', 'v', '1'):
             return MEDIA_MIMETYPE_VIDEO_AV1;
 
         default:
@@ -1349,6 +1350,8 @@ status_t MPEG4Extractor::parseChunk(off64_t *offset, int depth) {
         case FOURCC('a', 'v', 'c', '1'):
         case FOURCC('a', 'v', 'c', '3'):
         case FOURCC('V', 'P', '6', 'F'):
+        case FOURCC('a', 'v', '0', '1'):
+        case FOURCC('.', 'a', 'v', '1'):
         {
             mHasVideo = true;
 

--- a/media/libstagefright/frameworks/av/media/libstagefright/MediaDefs.cpp
+++ b/media/libstagefright/frameworks/av/media/libstagefright/MediaDefs.cpp
@@ -23,6 +23,7 @@ const char *MEDIA_MIMETYPE_IMAGE_JPEG = "image/jpeg";
 const char *MEDIA_MIMETYPE_VIDEO_VP6 = "video/x-vnd.on2.vp6";
 const char *MEDIA_MIMETYPE_VIDEO_VP8 = "video/x-vnd.on2.vp8";
 const char *MEDIA_MIMETYPE_VIDEO_VP9 = "video/x-vnd.on2.vp9";
+const char *MEDIA_MIMETYPE_VIDEO_AV1 = "video/av1";
 const char *MEDIA_MIMETYPE_VIDEO_AVC = "video/avc";
 const char *MEDIA_MIMETYPE_VIDEO_MPEG4 = "video/mp4v-es";
 const char *MEDIA_MIMETYPE_VIDEO_H263 = "video/3gpp";


### PR DESCRIPTION
This PR updates our in-tree copy of libstagefright (used by UXP applications for MP4 parsing) to support AV1 video within the MP4 container. It also adds AV1 support to the MP4Decoder (allowing playback of AV1-encoded MP4 files). This PR resolves #853 and allows for AV1 in MP4 + MSE playback. 480p playback seemed to work just fine, however I did notice some performance issues when playing back 720p and 1080p video on YouTube. I'm thinking that it is due to the higher performance demands of AV1 decoding using libaom, but will investigate (I'd be interested to hear if others also experience performance issues).

Some links for testing AV1 in MP4:

[Test file from Google.](https://raw.githubusercontent.com/chromium/chromium/3033eaecc684727a6f87834d3336a509f9ec9e36/media/test/data/bear-av1.mp4)
[Test file from Mozilla.](https://hg.mozilla.org/mozilla-central/raw-file/efb8bd6f8062/dom/media/test/av1.mp4)
[Link to enable AV1 playback on YouTube.](https://www.youtube.com/testtube)
[Link to AV1 playlist on YouTube.](https://www.youtube.com/watch?v=2nXYbGmF3_Q&t=0s&list=PLyqf6gJt7KuHBmeVzZteZUlNUQAVLwrZS&index=2)