### PR TITLE
 Avoid multiple hashtable lookups in DisplayItemData destructor

### DIFF
--- a/layout/base/FrameLayerBuilder.cpp
+++ b/layout/base/FrameLayerBuilder.cpp
@@ -272,8 +272,13 @@ FrameLayerBuilder::DisplayItemData::~DisplayItemData()
     array->RemoveElement(this);
   }
 
-  MOZ_RELEASE_ASSERT(sAliveDisplayItemDatas && sAliveDisplayItemDatas->Contains(this));
-  sAliveDisplayItemDatas->RemoveEntry(this);
+  MOZ_RELEASE_ASSERT(sAliveDisplayItemDatas);
+  nsPtrHashKey<mozilla::FrameLayerBuilder::DisplayItemData>* entry
+    = sAliveDisplayItemDatas->GetEntry(this);
+  MOZ_RELEASE_ASSERT(entry);
+
+  sAliveDisplayItemDatas->RemoveEntry(entry);
+
   if (sAliveDisplayItemDatas->Count() == 0) {
     delete sAliveDisplayItemDatas;
     sAliveDisplayItemDatas = nullptr;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1367219

UXP currently has:

MOZ_RELEASE_ASSERT(sAliveDisplayItemDatas && sAliveDisplayItemDatas >Contains(this));
sAliveDisplayItemDatas->RemoveEntry(this);

and this gets hit during frame destruction.

This pull request combines these checks and avoids multiple hashtable lookups in DisplayItemData destructor

This should improve performance little by combining checks/avoiding lookups.

Resolves #1166