### PR TITLE
Pale Moon: Use file path for bookmarks import/export.

### DIFF
--- a/application/palemoon/components/places/content/places.js
+++ b/application/palemoon/components/places/content/places.js
@@ -491,7 +491,7 @@ var PlacesOrganizer = {
 
     Task.spawn(function() {
       try {
-        yield BookmarkJSONUtils.importFromFile(aFile, true);
+        yield BookmarkJSONUtils.importFromFile(aFile.path, true);
       } catch(ex) {
         PlacesOrganizer._showErrorAlert(PlacesUIUtils.getString("bookmarksRestoreParseError"));
       }
@@ -519,7 +519,7 @@ var PlacesOrganizer = {
     let fp = Cc["@mozilla.org/filepicker;1"].createInstance(Ci.nsIFilePicker);
     let fpCallback = function fpCallback_done(aResult) {
       if (aResult != Ci.nsIFilePicker.returnCancel) {
-        BookmarkJSONUtils.exportToFile(fp.file);
+        BookmarkJSONUtils.exportToFile(fp.file.path);
       }
     };
 


### PR DESCRIPTION
This PR changes calls to the bookmark JSON import/export utility methods in Pale Moon to use file paths instead of file objects, thereby eliminating warnings for the deprecated file access methods in places.js.

Resolves #941.