### PR TITLE
Disable <style scoped> in content documents

### DIFF
--- a/dom/base/nsContentUtils.cpp
+++ b/dom/base/nsContentUtils.cpp
@@ -289,6 +289,7 @@ bool nsContentUtils::sGettersDecodeURLHash = false;
 bool nsContentUtils::sPrivacyResistFingerprinting = false;
 bool nsContentUtils::sSendPerformanceTimingNotifications = false;
 bool nsContentUtils::sUseActivityCursor = false;
+bool nsContentUtils::sIsScopedStyleEnabled = false;
 
 uint32_t nsContentUtils::sHandlingInputTimeout = 1000;
 
@@ -618,6 +619,9 @@ nsContentUtils::Init()
 
   Preferences::AddBoolVarCache(&sUseActivityCursor,
                                "ui.use_activity_cursor", false);
+
+  Preferences::AddBoolVarCache(&sIsScopedStyleEnabled,
+                               "layout.css.scoped-style.enabled", false);
 
   Element::InitCCCallbacks();
 

--- a/dom/base/nsContentUtils.h
+++ b/dom/base/nsContentUtils.h
@@ -2101,6 +2101,14 @@ public:
     return sUseActivityCursor;
   }
 
+   /**
+   * Returns true if the <style scoped> enabling pref is true.
+   */
+  static bool IsScopedStylePrefEnabled()
+  {
+    return sIsScopedStyleEnabled;
+  }
+
   /**
    * Return true if this doc is controlled by a ServiceWorker.
    */
@@ -2851,6 +2859,7 @@ private:
   static bool sPrivacyResistFingerprinting;
   static bool sSendPerformanceTimingNotifications;
   static bool sUseActivityCursor;
+  static bool sIsScopedStyleEnabled;
   static uint32_t sCookiesLifetimePolicy;
   static uint32_t sCookiesBehavior;
 

--- a/dom/base/nsDocument.cpp
+++ b/dom/base/nsDocument.cpp
@@ -1312,6 +1312,7 @@ nsIDocument::nsIDocument()
     mDidFireDOMContentLoaded(true),
     mHasScrollLinkedEffect(false),
     mFrameRequestCallbacksScheduled(false),
+    mIsScopedStyleEnabled(eScopedStyle_Unknown),
     mBidiOptions(IBMBIDI_DEFAULT_BIDI_OPTIONS),
     mPartID(0),
     mUserHasInteracted(false)
@@ -12709,6 +12710,18 @@ nsDocument::CheckCustomElementName(const ElementCreationOptions& aOptions,
   }
 
   return is;
+}
+
+bool
+nsIDocument::IsScopedStyleEnabled()
+{
+  if (mIsScopedStyleEnabled == eScopedStyle_Unknown) {
+    mIsScopedStyleEnabled = nsContentUtils::IsChromeDoc(this) ||
+                            nsContentUtils::IsScopedStylePrefEnabled()
+                              ? eScopedStyle_Enabled
+                              : eScopedStyle_Disabled;
+  }
+  return mIsScopedStyleEnabled == eScopedStyle_Enabled;
 }
 
 Selection*

--- a/dom/base/nsIDocument.h
+++ b/dom/base/nsIDocument.h
@@ -2857,6 +2857,8 @@ public:
   virtual void ScheduleIntersectionObserverNotification() = 0;
   virtual void NotifyIntersectionObservers() = 0;
 
+  bool IsScopedStyleEnabled();
+
 protected:
   bool GetUseCounter(mozilla::UseCounter aUseCounter)
   {
@@ -2999,6 +3001,10 @@ protected:
 
   // container for per-context fonts (downloadable, SVG, etc.)
   RefPtr<mozilla::dom::FontFaceSet> mFontFaceSet;
+
+  // Whether <style scoped> support is enabled in this document.
+  enum { eScopedStyle_Unknown, eScopedStyle_Disabled, eScopedStyle_Enabled };
+  unsigned int mIsScopedStyleEnabled : 2;
 
   // Compatibility mode
   nsCompatibility mCompatMode;

--- a/dom/base/nsStyleLinkElement.cpp
+++ b/dom/base/nsStyleLinkElement.cpp
@@ -241,7 +241,8 @@ IsScopedStyleElement(nsIContent* aContent)
   // if it is scoped.
   return (aContent->IsHTMLElement(nsGkAtoms::style) ||
           aContent->IsSVGElement(nsGkAtoms::style)) &&
-         aContent->HasAttr(kNameSpaceID_None, nsGkAtoms::scoped);
+         aContent->HasAttr(kNameSpaceID_None, nsGkAtoms::scoped) &&
+         aContent->OwnerDoc()->IsScopedStyleEnabled();
 }
 
 static bool

--- a/dom/html/HTMLStyleElement.cpp
+++ b/dom/html/HTMLStyleElement.cpp
@@ -178,7 +178,8 @@ HTMLStyleElement::AfterSetAttr(int32_t aNameSpaceID, nsIAtom* aName,
         aName == nsGkAtoms::media ||
         aName == nsGkAtoms::type) {
       UpdateStyleSheetInternal(nullptr, nullptr, true);
-    } else if (aName == nsGkAtoms::scoped) {
+    } else if (aName == nsGkAtoms::scoped &&
+               OwnerDoc()->IsScopedStyleEnabled()) {
       bool isScoped = aValue;
       UpdateStyleSheetScopedness(isScoped);
     }
