### PR TITLE
[Basilisk] Fix packaging when sync is not built

### DIFF
--- a/application/basilisk/installer/package-manifest.in
+++ b/application/basilisk/installer/package-manifest.in
@@ -477,8 +477,10 @@
 @RESPATH@/browser/components/SelfSupportService.manifest
 @RESPATH@/browser/components/SelfSupportService.js
 #endif
+#ifdef MOZ_SERVICES_SYNC
 @RESPATH@/components/SyncComponents.manifest
 @RESPATH@/components/Weave.js
+#endif
 @RESPATH@/components/CaptivePortalDetectComponents.manifest
 @RESPATH@/components/captivedetect.js
 @RESPATH@/components/servicesComponents.manifest
@@ -629,7 +631,9 @@
 @RESPATH@/defaults/pref/channel-prefs.js
 
 ; Services (gre) prefs
+#ifdef MOZ_SERVICES_SYNC
 @RESPATH@/defaults/pref/services-sync.js
+#endif
 
 ; [Layout Engine Resources]
 ; Style Sheets, Graphics and other Resources used by the layout engine.

--- a/application/basilisk/locales/Makefile.in
+++ b/application/basilisk/locales/Makefile.in
@@ -97,7 +97,9 @@ DEFINES += -DBOOKMARKS_INCLUDE_DIR=$(dir $(call MERGE_FILE,profile/bookmarks.inc
 libs-%:
 	$(NSINSTALL) -D $(DIST)/install
 	@$(MAKE) -C $(DEPTH)/toolkit/locales libs-$* XPI_ROOT_APPID='$(XPI_ROOT_APPID)'
+ifdef MOZ_SERVICES_SYNC
 	@$(MAKE) -C $(DEPTH)/services/sync/locales AB_CD=$* XPI_NAME=locale-$*
+endif
 	@$(MAKE) -C $(DEPTH)/extensions/spellcheck/locales AB_CD=$* XPI_NAME=locale-$*
 # 	@$(MAKE) -C ../extensions/pocket/locale AB_CD=$* XPI_NAME=locale-$*
 	@$(MAKE) -C $(DEPTH)/intl/locales AB_CD=$* XPI_NAME=locale-$*

--- a/application/basilisk/locales/l10n.ini
+++ b/application/basilisk/locales/l10n.ini
@@ -16,7 +16,9 @@ dirs = browser
 # non-central apps might want to use %(topsrcdir)s here, or other vars
 # RFE: that needs to be supported by compare-locales, too, though
 toolkit = toolkit/locales/l10n.ini
+#ifdef MOZ_SERVICES_SYNC
 services_sync = services/sync/locales/l10n.ini
+#endif
 
 [extras]
 dirs = extensions/spellcheck


### PR DESCRIPTION
Packaging will fail due to missing ifdefs when --disable-sync is passed in .mozconfig. This fixes that issue by including the missing ifdefs.