### PR TITLE
Fix SVG mask crashes

### DIFF
--- a/gfx/2d/2D.h
+++ b/gfx/2d/2D.h
@@ -488,6 +488,9 @@ public:
   /**
    * Returns a DataSourceSurface with the same data as this one, but
    * guaranteed to have surface->GetType() == SurfaceType::DATA.
+   *
+   * The returning surface might be null, because of OOM or gfx device reset.
+   * The caller needs to do null-check before using it.
    */
   virtual already_AddRefed<DataSourceSurface> GetDataSurface() override;
 

--- a/layout/svg/nsSVGMaskFrame.cpp
+++ b/layout/svg/nsSVGMaskFrame.cpp
@@ -274,7 +274,8 @@ nsSVGMaskFrame::GetMaskForMaskedFrame(gfxContext* aContext,
   }
   RefPtr<DataSourceSurface> maskSurface = maskSnapshot->GetDataSurface();
   DataSourceSurface::MappedSurface map;
-  if (!maskSurface->Map(DataSourceSurface::MapType::READ, &map)) {
+  if (!maskSurface ||
+      !maskSurface->Map(DataSourceSurface::MapType::READ, &map)) {
     return nullptr;
   }
 

--- a/layout/svg/nsSVGUtils.cpp
+++ b/layout/svg/nsSVGUtils.cpp
@@ -685,7 +685,7 @@ nsSVGUtils::PaintFrameWithEffects(nsIFrame *aFrame,
   bool isOK = effectProperties.HasNoFilterOrHasValidFilter();
   nsSVGClipPathFrame *clipPathFrame = effectProperties.GetClipPathFrame(&isOK);
   nsSVGMaskFrame *maskFrame = effectProperties.GetFirstMaskFrame(&isOK);
-  if (!isOK) {
+  if (!isOK || !maskFrame) {
     // Some resource is invalid. We shouldn't paint anything.
     return DrawResult::SUCCESS;
   }


### PR DESCRIPTION
This fixes #1034 by adding a `nullptr` check for both `maskSurface` and `maskFrame`.