### PR TITLE
Use memcmp in nsHtml5Portability::localEqualsBuffer 

### DIFF
--- a/parser/html/nsHtml5Portability.cpp
+++ b/parser/html/nsHtml5Portability.cpp
@@ -91,7 +91,7 @@ nsHtml5Portability::releaseString(nsString* str)
 bool
 nsHtml5Portability::localEqualsBuffer(nsIAtom* local, char16_t* buf, int32_t offset, int32_t length)
 {
-  return local->Equals(nsDependentSubstring(buf + offset, buf + offset + length));
+  return local->Equals(buf + offset, length);
 }
 
 bool

--- a/xpcom/ds/nsAtomTable.cpp
+++ b/xpcom/ds/nsAtomTable.cpp
@@ -325,13 +325,7 @@ AtomTableMatchKey(const PLDHashEntryHdr* aEntry, const void* aKey)
                          nsDependentAtomString(he->mAtom)) == 0;
   }
 
-  uint32_t length = he->mAtom->GetLength();
-  if (length != k->mLength) {
-    return false;
-  }
-
-  return memcmp(he->mAtom->GetUTF16String(),
-                k->mUTF16String, length * sizeof(char16_t)) == 0;
+  return he->mAtom->Equals(k->mUTF16String, k->mLength);
 }
 
 static void

--- a/xpcom/ds/nsIAtom.idl
+++ b/xpcom/ds/nsIAtom.idl
@@ -37,9 +37,15 @@ interface nsIAtom : nsISupports
   size_t SizeOfIncludingThis(in MallocSizeOf aMallocSizeOf);
 
 %{C++
-  // note this is NOT virtual so this won't muck with the vtable!
+  // note these are NOT virtual so they won't muck with the vtable!  
+  inline bool Equals(char16ptr_t aString, uint32_t aLength) const 
+  {
+    return mLength == aLength &&
+           memcmp(mString, aString, mLength * sizeof(char16_t)) == 0;
+  }
+
   inline bool Equals(const nsAString& aString) const {
-    return aString.Equals(nsDependentString(mString, mLength));
+    return Equals(aString.BeginReading(), aString.Length());
   }
 
   inline bool IsStaticAtom() const {


### PR DESCRIPTION
Resolves #1113.

Use memcmp and not slower string Equals in nsHtml5Portability::localEqualsBuffer

Based to https://bugzilla.mozilla.org/show_bug.cgi?id=1352734