### PR TITLE
Issue #1195 - Fix errant use of JSContext in ErrorNotes

### DIFF
--- a/js/src/jsapi.cpp
+++ b/js/src/jsapi.cpp
@@ -6326,7 +6326,7 @@ JSErrorNotes::~JSErrorNotes()
 }
 
 static UniquePtr<JSErrorNotes::Note>
-CreateErrorNoteVA(JSContext* cx,
+CreateErrorNoteVA(ExclusiveContext* cx,
                   const char* filename, unsigned lineno, unsigned column,
                   JSErrorCallback errorCallback, void* userRef,
                   const unsigned errorNumber,
@@ -6357,7 +6357,7 @@ JSErrorNotes::addNoteASCII(ExclusiveContext* cx,
 {
     va_list ap;
     va_start(ap, errorNumber);
-    auto note = CreateErrorNoteVA(cx->asJSContext(), filename, lineno, column, errorCallback, userRef,
+    auto note = CreateErrorNoteVA(cx, filename, lineno, column, errorCallback, userRef,
                                   errorNumber, ArgumentsAreASCII, ap);
     va_end(ap);
 
@@ -6376,7 +6376,7 @@ JSErrorNotes::addNoteLatin1(ExclusiveContext* cx,
 {
     va_list ap;
     va_start(ap, errorNumber);
-    auto note = CreateErrorNoteVA(cx->asJSContext(), filename, lineno, column, errorCallback, userRef,
+    auto note = CreateErrorNoteVA(cx, filename, lineno, column, errorCallback, userRef,
                                   errorNumber, ArgumentsAreLatin1, ap);
     va_end(ap);
 
@@ -6395,7 +6395,7 @@ JSErrorNotes::addNoteUTF8(ExclusiveContext* cx,
 {
     va_list ap;
     va_start(ap, errorNumber);
-    auto note = CreateErrorNoteVA(cx->asJSContext(), filename, lineno, column, errorCallback, userRef,
+    auto note = CreateErrorNoteVA(cx, filename, lineno, column, errorCallback, userRef,
                                   errorNumber, ArgumentsAreUTF8, ap);
     va_end(ap);
 

--- a/js/src/jscntxt.cpp
+++ b/js/src/jscntxt.cpp
@@ -748,7 +748,7 @@ js::ExpandErrorArgumentsVA(ExclusiveContext* cx, JSErrorCallback callback,
 }
 
 bool
-js::ExpandErrorArgumentsVA(JSContext* cx, JSErrorCallback callback,
+js::ExpandErrorArgumentsVA(ExclusiveContext* cx, JSErrorCallback callback,
                            void* userRef, const unsigned errorNumber,
                            const char16_t** messageArgs,
                            ErrorArgumentsType argumentsType,

--- a/js/src/jscntxt.h
+++ b/js/src/jscntxt.h
@@ -622,7 +622,7 @@ ExpandErrorArgumentsVA(ExclusiveContext* cx, JSErrorCallback callback,
                        JSErrorReport* reportp, va_list ap);
 
 extern bool
-ExpandErrorArgumentsVA(JSContext* cx, JSErrorCallback callback,
+ExpandErrorArgumentsVA(ExclusiveContext* cx, JSErrorCallback callback,
                        void* userRef, const unsigned errorNumber,
                        const char16_t** messageArgs,
                        ErrorArgumentsType argumentsType,


### PR DESCRIPTION
We want to ensure that ErrorNotes stays on the main thread to prevent a race condition that was introduced in 1283712 - Part 1. This fixes #1195.