### PR TITLE
NodeInfoManager should use a local cache

### DIFF
--- a/dom/base/nsNodeInfoManager.cpp
+++ b/dom/base/nsNodeInfoManager.cpp
@@ -112,7 +112,8 @@ nsNodeInfoManager::nsNodeInfoManager()
     mNonDocumentNodeInfos(0),
     mTextNodeInfo(nullptr),
     mCommentNodeInfo(nullptr),
-    mDocumentNodeInfo(nullptr)
+    mDocumentNodeInfo(nullptr),
+    mRecentlyUsedNodeInfos{}
 {
   nsLayoutStatics::AddRef();
 
@@ -232,11 +233,19 @@ nsNodeInfoManager::GetNodeInfo(nsIAtom *aName, nsIAtom *aPrefix,
   NodeInfo::NodeInfoInner tmpKey(aName, aPrefix, aNamespaceID, aNodeType,
                                  aExtraName);
 
+    uint32_t index =
+      GetNodeInfoInnerHashValue(&tmpKey) % RECENTLY_USED_NODEINFOS_SIZE;
+    NodeInfo* ni = mRecentlyUsedNodeInfos[index];
+    if (ni && NodeInfoInnerKeyCompare(&(ni->mInner), &tmpKey)) {
+    RefPtr<NodeInfo> nodeInfo = ni;
+    return nodeInfo.forget();
+    }
+
   void *node = PL_HashTableLookup(mNodeInfoHash, &tmpKey);
 
   if (node) {
     RefPtr<NodeInfo> nodeInfo = static_cast<NodeInfo*>(node);
-
+    mRecentlyUsedNodeInfos[index] = nodeInfo;
     return nodeInfo.forget();
   }
 
@@ -254,6 +263,7 @@ nsNodeInfoManager::GetNodeInfo(nsIAtom *aName, nsIAtom *aPrefix,
     NS_IF_ADDREF(mDocument);
   }
 
+  mRecentlyUsedNodeInfos[index] = newNodeInfo;
   return newNodeInfo.forget();
 }
 
@@ -272,10 +282,20 @@ nsNodeInfoManager::GetNodeInfo(const nsAString& aName, nsIAtom *aPrefix,
 
   NodeInfo::NodeInfoInner tmpKey(aName, aPrefix, aNamespaceID, aNodeType);
 
+  uint32_t index =
+    GetNodeInfoInnerHashValue(&tmpKey) % RECENTLY_USED_NODEINFOS_SIZE;
+  NodeInfo* ni = mRecentlyUsedNodeInfos[index];
+  if (ni && NodeInfoInnerKeyCompare(&(ni->mInner), &tmpKey)) {
+    RefPtr<NodeInfo> nodeInfo = ni;
+    nodeInfo.forget(aNodeInfo);
+    return NS_OK;
+  }
+
   void *node = PL_HashTableLookup(mNodeInfoHash, &tmpKey);
 
   if (node) {
     RefPtr<NodeInfo> nodeInfo = static_cast<NodeInfo*>(node);
+    mRecentlyUsedNodeInfos[index] = nodeInfo;
     nodeInfo.forget(aNodeInfo);
 
     return NS_OK;
@@ -297,6 +317,7 @@ nsNodeInfoManager::GetNodeInfo(const nsAString& aName, nsIAtom *aPrefix,
     NS_IF_ADDREF(mDocument);
   }
 
+  mRecentlyUsedNodeInfos[index] = newNodeInfo;
   newNodeInfo.forget(aNodeInfo);
 
   return NS_OK;
@@ -419,6 +440,12 @@ nsNodeInfoManager::RemoveNodeInfo(NodeInfo *aNodeInfo)
     else if (aNodeInfo == mCommentNodeInfo) {
       mCommentNodeInfo = nullptr;
     }
+  }
+
+  uint32_t index =
+    GetNodeInfoInnerHashValue(&aNodeInfo->mInner) % RECENTLY_USED_NODEINFOS_SIZE;
+  if (mRecentlyUsedNodeInfos[index] == aNodeInfo) {
+    mRecentlyUsedNodeInfos[index] = nullptr;
   }
 
 #ifdef DEBUG

--- a/dom/base/nsNodeInfoManager.h
+++ b/dom/base/nsNodeInfoManager.h
@@ -32,6 +32,8 @@ class NodeInfo;
 } // namespace dom
 } // namespace mozilla
 
+#define RECENTLY_USED_NODEINFOS_SIZE 31
+
 class nsNodeInfoManager final
 {
 private:
@@ -137,6 +139,7 @@ private:
   mozilla::dom::NodeInfo * MOZ_NON_OWNING_REF mCommentNodeInfo; // WEAK to avoid circular ownership
   mozilla::dom::NodeInfo * MOZ_NON_OWNING_REF mDocumentNodeInfo; // WEAK to avoid circular ownership
   RefPtr<nsBindingManager> mBindingManager;
+  mozilla::dom::NodeInfo* mRecentlyUsedNodeInfos[RECENTLY_USED_NODEINFOS_SIZE];
 };
 
 #endif /* nsNodeInfoManager_h___ */


### PR DESCRIPTION
NodeInfoManager should use a local cache for recently used nodeinfos to avoid slow hashtable lookups.

Based to https://bugzilla.mozilla.org/show_bug.cgi?id=1352235

Resolves #1111
