### PR TITLE
Use NS_DECL_THREADSAFE_ISUPPORTS in HttpBaseChannel.cpp

### DIFF
--- a/netwerk/protocol/http/HttpBaseChannel.cpp
+++ b/netwerk/protocol/http/HttpBaseChannel.cpp
@@ -897,7 +897,7 @@ public:
   InterceptFailedOnStop(nsIStreamListener *arg, HttpBaseChannel *chan)
   : mNext(arg)
   , mChannel(chan) {}
-  NS_DECL_ISUPPORTS
+  NS_DECL_THREADSAFE_ISUPPORTS
 
   NS_IMETHOD OnStartRequest(nsIRequest *aRequest, nsISupports *aContext) override
   {


### PR DESCRIPTION
Fixes a regression in #1288 Part 1b which caused HTML5 parser to fall off the main thread.