### PR TITLE
Draw a border when hiding the tab bar

### DIFF
--- a/application/palemoon/themes/linux/browser.css
+++ b/application/palemoon/themes/linux/browser.css
@@ -1607,6 +1607,17 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   background-image: linear-gradient(to top, rgba(0,0,0,.3) 1px, rgba(0,0,0,.05) 1px, transparent 50%);
 }
 
+/* When the tab bar is collapsed, show a 1px border in its place. */
+#TabsToolbar[collapsed="true"] {
+  visibility: visible;
+  height: 1px;
+  border-bottom-width: 1px;
+  /* !important here to override border-style: none on the toolbar */
+  border-bottom-style: solid !important;
+  border-bottom-color: ThreeDShadow;
+  overflow: hidden;
+}
+
 .tabbrowser-tab,
 .tabs-newtab-button {
   position: static;

--- a/application/palemoon/themes/osx/browser.css
+++ b/application/palemoon/themes/osx/browser.css
@@ -1630,6 +1630,17 @@ richlistitem[type~="action"][actiontype="switchtab"][selected="true"] > .ac-url-
     background-image: linear-gradient(to top, @toolbarShadowColor@ 1px, rgba(0,0,0,.05) 1px, transparent 50%);
 }
 
+/* When the tab bar is collapsed, show a 1px border in its place. */
+#TabsToolbar[collapsed="true"] {
+  visibility: visible;
+  height: 1px;
+  border-bottom-width: 1px;
+  /* !important here to override border-style: none on the toolbar */
+  border-bottom-style: solid !important;
+  border-bottom-color: ThreeDShadow;
+  overflow: hidden;
+}
+
 @media (-moz-mac-lion-theme) {
     #main-window[sizemode=normal] #TabsToolbar {
         padding-left: 2px;

--- a/application/palemoon/themes/windows/browser.css
+++ b/application/palemoon/themes/windows/browser.css
@@ -3057,7 +3057,7 @@ toolbar[brighttext] #addonbar-closebutton {
   
   @media (-moz-os-version: windows-vista),
          (-moz-os-version: windows-win7) {
-    :root {
+    :root:not(:-moz-lwtheme) {
       --toolbox-after-color: #aabccf;
     }
   }
@@ -3065,8 +3065,11 @@ toolbar[brighttext] #addonbar-closebutton {
   @media (-moz-os-version: windows-win8),
          (-moz-os-version: windows-win10) {
     :root {
-      --toolbox-after-color: #bcbcbc;
       --toolbar-custom-color: hsl(210,0%,92%);
+    }
+    
+    :root:not(:-moz-lwtheme) {
+      --toolbox-after-color: #bcbcbc;
     }
   }
  

--- a/application/palemoon/themes/windows/browser.css
+++ b/application/palemoon/themes/windows/browser.css
@@ -31,6 +31,8 @@
 %endif
 
 :root {
+  --toolbox-after-color: ThreeDShadow;
+
   --toolbar-custom-color: hsl(210,75%,92%);
   --toolbar-highlight-top: rgba(255,255,255,.5);
   --toolbar-highlight-bottom: transparent;
@@ -91,7 +93,7 @@
   display: -moz-box;
   -moz-box-ordinal-group: 101; /* tabs toolbar is 100 */
   height: 1px;
-  background-color: ThreeDShadow;
+  background-color: var(--toolbox-after-color);
 }
 #navigator-toolbox[tabsontop=false]::after,
 #main-window[disablechrome] #navigator-toolbox::after {
@@ -1841,6 +1843,17 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
   background-image: linear-gradient(to top, @toolbarShadowColor@ 1px, rgba(0,0,0,.05) 1px, transparent 50%);
 }
 
+/* When the tab bar is collapsed, show a 1px border in its place. */
+#TabsToolbar[collapsed="true"] {
+  visibility: visible;
+  height: 1px;
+  border-bottom-width: 1px;
+  /* !important here to override border-style: none on the toolbar */
+  border-bottom-style: solid !important;
+  border-bottom-color: var(--toolbox-after-color);
+  overflow: hidden;
+}
+
 .tabbrowser-tab,
 .tabs-newtab-button {
   -moz-appearance: none;
@@ -3044,19 +3057,16 @@ toolbar[brighttext] #addonbar-closebutton {
   
   @media (-moz-os-version: windows-vista),
          (-moz-os-version: windows-win7) {
-    #navigator-toolbox:not(:-moz-lwtheme)::after {
-      background-color: #aabccf;
+    :root {
+      --toolbox-after-color: #aabccf;
     }
   }
 
   @media (-moz-os-version: windows-win8),
          (-moz-os-version: windows-win10) {
     :root {
+      --toolbox-after-color: #bcbcbc;
       --toolbar-custom-color: hsl(210,0%,92%);
-    }
-
-    #navigator-toolbox:not(:-moz-lwtheme)::after {
-      background-color: #bcbcbc;
     }
   }
  


### PR DESCRIPTION
Tag #725 

This forces visibility of `#TabsToolbar` when it is collapsed, but only lets it show the bottom 1px - which we then use to draw a border. On Windows, a new var `--toolbox-after-color` has been made to accomodate the fact we have different stylings for `#navigator-toolbox::after` depending what Windows version we're on - not only does it simplify that code, it also means our `#TabsToolbar` hack uses the same border style. On other platforms it just uses `ThreeDShadow` since they also only use this with `#navigator-toolbox::after` - since there aren't multiple versions of things to be considered which need different stylings.