### PR TITLE
[minor] Fix a variable name in Basilisk error page

### DIFF
--- a/application/basilisk/base/content/aboutNetError.xhtml
+++ b/application/basilisk/base/content/aboutNetError.xhtml
@@ -362,7 +362,7 @@
           // First, find the index of the <a> tag we care about, being
           // careful not to use an over-greedy regex.
           var re = /<a id="cert_domain_link" title="([^"]+)">/;
-          var result = domainRe.exec(desc);
+          var result = re.exec(desc);
 
           if (!result)
             return;


### PR DESCRIPTION
Related commit: https://github.com/MoonchildProductions/UXP/commit/e313e5e2ec19355988c3d59745c202f4604670d3#diff-115f6bd87bbdaa1f6445547dac684c9c