### PR TITLE
Update sync clear history function to use new clear() API call.

### DIFF
--- a/services/sync/modules/engines/history.js
+++ b/services/sync/modules/engines/history.js
@@ -346,7 +346,7 @@ HistoryStore.prototype = {
   },
 
   wipe: function HistStore_wipe() {
-    PlacesUtils.history.removeAllPages();
+    PlacesUtils.history.clear();
   }
 };
 


### PR DESCRIPTION
I ran into this bug while trying to add a new browser to my sync setup. Selecting the "Replace all data on this device with my Sync data" option was causing a sync failed: unknown reason error. Reading the sync logs, I saw this:

`1557617922428	Sync.Service	DEBUG	Exception: : TypeError: PlacesUtils.history.removeAllPages is not a function (resource://gre/modules/services-sync/engines/history.js:349:5) JS Stack trace: HistStore_wipe@history.js:349:5 < _wipeClient@engines.js:696:5 < WrappedNotify@util.js:148:21 < wipeClient@engines.js:702:5 < wipeClient@service.js:1472:9 < sync@enginesync.js:105:9 < onNotify@service.js:1273:7 < WrappedNotify@util.js:148:21 < WrappedLock@util.js:103:16 < _lockedSync@service.js:1266:12 < sync/<@service.js:1258:14 < WrappedCatch@util.js:77:16 < sync@service.js:1246:5`

Apparently the API was changed a while back: https://bugzilla.mozilla.org/show_bug.cgi?format=default&id=1124185

Simple one-line fix, I tested this on Linux and it fixes the sync error.