### PR TITLE
Dispatch a PluginRemoved event for actual plugins, not images/unknown/iframe-type <objects>

### DIFF
--- a/dom/base/nsObjectLoadingContent.cpp
+++ b/dom/base/nsObjectLoadingContent.cpp
@@ -715,11 +715,13 @@ nsObjectLoadingContent::UnbindFromTree(bool aDeep, bool aNullParent)
     ///             would keep the docshell around, but trash the frameloader
     UnloadObject();
   }
-  nsIDocument* doc = thisContent->GetComposedDoc();
-  if (doc && doc->IsActive()) {
+  if (mType == eType_Plugin) {
+    nsIDocument* doc = thisContent->GetComposedDoc();
+    if (doc && doc->IsActive()) {
     nsCOMPtr<nsIRunnable> ev = new nsSimplePluginEvent(doc,
                                                        NS_LITERAL_STRING("PluginRemoved"));
     NS_DispatchToCurrentThread(ev);
+    }
   }
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1317032

test: http://umlnotation.sparxsystems.eu/#chapter_EE843E93_9D9B_44d5_AD15_6B6F3371710C

This website makes UXP completely unresponsive. Pull request fixes this hang.

If a page uses or removes many <object> elements which are not actually plugins, loading the page goes to a crawl because UXP recalculates the plugin UI every time.

Only dispatch a PluginRemoved event for actual plugins.

Resolves #1179