### PR TITLE
Fix duplicate icons and incorrect capitalisations in GNOME, and disabled startup feedback

### DIFF
--- a/application/palemoon/branding/official/palemoon.desktop
+++ b/application/palemoon/branding/official/palemoon.desktop
@@ -87,8 +87,9 @@ Type=Application
 Icon=palemoon
 Categories=Network;WebBrowser;
 MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;
-StartupNotify=true
+StartupNotify=false
 Actions=NewTab;NewWindow;NewPrivateWindow;
+StartupWMClass="pale moon"
 
 [Desktop Action NewTab]
 Name=Open new tab

--- a/application/palemoon/branding/unofficial/newmoon.desktop
+++ b/application/palemoon/branding/unofficial/newmoon.desktop
@@ -87,8 +87,9 @@ Type=Application
 Icon=palemoon
 Categories=Network;WebBrowser;
 MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;
-StartupNotify=true
+StartupNotify=false
 Actions=NewTab;NewWindow;NewPrivateWindow;
+StartupWMClass="new moon"
 
 [Desktop Action NewTab]
 Name=Open new tab


### PR DESCRIPTION
Fix is based on [this tutorial](https://www.youtube.com/watch?v=xZ_M3Q-U-J0).

More info in issue #1148 .