@@ -241,7 +242,8 @@ HTMLStyleElement::GetStyleSheetInfo(nsAString& aTitle,
 
   GetAttr(kNameSpaceID_None, nsGkAtoms::type, aType);
 
-  *aIsScoped = HasAttr(kNameSpaceID_None, nsGkAtoms::scoped);
+  *aIsScoped = HasAttr(kNameSpaceID_None, nsGkAtoms::scoped) &&
+               OwnerDoc()->IsScopedStyleEnabled();
 
   nsAutoString mimeType;
   nsAutoString notUsed;

--- a/dom/html/test/test_style_attributes_reflection.html
+++ b/dom/html/test/test_style_attributes_reflection.html
@@ -29,11 +29,13 @@ reflectString({
   attribute: "type"
 });
 
-// .scoped
-reflectBoolean({
-  element: e,
-  attribute: "scoped"
-});
+if (SpecialPowers.getBoolPref("layout.css.scoped-style.enabled")) {
+  // .scoped
+  reflectBoolean({
+    element: e,
+    attribute: "scoped"
+  });
+}
 
 </script>
 </pre>

--- a/dom/svg/SVGStyleElement.cpp
+++ b/dom/svg/SVGStyleElement.cpp
@@ -104,7 +104,8 @@ SVGStyleElement::SetAttr(int32_t aNameSpaceID, nsIAtom* aName,
         aName == nsGkAtoms::media ||
         aName == nsGkAtoms::type) {
       UpdateStyleSheetInternal(nullptr, nullptr, true);
-    } else if (aName == nsGkAtoms::scoped) {
+    } else if (aName == nsGkAtoms::scoped &&
+               OwnerDoc()->IsScopedStyleEnabled()) {
       UpdateStyleSheetScopedness(true);
     }
   }
@@ -123,7 +124,8 @@ SVGStyleElement::UnsetAttr(int32_t aNameSpaceID, nsIAtom* aAttribute,
         aAttribute == nsGkAtoms::media ||
         aAttribute == nsGkAtoms::type) {
       UpdateStyleSheetInternal(nullptr, nullptr, true);
-    } else if (aAttribute == nsGkAtoms::scoped) {
+    } else if (aAttribute == nsGkAtoms::scoped &&
+               OwnerDoc()->IsScopedStyleEnabled()) {
       UpdateStyleSheetScopedness(false);
     }
   }
@@ -290,7 +292,8 @@ SVGStyleElement::GetStyleSheetInfo(nsAString& aTitle,
     aType.AssignLiteral("text/css");
   }
 
-  *aIsScoped = HasAttr(kNameSpaceID_None, nsGkAtoms::scoped);
+  *aIsScoped = HasAttr(kNameSpaceID_None, nsGkAtoms::scoped) &&
+               OwnerDoc()->IsScopedStyleEnabled();
 
   return;
 }

--- a/dom/webidl/HTMLStyleElement.webidl
+++ b/dom/webidl/HTMLStyleElement.webidl
@@ -15,7 +15,7 @@ interface HTMLStyleElement : HTMLElement {
            attribute DOMString media;
            [SetterThrows, Pure]
            attribute DOMString type;
-           [SetterThrows, Pure]
+           [SetterThrows, Pure, Pref="layout.css.scoped-style.enabled"]
            attribute boolean scoped;
 };
 HTMLStyleElement implements LinkStyle;

--- a/dom/webidl/SVGStyleElement.webidl
+++ b/dom/webidl/SVGStyleElement.webidl
@@ -19,7 +19,7 @@ interface SVGStyleElement : SVGElement {
   attribute DOMString media;
   [SetterThrows]
   attribute DOMString title;
-  [SetterThrows]
+  [SetterThrows, Pref="layout.css.scoped-style.enabled"]
   attribute boolean scoped;
 };
 SVGStyleElement implements LinkStyle;

--- a/layout/reftests/css-display/reftest.list
+++ b/layout/reftests/css-display/reftest.list
@@ -7,9 +7,9 @@ fuzzy-if(Android,8,604) pref(layout.css.display-contents.enabled,true) == displa
 fuzzy-if(Android,8,604) pref(layout.css.display-contents.enabled,true) == display-contents-acid-dyn-3.html display-contents-acid-ref.html
 pref(layout.css.display-contents.enabled,true) == display-contents-generated-content.html display-contents-generated-content-ref.html
 pref(layout.css.display-contents.enabled,true) == display-contents-generated-content-2.html display-contents-generated-content-ref.html
