### PR TITLE
Use memcmp in nsHtml5Portability::localEqualsBuffer 

### DIFF
--- a/parser/html/nsHtml5Portability.cpp
+++ b/parser/html/nsHtml5Portability.cpp
@@ -91,7 +91,7 @@ nsHtml5Portability::releaseString(nsString* str)
 bool
 nsHtml5Portability::localEqualsBuffer(nsIAtom* local, char16_t* buf, int32_t offset, int32_t length)
 {
-  return local->Equals(nsDependentSubstring(buf + offset, buf + offset + length));
+  return local->Equals(buf + offset, length);
 }
 
 bool

--- a/xpcom/ds/nsAtomTable.cpp
+++ b/xpcom/ds/nsAtomTable.cpp
@@ -325,13 +325,7 @@ AtomTableMatchKey(const PLDHashEntryHdr* aEntry, const void* aKey)
                          nsDependentAtomString(he->mAtom)) == 0;
   }
 
-  uint32_t length = he->mAtom->GetLength();
-  if (length != k->mLength) {
-    return false;
-  }
-
-  return memcmp(he->mAtom->GetUTF16String(),
-                k->mUTF16String, length * sizeof(char16_t)) == 0;
+  return he->mAtom->Equals(k->mUTF16String, k->mLength);
 }
 
 static void
@@ -368,6 +362,7 @@ static const PLDHashTableOps AtomTableOps = {
 static nsIAtom*
   sRecentlyUsedMainThreadAtoms[RECENTLY_USED_MAIN_THREAD_ATOM_CACHE_SIZE] = {};
 
+
 void
 DynamicAtom::GCAtomTable()
 {
@@ -386,6 +381,7 @@ DynamicAtom::GCAtomTableLocked(const MutexAutoLock& aProofOfLock,
   for (uint32_t i = 0; i < RECENTLY_USED_MAIN_THREAD_ATOM_CACHE_SIZE; ++i) {
     sRecentlyUsedMainThreadAtoms[i] = nullptr;
   }
+
 
   uint32_t removedCount = 0; // Use a non-atomic temporary for cheaper increments.
   nsAutoCString nonZeroRefcountAtoms;
@@ -684,6 +680,8 @@ NS_Atomize(const nsACString& aUTF8String)
 
     return atom.forget();
   }
+
+
 
   // This results in an extra addref/release of the nsStringBuffer.
   // Unfortunately there doesn't seem to be any APIs to avoid that.

--- a/xpcom/ds/nsAtomTable.cpp
+++ b/xpcom/ds/nsAtomTable.cpp
@@ -362,7 +362,6 @@ static const PLDHashTableOps AtomTableOps = {
 static nsIAtom*
   sRecentlyUsedMainThreadAtoms[RECENTLY_USED_MAIN_THREAD_ATOM_CACHE_SIZE] = {};
 
-
 void
 DynamicAtom::GCAtomTable()
 {
@@ -381,7 +380,6 @@ DynamicAtom::GCAtomTableLocked(const MutexAutoLock& aProofOfLock,
   for (uint32_t i = 0; i < RECENTLY_USED_MAIN_THREAD_ATOM_CACHE_SIZE; ++i) {
     sRecentlyUsedMainThreadAtoms[i] = nullptr;
   }
-
 
   uint32_t removedCount = 0; // Use a non-atomic temporary for cheaper increments.
   nsAutoCString nonZeroRefcountAtoms;
@@ -680,8 +678,6 @@ NS_Atomize(const nsACString& aUTF8String)
 
     return atom.forget();
   }
-
-
 
   // This results in an extra addref/release of the nsStringBuffer.
   // Unfortunately there doesn't seem to be any APIs to avoid that.

--- a/xpcom/ds/nsIAtom.idl
+++ b/xpcom/ds/nsIAtom.idl
@@ -37,9 +37,15 @@ interface nsIAtom : nsISupports
   size_t SizeOfIncludingThis(in MallocSizeOf aMallocSizeOf);
 
 %{C++
-  // note this is NOT virtual so this won't muck with the vtable!
+  // note these are NOT virtual so they won't muck with the vtable!  
+  inline bool Equals(char16ptr_t aString, uint32_t aLength) const 
+  {
+    return mLength == aLength &&
+           memcmp(mString, aString, mLength * sizeof(char16_t)) == 0;
+  }
+
   inline bool Equals(const nsAString& aString) const {
-    return aString.Equals(nsDependentString(mString, mLength));
+    return Equals(aString.BeginReading(), aString.Length());
   }
 
   inline bool IsStaticAtom() const {


### PR DESCRIPTION
Resolves #1113.

Use memcmp and not slower string Equals in nsHtml5Portability::localEqualsBuffer

Based to  https://bugzilla.mozilla.org/show_bug.cgi?id=1352734