### PR TITLE
Clicking a link with a target should open only 1 tab

### DIFF
--- a/application/palemoon/base/content/browser.js
+++ b/application/palemoon/base/content/browser.js
@@ -4481,13 +4481,15 @@ nsBrowserAccess.prototype = {
         }
 
         let loadInBackground = gPrefService.getBoolPref("browser.tabs.loadDivertedInBackground");
+        let openerWindow = (aContext & Ci.nsIBrowserDOMWindow.OPEN_NO_OPENER) ? null : aOpener;
 
         let tab = win.gBrowser.loadOneTab(aURI ? aURI.spec : "about:blank", {
                                           triggeringPrincipal: triggeringPrincipal,
                                           referrerURI: referrer,
                                           referrerPolicy: referrerPolicy,
                                           fromExternal: isExternal,
-                                          inBackground: loadInBackground});
+                                          inBackground: loadInBackground,
+                                          opener: openerWindow });
         let browser = win.gBrowser.getBrowserForTab(tab);
 
         if (gPrefService.getBoolPref("browser.tabs.noWindowActivationOnExternal")) {

--- a/application/palemoon/base/content/tabbrowser.xml
+++ b/application/palemoon/base/content/tabbrowser.xml
@@ -1337,6 +1337,7 @@
             var aFromExternal;
             var aRelatedToCurrent;
             var aOriginPrincipal;
+            var aOpener;
             if (arguments.length == 2 &&
                 typeof arguments[1] == "object" &&
                 !(arguments[1] instanceof Ci.nsIURI)) {
@@ -1351,6 +1352,7 @@
               aFromExternal         = params.fromExternal;
               aRelatedToCurrent     = params.relatedToCurrent;
               aOriginPrincipal      = params.originPrincipal;
+              aOpener               = params.opener;
             }
 
             var bgLoad = (aLoadInBackground != null) ? aLoadInBackground :
@@ -1366,7 +1368,8 @@
                                   allowThirdPartyFixup: aAllowThirdPartyFixup,
                                   fromExternal: aFromExternal,
                                   originPrincipal: aOriginPrincipal,
-                                  relatedToCurrent: aRelatedToCurrent});
+                                  relatedToCurrent: aRelatedToCurrent,
+                                  opener: aOpener });
             if (!bgLoad)
               this.selectedTab = tab;
 
@@ -1489,6 +1492,7 @@
             var aSkipAnimation;
             var aOriginPrincipal;
             var aSkipBackgroundNotify;
+            var aOpener;
             if (arguments.length == 2 &&
                 typeof arguments[1] == "object" &&
                 !(arguments[1] instanceof Ci.nsIURI)) {
@@ -1504,6 +1508,7 @@
               aRelatedToCurrent     = params.relatedToCurrent;
               aSkipAnimation        = params.skipAnimation;
               aOriginPrincipal      = params.originPrincipal;
+              aOpener               = params.opener;
               aSkipBackgroundNotify = params.skipBackgroundNotify;
             }
 
@@ -1576,6 +1581,10 @@
             if (window.gShowPageResizers && document.getElementById("addon-bar").collapsed &&
                 window.windowState == window.STATE_NORMAL) {
               b.setAttribute("showresizer", "true");
+            }
+
+            if (aOpener) {
+              b.QueryInterface(Ci.nsIFrameLoaderOwner).presetOpenerWindow(aOpener);
             }
 
             if (this.hasAttribute("autocompletepopup"))


### PR DESCRIPTION
This resolves #1104.

> It includes changes to both the `openURI` function passing an opener to the `loadOneTab` function inside the tabbrowser binding. `loadOneTab` and `addTab` were modified to accept an opener and set it as the new browser's opener.

Please add the `Verification Needed` label.