### PR TITLE
[PALEMOON] Link dictionaries to addons.palemoon.org

### DIFF
--- a/application/palemoon/app/profile/palemoon.js
+++ b/application/palemoon/app/profile/palemoon.js
@@ -38,7 +38,8 @@ pref("extensions.strictCompatibility", false);
 pref("extensions.minCompatibleAppVersion", "1.5");
 
 // Preferences for APO integration
-#define APO_AM_URL addons.palemoon.org/integration/addon-manager
+#define APO_URL addons.palemoon.org
+#define APO_AM_URL @APO_URL@/integration/addon-manager
 #define APO_AUS_ARGS reqVersion=%REQ_VERSION%&id=%ITEM_ID%&version=%ITEM_VERSION%&maxAppVersion=%ITEM_MAXAPPVERSION%&status=%ITEM_STATUS%&appID=%APP_ID%&appVersion=%APP_VERSION%&appOS=%APP_OS%&appABI=%APP_ABI%&locale=%APP_LOCALE%&currentAppVersion=%CURRENT_APP_VERSION%&updateType=%UPDATE_TYPE%&compatMode=%COMPATIBILITY_MODE%
 
 pref("extensions.getAddons.cache.enabled", false);
@@ -70,7 +71,7 @@ pref("extensions.update.autoUpdateDefault", true);
 pref("extensions.autoDisableScopes", 15);
 
 // Dictionary download preference
-pref("browser.dictionaries.download.url", "https://addons.mozilla.org/%LOCALE%/firefox/dictionaries/");
+pref("browser.dictionaries.download.url", "https://@APO_URL@/dictionaries/");
 
 // Get More Tools link URL
 pref("browser.getdevtools.url","https://@APO_AM_URL@/external/devtools");

--- a/application/palemoon/branding/shared/pref/preferences.inc
+++ b/application/palemoon/branding/shared/pref/preferences.inc
@@ -1,4 +1,5 @@
-#define APO_AM_URL addons.palemoon.org/integration/addon-manager
+#define APO_URL addons.palemoon.org
+#define APO_AM_URL @APO_URL@/integration/addon-manager
 #define APO_AUS_ARGS reqVersion=%REQ_VERSION%&id=%ITEM_ID%&version=%ITEM_VERSION%&maxAppVersion=%ITEM_MAXAPPVERSION%&status=%ITEM_STATUS%&appID=%APP_ID%&appVersion=%APP_VERSION%&appOS=%APP_OS%&appABI=%APP_ABI%&locale=%APP_LOCALE%&currentAppVersion=%CURRENT_APP_VERSION%&updateType=%UPDATE_TYPE%&compatMode=%COMPATIBILITY_MODE%
 
 // ===| General |==============================================================
@@ -36,7 +37,7 @@ pref("extensions.blocklist.url","http://blocklist.palemoon.org/%VERSION%/blockli
 pref("extensions.blocklist.itemURL", "http://blocklist.palemoon.org/info/?id=%blockID%");
 
 // Dictionary URL
-pref("browser.dictionaries.download.url", "https://addons.mozilla.org/%LOCALE%/firefox/dictionaries/");
+pref("browser.dictionaries.download.url", "https://@APO_URL@/dictionaries/");
 
 pref("extensions.update.autoUpdateDefault", true); // Automatically update extensions by default
 pref("extensions.getAddons.maxResults", 10);


### PR DESCRIPTION
Set `browser.dictionaries.download.url` to `https://addons.palemoon.org/dictionaries/`.

This resolves #933.

Uplift is wanted.

The 2nd attempt, so as something went wrong when beautifying already approved #974. Sorry for the noise.