### PR TITLE
Fix option for disabling HSTS in Pale Moon

### DIFF
--- a/application/palemoon/components/preferences/security.xul
+++ b/application/palemoon/components/preferences/security.xul
@@ -43,8 +43,8 @@
 
       <!-- Security Protocols -->
       
-      <preference id="network.stricttransportsecurity.preloadlist"
-                  name="network.stricttransportsecurity.preloadlist"
+      <preference id="network.stricttransportsecurity.enabled"
+                  name="network.stricttransportsecurity.enabled"
                   type="bool"/>
       <preference id="security.cert_pinning.enforcement_level"
                   name="security.cert_pinning.enforcement_level"
@@ -146,7 +146,7 @@
         <checkbox id="enableHSTS"
                   label="&enableHSTS.label;"
                   accesskey="&enableHSTS.accesskey;"
-                  preference="network.stricttransportsecurity.preloadlist" />
+                  preference="network.stricttransportsecurity.enabled" />
         <checkbox id="enableHPKP"
                   label="&enableHPKP.label;"
                   accesskey="&enableHPKP.accesskey;"

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -2038,6 +2038,8 @@ pref("network.proxy.autoconfig_url.include_path", false);
 pref("network.proxy.autoconfig_retry_interval_min", 5);    // 5 seconds
 pref("network.proxy.autoconfig_retry_interval_max", 300);  // 5 minutes
 
+// Master switch for HSTS usage (security <-> privacy tradeoff)
+pref("network.stricttransportsecurity.enabled", true);
 // Use the HSTS preload list by default
 pref("network.stricttransportsecurity.preloadlist", true);
 

--- a/security/manager/ssl/nsSiteSecurityService.h
+++ b/security/manager/ssl/nsSiteSecurityService.h
@@ -150,6 +150,7 @@ private:
 
   uint64_t mMaxMaxAge;
   bool mUsePreloadList;
+  bool mUseStsService;
   int64_t mPreloadListTimeOffset;
   bool mProcessPKPHeadersFromNonBuiltInRoots;
   RefPtr<mozilla::DataStorage> mSiteStateStorage;


### PR DESCRIPTION
This addresses #930.

In addition to porting [this commit](https://github.com/MoonchildProductions/Pale-Moon/commit/9bc65e235b62c4e84c69f301bd89de29769f4abf), I made three additional changes to nsSiteSecurityService:
- Added a check in `SetHSTSState` so that the cache is not actually written to.
- Added a condition to the check in `IsSecureHost` so as not to interfere with HPKP.
- Added the preference to `Observe` so that it can take effect without restarting the browser.