### PR TITLE
Don't shrink the tab bar in customize mode

### DIFF
--- a/application/palemoon/themes/linux/browser.css
+++ b/application/palemoon/themes/linux/browser.css
@@ -1608,7 +1608,7 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 }
 
 /* When the tab bar is collapsed, show a 1px border in its place. */
-#TabsToolbar[tabsontop="false"][collapsed="true"] {
+#TabsToolbar[tabsontop="false"][collapsed="true"]:not([customizing="true"]) {
   visibility: visible;
   height: 1px;
   border-bottom-width: 1px;

--- a/application/palemoon/themes/osx/browser.css
+++ b/application/palemoon/themes/osx/browser.css
@@ -1631,7 +1631,7 @@ richlistitem[type~="action"][actiontype="switchtab"][selected="true"] > .ac-url-
 }
 
 /* When the tab bar is collapsed, show a 1px border in its place. */
-#TabsToolbar[tabsontop="false"][collapsed="true"] {
+#TabsToolbar[tabsontop="false"][collapsed="true"]:not([customizing="true"]) {
   visibility: visible;
   height: 1px;
   border-bottom-width: 1px;

--- a/application/palemoon/themes/windows/browser.css
+++ b/application/palemoon/themes/windows/browser.css
@@ -1844,7 +1844,7 @@ richlistitem[type~="action"][actiontype="switchtab"] > .ac-url-box > .ac-action-
 }
 
 /* When the tab bar is collapsed, show a 1px border in its place. */
-#TabsToolbar[tabsontop="false"][collapsed="true"] {
+#TabsToolbar[tabsontop="false"][collapsed="true"]:not([customizing="true"]) {
   visibility: visible;
   height: 1px;
   border-bottom-width: 1px;


### PR DESCRIPTION
This resolves #1072. 

Admittedly I hadn't noticed that the tab bar expands when the customize mode is entered - this patch makes sure not to make changes to the tab bar in this mode (as the full bar shows anyway, so there's already a border there).