### PR TITLE
Remove unused parameter from call

### DIFF
--- a/toolkit/components/viewsource/content/viewSource-content.js
+++ b/toolkit/components/viewsource/content/viewSource-content.js
@@ -128,8 +128,7 @@ var ViewSourceContent = {
     let objects = msg.objects;
     switch (msg.name) {
       case "ViewSource:LoadSource":
-        this.viewSource(data.URL, data.outerWindowID, data.lineNumber,
-                        data.shouldWrap);
+        this.viewSource(data.URL, data.outerWindowID, data.lineNumber);
         break;
       case "ViewSource:LoadSourceOriginal":
         this.viewSourceOriginal(data.URL, objects.pageDescriptor, data.lineNumber,


### PR DESCRIPTION
Removes an unnecessary parameter (which also references an undefined property) from the call to viewSource

Fixes #1043