### PR TITLE
Lots of time spent maintaining nsDisplayLayerEventRegions

### DIFF
--- a/layout/base/nsDisplayList.cpp
+++ b/layout/base/nsDisplayList.cpp
@@ -3808,14 +3808,14 @@ nsDisplayLayerEventRegions::AddFrame(nsDisplayListBuilder* aBuilder,
     // region on scrollbar frames that won't be placed in their own layer. See
     // bug 1213324 for details.
     mDispatchToContentHitRegion.Or(mDispatchToContentHitRegion, borderBox);
-	mDispatchToContentHitRegion.SimplifyOutward(8);
+    mDispatchToContentHitRegion.SimplifyOutward(8);
   } else if (aFrame->GetType() == nsGkAtoms::objectFrame) {
     // If the frame is a plugin frame and wants to handle wheel events as
     // default action, we should add the frame to dispatch-to-content region.
     nsPluginFrame* pluginFrame = do_QueryFrame(aFrame);
     if (pluginFrame && pluginFrame->WantsToHandleWheelEventAsDefaultAction()) {
       mDispatchToContentHitRegion.Or(mDispatchToContentHitRegion, borderBox);
-	  mDispatchToContentHitRegion.SimplifyOutward(8);
+      mDispatchToContentHitRegion.SimplifyOutward(8);
     }
   }
 
@@ -3852,7 +3852,7 @@ nsDisplayLayerEventRegions::AddFrame(nsDisplayListBuilder* aBuilder,
     }
     if (alreadyHadRegions) {
       mDispatchToContentHitRegion.OrWith(CombinedTouchActionRegion());
-	  mDispatchToContentHitRegion.SimplifyOutward(8);
+      mDispatchToContentHitRegion.SimplifyOutward(8);
     }
   }
 }

--- a/layout/base/nsDisplayList.cpp
+++ b/layout/base/nsDisplayList.cpp
@@ -3808,12 +3808,14 @@ nsDisplayLayerEventRegions::AddFrame(nsDisplayListBuilder* aBuilder,
     // region on scrollbar frames that won't be placed in their own layer. See
     // bug 1213324 for details.
     mDispatchToContentHitRegion.Or(mDispatchToContentHitRegion, borderBox);
+	mDispatchToContentHitRegion.SimplifyOutward(8);
   } else if (aFrame->GetType() == nsGkAtoms::objectFrame) {
     // If the frame is a plugin frame and wants to handle wheel events as
     // default action, we should add the frame to dispatch-to-content region.
     nsPluginFrame* pluginFrame = do_QueryFrame(aFrame);
     if (pluginFrame && pluginFrame->WantsToHandleWheelEventAsDefaultAction()) {
       mDispatchToContentHitRegion.Or(mDispatchToContentHitRegion, borderBox);
+	  mDispatchToContentHitRegion.SimplifyOutward(8);
     }
   }
 
@@ -3850,6 +3852,7 @@ nsDisplayLayerEventRegions::AddFrame(nsDisplayListBuilder* aBuilder,
     }
     if (alreadyHadRegions) {
       mDispatchToContentHitRegion.OrWith(CombinedTouchActionRegion());
+	  mDispatchToContentHitRegion.SimplifyOutward(8);
     }
   }
 }
@@ -3859,6 +3862,7 @@ nsDisplayLayerEventRegions::AddInactiveScrollPort(const nsRect& aRect)
 {
   mHitRegion.Or(mHitRegion, aRect);
   mDispatchToContentHitRegion.Or(mDispatchToContentHitRegion, aRect);
+  mDispatchToContentHitRegion.SimplifyOutward(8);
 }
 
 bool


### PR DESCRIPTION
Based to https://bugzilla.mozilla.org/show_bug.cgi?id=1371508

the DispatchToContent region, like the maybe-hit region, should be safe to simplify outward. Similar to #1070 pull request.

This resolves #1112.

Simplify the dispatch-to-content region in nsDisplayLayerEventRegions::AddFrame() and AddInactiveScrollPort() if it starts to get large