### PR TITLE
Add space to MOZ_APP_DISPLAYNAME

### DIFF
--- a/application/palemoon/branding/official/configure.sh
+++ b/application/palemoon/branding/official/configure.sh
@@ -2,5 +2,5 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-MOZ_APP_DISPLAYNAME=PaleMoon
+MOZ_APP_DISPLAYNAME="Pale Moon"
 # MOZ_UA_BUILDID=20100101

--- a/application/palemoon/branding/unofficial/configure.sh
+++ b/application/palemoon/branding/unofficial/configure.sh
@@ -2,4 +2,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-MOZ_APP_DISPLAYNAME=NewMoon
+MOZ_APP_DISPLAYNAME="New Moon"

--- a/application/palemoon/branding/unstable/configure.sh
+++ b/application/palemoon/branding/unstable/configure.sh
@@ -2,5 +2,5 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-MOZ_APP_DISPLAYNAME=Palemoon
+MOZ_APP_DISPLAYNAME="Pale Moon"
 # MOZ_UA_BUILDID=20100101


### PR DESCRIPTION
This will need to be tested on Windows and Linux, but it corrects the menu bar title on MacOS. Before it would display NewMoon or PaleMoon, now it looks proper. No issues building or packaging from UXP Master with this change.

![Space PM](https://user-images.githubusercontent.com/39230578/61684001-6d1edd80-acdd-11e9-9103-65fbed9111bb.png)
