### PR TITLE
Add null check for URL Bar in the writePlaceholder() method

### DIFF
--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -412,6 +412,9 @@ var gURLBarSettings = {
   },
 
   writePlaceholder: function() {
+    if (!gURLBar)
+      return;
+
     let attribute = "placeholder";
     let prefs = this.prefSuggests.map(pref => {
       return this.prefSuggest + pref;

--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -3474,6 +3474,7 @@ function BrowserToolboxCustomizeDone(aToolboxChanged) {
 
   // Update the urlbar
   if (gURLBar) {
+    gURLBarSettings.writePlaceholder();
     URLBarSetURI();
     XULBrowserWindow.asyncUpdateUI();
     BookmarkingUI.updateStarState();

--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -412,8 +412,9 @@ var gURLBarSettings = {
   },
 
   writePlaceholder: function() {
-    if (!gURLBar)
+    if (!gURLBar) {
       return;
+    }
 
     let attribute = "placeholder";
     let prefs = this.prefSuggests.map(pref => {


### PR DESCRIPTION
This resolves #1084.
Does as the title says, adds a null check for the URL Bar in the writePlaceholder() method.