### PR TITLE
Fix comments for FrameProperties (no code changes)

### DIFF
--- a/layout/base/FrameProperties.h
+++ b/layout/base/FrameProperties.h
@@ -62,7 +62,7 @@ protected:
  *
  * To use this class, declare a global (i.e., file, class or function-scope
  * static member) FramePropertyDescriptor and pass its address as
- * aProperty in the FramePropertyTable methods.
+ * aProperty in the FrameProperties methods.
  */
 template<typename T>
 struct FramePropertyDescriptor : public FramePropertyDescriptorUntyped

--- a/layout/generic/nsIFrame.h
+++ b/layout/generic/nsIFrame.h
@@ -997,7 +997,7 @@ public:
 #define NS_DECLARE_FRAME_PROPERTY_WITH_DTOR_NEVER_CALLED(prop, type)  \
   static void AssertOnDestroyingProperty##prop(type*) {               \
     MOZ_ASSERT_UNREACHABLE("Frame property " #prop " should never "   \
-                           "be destroyed by the FramePropertyTable"); \
+                           "be destroyed by the FrameProperties class"); \
   }                                                                   \
   NS_DECLARE_FRAME_PROPERTY_WITH_DTOR(prop, type,                     \
                                       AssertOnDestroyingProperty##prop)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1373884

Fixes comments for FrameProperties.

These comments went unnoticed earlier and this pull request updates them to mention FrameProperties instead of FramePropertyTable.

No code changes.