-pref(layout.css.display-contents.enabled,true) == display-contents-style-inheritance-1.html display-contents-style-inheritance-1-ref.html
-pref(layout.css.display-contents.enabled,true) == display-contents-style-inheritance-1-stylechange.html display-contents-style-inheritance-1-ref.html
-pref(layout.css.display-contents.enabled,true) fuzzy-if(winWidget,12,100) == display-contents-style-inheritance-1-dom-mutations.html display-contents-style-inheritance-1-ref.html
+pref(layout.css.display-contents.enabled,true) pref(layout.css.scoped-style.enabled,true) == display-contents-style-inheritance-1.html display-contents-style-inheritance-1-ref.html
+pref(layout.css.display-contents.enabled,true) pref(layout.css.scoped-style.enabled,true) == display-contents-style-inheritance-1-stylechange.html display-contents-style-inheritance-1-ref.html
+pref(layout.css.display-contents.enabled,true) fuzzy-if(winWidget,12,100) pref(layout.css.scoped-style.enabled,true) == display-contents-style-inheritance-1-dom-mutations.html display-contents-style-inheritance-1-ref.html
 pref(layout.css.display-contents.enabled,true) == display-contents-tables.xhtml display-contents-tables-ref.xhtml
 pref(layout.css.display-contents.enabled,true) == display-contents-tables-2.xhtml display-contents-tables-ref.xhtml
 pref(layout.css.display-contents.enabled,true) == display-contents-tables-3.xhtml display-contents-tables-3-ref.xhtml
@@ -17,7 +17,7 @@ pref(layout.css.display-contents.enabled,true) == display-contents-visibility-hi
 pref(layout.css.display-contents.enabled,true) == display-contents-visibility-hidden-2.html display-contents-visibility-hidden-ref.html
 pref(layout.css.display-contents.enabled,true) == display-contents-495385-2d.html display-contents-495385-2d-ref.html
 fuzzy-if(Android,7,3935) pref(layout.css.display-contents.enabled,true) == display-contents-xbl.xhtml display-contents-xbl-ref.html
-fuzzy-if(Android,7,1186) pref(layout.css.display-contents.enabled,true) pref(dom.webcomponents.enabled,true) == display-contents-shadow-dom-1.html display-contents-shadow-dom-1-ref.html
+fuzzy-if(Android,7,1186) pref(layout.css.display-contents.enabled,true) pref(dom.webcomponents.enabled,true) pref(layout.css.scoped-style.enabled,true) == display-contents-shadow-dom-1.html display-contents-shadow-dom-1-ref.html
 pref(layout.css.display-contents.enabled,true) == display-contents-xbl-2.xul display-contents-xbl-2-ref.xul
 asserts(1) pref(layout.css.display-contents.enabled,true) == display-contents-xbl-3.xul display-contents-xbl-3-ref.xul # bug 1089223
 skip pref(layout.css.display-contents.enabled,true) == display-contents-xbl-4.xul display-contents-xbl-4-ref.xul # fails (not just asserts) due to bug 1089223

--- a/layout/reftests/css-mediaqueries/reftest.list
+++ b/layout/reftests/css-mediaqueries/reftest.list
@@ -15,5 +15,5 @@ fuzzy-if(Android,8,454) == mq_print_maxheight.xhtml mq_print-ref.xhtml
 == mq_print_minheight_updown.xhtml mq_print-ref.xhtml
 == mq_print_minwidth_updown.xhtml mq_print-ref.xhtml
 
-== scoped-mq-update.html scoped-mq-update-ref.html
+pref(layout.css.scoped-style.enabled,true) == scoped-mq-update.html scoped-mq-update-ref.html
 == system-metrics-1.html system-metrics-1-ref.html

--- a/layout/reftests/scoped-style/reftest.list
+++ b/layout/reftests/scoped-style/reftest.list
@@ -1,3 +1,5 @@
+default-preferences pref(layout.css.scoped-style.enabled,true)
+
 == scoped-style-001.html scoped-style-001-ref.html
 == scoped-style-002.html scoped-style-002-ref.html
 == scoped-style-003.html scoped-style-003-ref.html

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -2563,6 +2563,12 @@ pref("layout.css.unprefixing-service.enabled", true);
 pref("layout.css.unprefixing-service.globally-whitelisted", false);
 #endif
 
+// Is support for <style scoped> enabled in content documents?
+//
+// If disabled, this will also disable the DOM API (HTMLStyleElement.scoped)
+// in chrome documents.
+pref("layout.css.scoped-style.enabled", true);
+
 // Is support for the :scope selector enabled?
 pref("layout.css.scope-pseudo.enabled", true);
 

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -2567,7 +2567,7 @@ pref("layout.css.unprefixing-service.globally-whitelisted", false);
 //
 // If disabled, this will also disable the DOM API (HTMLStyleElement.scoped)
 // in chrome documents.
-pref("layout.css.scoped-style.enabled", true);
+pref("layout.css.scoped-style.enabled", false);
 
 // Is support for the :scope selector enabled?
 pref("layout.css.scope-pseudo.enabled", true);


### PR DESCRIPTION
Introduce a pref for `<style scoped>` and disable it by default.

Based on [Bug #1291515](https://bugzilla.mozilla.org/show_bug.cgi?id=1291515).

Resolves #1038.