### PR TITLE
Prevent mistaken overwriting of browser.newtab.url when using the browser preferences dialog

### DIFF
--- a/application/palemoon/components/preferences/newtaburl.js
+++ b/application/palemoon/components/preferences/newtaburl.js
@@ -22,7 +22,11 @@ var gNewtabUrl = {
           return;
         }
       } else {
-        newtabUrlChoice = Services.prefs.getIntPref("browser.newtab.choice");
+        if (this.newtabUrlChoiceIsSet) {
+          newtabUrlChoice = Services.prefs.getIntPref("browser.newtab.choice");
+        } else {
+          newtabUrlChoice = this.getNewtabChoice();
+        }
       }
       if (browserHomepageUrl || browserHomepageUrl == "") {
         if (Services.prefs.getBoolPref("browser.preferences.instantApply")) {
@@ -64,5 +68,35 @@ var gNewtabUrl = {
       } 
       Services.prefs.setCharPref("browser.newtab.url",newtabUrlPref);
     } catch(e) { console.error(e); }
+  },
+
+  /**
+   * Determines the value of browser.newtab.choice based
+   * on the value of browser.newtab.url
+   *
+   * @returns the value of browser.newtab.choice
+   */
+  getNewtabChoice: function() {
+    let newtabUrlPref = Services.prefs.getCharPref("browser.newtab.url");
+    let browserHomepageUrl = Services.prefs.getComplexValue("browser.startup.homepage",
+                              Components.interfaces.nsIPrefLocalizedString).data;
+    let newtabUrlSanitizedPref = browserHomepageUrl.split("|")[0];
+    let defaultStartupHomepage = Services.prefs.getDefaultBranch("browser.")
+                                  .getComplexValue("startup.homepage",
+                                    Components.interfaces.nsIPrefLocalizedString).data;
+    switch (newtabUrlPref) {
+      case "about:logopage": 
+        return 1;
+      case defaultStartupHomepage:
+        return 2;
+      case newtabUrlSanitizedPref:
+        return 3;
+      case "about:newtab":
+        return 4;
+      default: // Custom URL entered.
+        // We need this to consider instantApply.
+        this.newtabPageCustom = newtabUrlPref;
+        return 0;
+    }
   }
 };

--- a/application/palemoon/components/preferences/preferences.xul
+++ b/application/palemoon/components/preferences/preferences.xul
@@ -56,7 +56,7 @@
 #endif
 #endif
             onunload="if (typeof gSecurityPane != 'undefined') gSecurityPane.syncAddonSecurityLevel();"
-            ondialogaccept="if (typeof gTabsPane != 'undefined') gNewtabUrl.writeNewtabUrl();">
+            ondialogaccept="gNewtabUrl.writeNewtabUrl();">
 
     <script type="application/javascript" src="chrome://browser/content/utilityOverlay.js"/>
     <script type="application/javascript" src="chrome://browser/content/preferences/newtaburl.js"/>

--- a/application/palemoon/components/preferences/tabs.js
+++ b/application/palemoon/components/preferences/tabs.js
@@ -78,34 +78,13 @@ var gTabsPane = {
   /**
    * Determines the value of the New Tab display drop-down based
    * on the value of browser.newtab.url.
-   *
-   * @returns the appropriate value of browser.newtab.choice
    */
   readNewtabUrl: function() {
-    let newtabUrlPref = document.getElementById("browser.newtab.url");
-    let newtabUrlSanitizedPref = document.getElementById("browser.newtab.myhome");
     let newtabUrlChoice = document.getElementById("browser.newtab.choice");
-    let defaultStartupHomepage = Services.prefs.getDefaultBranch("browser.")
-                                  .getComplexValue("startup.homepage",
-                                    Components.interfaces.nsIPrefLocalizedString).data;
-    switch (newtabUrlPref.value) {
-      case "about:logopage": 
-        newtabUrlChoice.value = 1;
-        break;
-      case defaultStartupHomepage:
-        newtabUrlChoice.value = 2;
-        break;
-      case newtabUrlSanitizedPref.value:
-        newtabUrlChoice.value = 3;
-        break;
-      case "about:newtab":
-        newtabUrlChoice.value = 4;
-        break;
-      default: // Custom URL entered.
-        document.getElementById("newtabPageCustom").hidden = false;
-        newtabUrlChoice.value = 0;
-        // We need this to consider instantApply.
-        this.newtabPageCustom = newtabUrlPref.value;
+    newtabUrlChoice.value = gNewtabUrl.getNewtabChoice();
+    if (newtabUrlChoice.value == 0) {
+      document.getElementById("newtabPageCustom").hidden = false;
     }
+    gNewtabUrl.newtabUrlChoiceIsSet = true;
   }
 };


### PR DESCRIPTION
Properly determine `browser.newtab.choice` in `gNewtabUrl.writeNewtabUrl()`.

This resolves #1026, also reverts https://github.com/MoonchildProductions/UXP/commit/eb77e289bbe056b58051db0fa868e95da803aa0a.