### PR TITLE
Issue #1142 - Cleanup unused debug code for unboxed objects

### DIFF
--- a/js/src/jit/BaselineIC.cpp
+++ b/js/src/jit/BaselineIC.cpp
@@ -289,7 +289,7 @@ DoTypeUpdateFallback(JSContext* cx, BaselineFrame* frame, ICUpdatedStub* stub, H
       case ICStub::SetProp_Native:
       case ICStub::SetProp_NativeAdd:
       case ICStub::SetProp_Unboxed: {
-        MOZ_ASSERT(obj->isNative() || obj->is<UnboxedPlainObject>());
+        MOZ_ASSERT(obj->isNative());
         jsbytecode* pc = stub->getChainFallback()->icEntry()->pc(script);
         if (*pc == JSOP_SETALIASEDVAR || *pc == JSOP_INITALIASEDLEXICAL)
             id = NameToId(EnvironmentCoordinateName(cx->caches.envCoordinateNameCache, script, pc));

--- a/js/src/jscompartment.cpp
+++ b/js/src/jscompartment.cpp
@@ -112,13 +112,6 @@ JSCompartment::~JSCompartment()
     js_delete(nonSyntacticLexicalEnvironments_),
     js_free(enumerators);
 
-#ifdef DEBUG
-    // Avoid assertion destroying the unboxed layouts list if the embedding
-    // leaked GC things.
-    if (!rt->gc.shutdownCollectedEverything())
-        unboxedLayouts.clear();
-#endif
-
     runtime_->numCompartments--;
 }
 


### PR DESCRIPTION
Also fixes an assertion during compile if debug is enabled since unboxed objects have been removed.