### PR TITLE
Issue #1142 - Follow up: Remove uneeded assertion

### DIFF
--- a/js/src/jit/MIR.h
+++ b/js/src/jit/MIR.h
@@ -3785,7 +3785,6 @@ class MObjectState
     MOZ_MUST_USE bool initFromTemplateObject(TempAllocator& alloc, MDefinition* undefinedVal);
 
     size_t numFixedSlots() const {
-        MOZ_ASSERT(!isUnboxed());
         return numFixedSlots_;
     }
     size_t numSlots() const {


### PR DESCRIPTION
Since unboxed objects were removed, isUnboxed is undefined. This causes a build failure when debuging is enabled. This patch fixes the issue by removing the uneeeded assertion.