### PR TITLE
[BASILISK] A prompt should be shown for new foreign add-ons on startup

### DIFF
--- a/application/basilisk/components/nsBrowserGlue.js
+++ b/application/basilisk/components/nsBrowserGlue.js
@@ -1074,7 +1074,7 @@ BrowserGlue.prototype = {
     // them to the user.
     let changedIDs = AddonManager.getStartupChanges(AddonManager.STARTUP_CHANGE_INSTALLED);
     if (changedIDs.length > 0) {
-      let win = this.getMostRecentBrowserWindow();
+      let win = RecentWindow.getMostRecentBrowserWindow();
       AddonManager.getAddonsByIDs(changedIDs, function(aAddons) {
         aAddons.forEach(function(aAddon) {
           // If the add-on isn't user disabled or can't be enabled then skip it.


### PR DESCRIPTION
- Follow up to: 2cbbc5de4596ef3436685fa3316eeed9af700249 and #937
- An error is thrown in the console at startup if you install an add-on by placing its XPI file in the extensions directory of the profile folder:
`TypeError: this.getMostRecentBrowserWindow is not a function.  
nsBrowserGlue.js:1077:17`
- Should be `RecentWindow.getMostRecentBrowserWindow()` instead of `this.getMostRecentBrowserWindow()`.
