### PR TITLE
Fix call to macro `MOZ_ASSERT_UNREACHABLE`

### DIFF
--- a/gfx/gl/GLUploadHelpers.cpp
+++ b/gfx/gl/GLUploadHelpers.cpp
@@ -495,7 +495,7 @@ UploadImageDataToTexture(GLContext* gl,
             surfaceFormat = SurfaceFormat::A8;
             break;
         default:
-            MOZ_ASSERT_UNREACHABLE(false, "Unhandled image surface format!");
+            MOZ_ASSERT_UNREACHABLE("Unhandled image surface format!");
     }
 
     if (aOutUploadSize) {


### PR DESCRIPTION
Fallout from 227b23606b0401245c9f0b15effd45b876b90260