### PR TITLE
Issue #971 - Fix browser.link.open_newwindow functionality in Pale Moon

### DIFF
--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -4481,7 +4481,6 @@ nsBrowserAccess.prototype = {
         }
 
         let loadInBackground = gPrefService.getBoolPref("browser.tabs.loadDivertedInBackground");
-        let referrer = aOpener ? makeURI(aOpener.location.href) : null;
 
         let tab = win.gBrowser.loadOneTab(aURI ? aURI.spec : "about:blank", {
                                           triggeringPrincipal: triggeringPrincipal,


### PR DESCRIPTION
This resolves #971.

This patch removes the `referrer` declaration at the second case of the switch block inside the `openURL` function. Additional details can be found at the mentioned issue.