### PR TITLE
Fix a typo in sys_info_posix.cc

### DIFF
--- a/ipc/chromium/src/base/sys_info_posix.cc
+++ b/ipc/chromium/src/base/sys_info_posix.cc
@@ -121,7 +121,7 @@ std::wstring SysInfo::GetEnvVar(const wchar_t* var) {
 
 // static
 std::string SysInfo::OperatingSystemName() {
-#ifndef XP_SOLARIS)	
+#ifndef XP_SOLARIS	
   utsname info;
 #else
   struct utsname info;


### PR DESCRIPTION
Tag #457.

I made a mistake when adapting the ifdef style to UXP standards in commit 687a798e6dedacb8b42826debcd8e89baa69ce94.  The compiler didn't care enough to error out, but apparently it did trigger a warning I failed to notice.