### PR TITLE
Adjust Widewine strings after removing Adobe Primetime support

### DIFF
--- a/dom/locales/en-US/chrome/plugins.properties
+++ b/dom/locales/en-US/chrome/plugins.properties
@@ -28,6 +28,5 @@ gmp_privacy_info=Privacy Information
 openH264_name=OpenH264 Video Codec provided by Cisco Systems, Inc.
 openH264_description2=This plugin is automatically installed by Mozilla to comply with the WebRTC specification and to enable WebRTC calls with devices that require the H.264 video codec. Visit http://www.openh264.org/ to view the codec source code and learn more about the implementation.
 
-eme-adobe_description=Play back protected web video.
-
-widevine_description=Widevine Content Decryption Module provided by Google Inc.
+widevine_name=Widevine Content Decryption Module provided by Google Inc.
+widevine_description2=Play back protected web video.

--- a/toolkit/mozapps/extensions/internal/GMPProvider.jsm
+++ b/toolkit/mozapps/extensions/internal/GMPProvider.jsm
@@ -51,9 +51,9 @@ const GMP_PLUGINS = [
   },
   {
     id:              WIDEVINE_ID,
-    name:            "widevine_description",
+    name:            "widevine_name",
     // Describe the purpose of both CDMs in the same way.
-    description:     "eme-adobe_description",
+    description:     "widevine_description2",
     licenseURL:      "https://www.google.com/policies/privacy/",
     homepageURL:     "https://www.widevine.com/",
     optionsURL:      "chrome://mozapps/content/extensions/gmpPrefs.xul",


### PR DESCRIPTION
Just what it says on the tin.

Tag #1259.