### PR TITLE
Disable <meta http-equiv=set-cookie>

### DIFF
--- a/dom/base/nsContentSink.cpp
+++ b/dom/base/nsContentSink.cpp
@@ -304,7 +304,8 @@ nsContentSink::ProcessHeaderData(nsIAtom* aHeader, const nsAString& aValue,
 
   mDocument->SetHeaderData(aHeader, aValue);
 
-  if (aHeader == nsGkAtoms::setcookie) {
+  if (aHeader == nsGkAtoms::setcookie &&
+      Preferences::GetBool("dom.meta-set-cookie.enabled", true)) {
     // Don't allow setting cookies in cookie-averse documents.
     if (mDocument->IsCookieAverse()) {
       return NS_OK;

--- a/extensions/cookie/test/file_domain_hierarchy_inner.html
+++ b/extensions/cookie/test/file_domain_hierarchy_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta=tag">
   <script type="text/javascript">
     document.cookie = "can=has";
 

--- a/extensions/cookie/test/file_domain_hierarchy_inner.html^headers^
+++ b/extensions/cookie/test/file_domain_hierarchy_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta=tag

--- a/extensions/cookie/test/file_domain_hierarchy_inner_inner.html
+++ b/extensions/cookie/test/file_domain_hierarchy_inner_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta2=tag2">
   <script type="text/javascript">
     document.cookie = "can2=has2";
 

--- a/extensions/cookie/test/file_domain_hierarchy_inner_inner.html^headers^
+++ b/extensions/cookie/test/file_domain_hierarchy_inner_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta2=tag2

--- a/extensions/cookie/test/file_domain_hierarchy_inner_inner_inner.html
+++ b/extensions/cookie/test/file_domain_hierarchy_inner_inner_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta3=tag3">
   <script type="text/javascript">
     document.cookie = "can3=has3";
 

--- a/extensions/cookie/test/file_domain_hierarchy_inner_inner_inner.html^headers^
+++ b/extensions/cookie/test/file_domain_hierarchy_inner_inner_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta3=tag3

--- a/extensions/cookie/test/file_domain_inner.html
+++ b/extensions/cookie/test/file_domain_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta=tag">
   <script type="text/javascript">
     document.cookie = "can=has";
 

--- a/extensions/cookie/test/file_domain_inner.html^headers^
+++ b/extensions/cookie/test/file_domain_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta=tag

--- a/extensions/cookie/test/file_domain_inner_inner.html
+++ b/extensions/cookie/test/file_domain_inner_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta2=tag2">
   <script type="text/javascript">
     document.cookie = "can2=has2";
 

--- a/extensions/cookie/test/file_domain_inner_inner.html^headers^
+++ b/extensions/cookie/test/file_domain_inner_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta2=tag2

--- a/extensions/cookie/test/file_image_inner.html
+++ b/extensions/cookie/test/file_image_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta=tag">
   <script type="text/javascript">
     document.cookie = "can=has";
 

--- a/extensions/cookie/test/file_image_inner.html^headers^
+++ b/extensions/cookie/test/file_image_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta=tag

--- a/extensions/cookie/test/file_image_inner_inner.html
+++ b/extensions/cookie/test/file_image_inner_inner.html
@@ -3,7 +3,6 @@
 <head>
   <link rel="stylesheet" type="text/css" media="all" href="http://example.org/tests/extensions/cookie/test/test1.css" />
   <link rel="stylesheet" type="text/css" media="all" href="http://example.com/tests/extensions/cookie/test/test2.css" />
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta2=tag2">
   <script type="text/javascript">
     function runTest() {
       document.cookie = "can2=has2";

--- a/extensions/cookie/test/file_image_inner_inner.html^headers^
+++ b/extensions/cookie/test/file_image_inner_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta2=tag2

--- a/extensions/cookie/test/file_loadflags_inner.html
+++ b/extensions/cookie/test/file_loadflags_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta=tag">
   <script type="text/javascript">
     function runTest() {
       document.cookie = "can=has";

--- a/extensions/cookie/test/file_loadflags_inner.html^headers^
+++ b/extensions/cookie/test/file_loadflags_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta=tag

--- a/extensions/cookie/test/file_localhost_inner.html
+++ b/extensions/cookie/test/file_localhost_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta=tag">
   <script type="text/javascript">
     document.cookie = "can=has";
 

--- a/extensions/cookie/test/file_localhost_inner.html^headers^
+++ b/extensions/cookie/test/file_localhost_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta=tag

--- a/extensions/cookie/test/file_loopback_inner.html
+++ b/extensions/cookie/test/file_loopback_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta=tag">
   <script type="text/javascript">
     document.cookie = "can=has";
 

--- a/extensions/cookie/test/file_loopback_inner.html^headers^
+++ b/extensions/cookie/test/file_loopback_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta=tag

--- a/extensions/cookie/test/file_subdomain_inner.html
+++ b/extensions/cookie/test/file_subdomain_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta=tag">
   <script type="text/javascript">
     document.cookie = "can=has";
 

--- a/extensions/cookie/test/file_subdomain_inner.html^headers^
+++ b/extensions/cookie/test/file_subdomain_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta=tag

--- a/extensions/cookie/test/mochitest.ini
+++ b/extensions/cookie/test/mochitest.ini
@@ -6,16 +6,27 @@ support-files =
   damonbowling.jpg^headers^
   file_chromecommon.js
   file_domain_hierarchy_inner.html
+  file_domain_hierarchy_inner.html^headers^
   file_domain_hierarchy_inner_inner.html
+  file_domain_hierarchy_inner_inner.html^headers^
   file_domain_hierarchy_inner_inner_inner.html
+  file_domain_hierarchy_inner_inner_inner.html^headers^
   file_domain_inner.html
+  file_domain_inner.html^headers^
   file_domain_inner_inner.html
+  file_domain_inner_inner.html^headers^
   file_image_inner.html
+  file_image_inner.html^headers^
   file_image_inner_inner.html
+  file_image_inner_inner.html^headers^
   file_loadflags_inner.html
+  file_loadflags_inner.html^headers^
   file_localhost_inner.html
+  file_localhost_inner.html^headers^
   file_loopback_inner.html
+  file_loopback_inner.html^headers^
   file_subdomain_inner.html
+  file_subdomain_inner.html^headers^
   file_testcommon.js
   file_testloadflags.js
   file_testloadflags_chromescript.js

--- a/extensions/cookie/test/test_same_base_domain.html
+++ b/extensions/cookie/test/test_same_base_domain.html
@@ -5,7 +5,7 @@
   <script type="text/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>        
   <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css" />
 </head>
-<body onload="setupTest('http://test1.example.org/tests/extensions/cookie/test/file_domain_inner.html', 5, 2)">
+<body onload="setupTest('http://test1.example.org/tests/extensions/cookie/test/file_domain_inner.html', 4, 2)">
 <p id="display"></p>
 <pre id="test">
 <script class="testbody" type="text/javascript" src="file_testcommon.js">

--- a/extensions/cookie/test/test_same_base_domain_2.html
+++ b/extensions/cookie/test/test_same_base_domain_2.html
@@ -5,7 +5,7 @@
   <script type="text/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>        
   <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css" />
 </head>
-<body onload="setupTest('http://test1.example.org/tests/extensions/cookie/test/file_subdomain_inner.html', 5, 2)">
+<body onload="setupTest('http://test1.example.org/tests/extensions/cookie/test/file_subdomain_inner.html', 4, 2)">
 <p id="display"></p>
 <pre id="test">
 <script class="testbody" type="text/javascript" src="file_testcommon.js">

--- a/extensions/cookie/test/test_same_base_domain_3.html
+++ b/extensions/cookie/test/test_same_base_domain_3.html
@@ -5,7 +5,7 @@
   <script type="text/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>        
   <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css" />
 </head>
-<body onload="setupTest('http://example.org/tests/extensions/cookie/test/file_subdomain_inner.html', 5, 2)">
+<body onload="setupTest('http://example.org/tests/extensions/cookie/test/file_subdomain_inner.html', 4, 2)">
 <p id="display"></p>
 <pre id="test">
 <script class="testbody" type="text/javascript" src="file_testcommon.js">

--- a/extensions/cookie/test/test_same_base_domain_5.html
+++ b/extensions/cookie/test/test_same_base_domain_5.html
@@ -5,7 +5,7 @@
   <script type="text/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>        
   <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css" />
 </head>
-<body onload="setupTest('http://sub1.test1.example.org/tests/extensions/cookie/test/file_subdomain_inner.html', 5, 2)">
+<body onload="setupTest('http://sub1.test1.example.org/tests/extensions/cookie/test/file_subdomain_inner.html', 4, 2)">
 <p id="display"></p>
 <pre id="test">
 <script class="testbody" type="text/javascript" src="file_testcommon.js">

--- a/extensions/cookie/test/test_samedomain.html
+++ b/extensions/cookie/test/test_samedomain.html
@@ -5,7 +5,7 @@
   <script type="text/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>        
   <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css" />
 </head>
-<body onload="setupTest('http://example.org/tests/extensions/cookie/test/file_domain_inner.html', 5, 2)">
+<body onload="setupTest('http://example.org/tests/extensions/cookie/test/file_domain_inner.html', 4, 2)">
 <p id="display"></p>
 <pre id="test">
 <script class="testbody" type="text/javascript" src="file_testcommon.js">

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -5199,6 +5199,9 @@ pref("intl.allow-insecure-text-input", false);
 // Enable meta-viewport support in remote APZ-enabled frames.
 pref("dom.meta-viewport.enabled", false);
 
+// Disable <meta http-equiv=set-cookie> support. See m-c bug 1457503 / UXP #1102.
+pref("dom.meta-set-cookie.enabled", false);
+
 // MozSettings debugging prefs for each component
 pref("dom.mozSettings.SettingsDB.debug.enabled", false);
 pref("dom.mozSettings.SettingsManager.debug.enabled", false);


### PR DESCRIPTION
Sets a new preference: `dom.meta-set-cookie.enabled` to `false`, by default. Fixing #1102.