### PR TITLE
Avoid redefined macro warning in MediaFormatReader

### DIFF
--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -32,6 +32,10 @@ using mozilla::layers::Image;
 using mozilla::layers::LayerManager;
 using mozilla::layers::LayersBackend;
 
+// avoid redefined macro warning in unified builds
+#undef LOG
+#undef LOGV
+
 static mozilla::LazyLogModule sFormatDecoderLog("MediaFormatReader");
 mozilla::LazyLogModule gMediaDemuxerLog("MediaDemuxer");
 


### PR DESCRIPTION
Just what it says in the tin. Tag #457.