### PR TITLE
Preserve newlines in textarea placeholders

### DIFF
--- a/dom/html/nsTextEditorState.cpp
+++ b/dom/html/nsTextEditorState.cpp
@@ -2255,7 +2255,11 @@ nsTextEditorState::UpdatePlaceholderText(bool aNotify)
 
   nsCOMPtr<nsIContent> content = do_QueryInterface(mTextCtrlElement);
   content->GetAttr(kNameSpaceID_None, nsGkAtoms::placeholder, placeholderValue);
-  nsContentUtils::RemoveNewlines(placeholderValue);
+  if (mTextCtrlElement->IsTextArea()) { // <textarea>s preserve newlines...
+    nsContentUtils::PlatformToDOMLineBreaks(placeholderValue);
+  } else { // ...<input>s don't
+    nsContentUtils::RemoveNewlines(placeholderValue);
+  }
   NS_ASSERTION(mPlaceholderDiv->GetFirstChild(), "placeholder div has no child");
   mPlaceholderDiv->GetFirstChild()->SetText(placeholderValue, aNotify);
 }


### PR DESCRIPTION
Just what it says in the tin; resolves #977.

Based on [Bug #1391044](https://bugzilla.mozilla.org/show_bug.cgi?id=1391044), but does not include updated reference tests.