### PR TITLE
[PALEMOON] Initialize the search service asynchronously when calling 'BrowserSearch.addEngine()'

### DIFF
--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -3046,7 +3046,9 @@ const DOMLinkHandler = {
                 /^(?:https?|ftp):/i.test(link.href) &&
                 !PrivateBrowsingUtils.isWindowPrivate(window)) {
               var engine = { title: link.title, href: link.href };
-              BrowserSearch.addEngine(engine, link.ownerDocument);
+              Services.search.init(function () {
+                BrowserSearch.addEngine(engine, link.ownerDocument);
+              });
               searchAdded = true;
             }
           }


### PR DESCRIPTION
This is necessary when the page displayed on startup contains a custom search engine.

Tag #918.