### PR TITLE
Issue #1156 - Location Bar Preferences Checkboxes

### DIFF
--- a/application/palemoon/components/preferences/privacy.js
+++ b/application/palemoon/components/preferences/privacy.js
@@ -298,36 +298,6 @@ var gPrivacyPane = {
 
   // HISTORY
 
-  /**
-   * Read the location bar enabled and suggestion prefs
-   * @return Int value for suggestion menulist
-   */
-  readSuggestionPref: function PPP_readSuggestionPref()
-  {
-    let getVal = function(aPref)
-      document.getElementById("browser.urlbar." + aPref).value;
-
-    // Suggest nothing if autocomplete is not enabled
-    if (!getVal("autocomplete.enabled"))
-      return -1;
-
-    // Bottom 2 bits of default.behavior specify history/bookmark
-    return getVal("default.behavior") & 3;
-  },
-
-  /**
-   * Update browser.urlbar.autocomplete.enabled when a
-   * browser.urlbar.suggest.* pref is changed from the ui.
-   */
-  writeSuggestionPref: function PPP_writeSuggestionPref() {
-    let getVal = (aPref) => {
-      return document.getElementById("browser.urlbar.suggest." + aPref).value;
-    }
-    // autocomplete.enabled is true if any of the suggestions is true
-    let enabled = ["history", "bookmark", "openpage"].map(getVal).some(v => v);
-    Services.prefs.setBoolPref("browser.urlbar.autocomplete.enabled", enabled);
-  },
-
   /*
    * Preferences:
    *

--- a/application/palemoon/components/preferences/privacy.xul
+++ b/application/palemoon/components/preferences/privacy.xul
@@ -254,15 +254,12 @@
 
           <vbox id="tabPrefsBox" align="start" flex="1">
             <checkbox id="historySuggestion" label="&locbar.history.label;"
-                      onsyncfrompreference="return gPrivacyPane.writeSuggestionPref();"
                       accesskey="&locbar.history.accesskey;"
                       preference="browser.urlbar.suggest.history"/>
             <checkbox id="bookmarkSuggestion" label="&locbar.bookmarks.label;"
-                      onsyncfrompreference="return gPrivacyPane.writeSuggestionPref();"
                       accesskey="&locbar.bookmarks.accesskey;"
                       preference="browser.urlbar.suggest.bookmark"/>
             <checkbox id="openpageSuggestion" label="&locbar.openpage.label;"
-                      onsyncfrompreference="return gPrivacyPane.writeSuggestionPref();"
                       accesskey="&locbar.openpage.accesskey;"
                       preference="browser.urlbar.suggest.openpage"/>
           </vbox>


### PR DESCRIPTION
Removes some unnecessary preference synchronizing functions from the privacy preferences pane.
The browser.url.autocomplete.enabled and browser.url.suggest.* preferences are already synced elsewhere.
This stops the pane from unnecessarily toggling browser.url.autocomplete.enabled and enabling all other browser.url.suggest.* preferences.
Fixes Issue #1156