### PR TITLE
Remove obsolete XP_QSORT reference and fix typo.

### DIFF
--- a/ipc/chromium/src/base/sys_info_posix.cc
+++ b/ipc/chromium/src/base/sys_info_posix.cc
@@ -121,7 +121,7 @@ std::wstring SysInfo::GetEnvVar(const wchar_t* var) {
 
 // static
 std::string SysInfo::OperatingSystemName() {
-#ifndef XP_SOLARIS)	
+#ifndef XP_SOLARIS
   utsname info;
 #else
   struct utsname info;
@@ -139,11 +139,11 @@ std::string SysInfo::OperatingSystemName() {
 
 // static
 std::string SysInfo::CPUArchitecture() {
-#ifndef XP_SOLARIS	
+#ifndef XP_SOLARIS
   utsname info;
 #else
   struct utsname info;
-#endif  
+#endif
   if (uname(&info) < 0) {
     NOTREACHED();
     return "";

--- a/ldap/c-sdk/libldap/sort.c
+++ b/ldap/c-sdk/libldap/sort.c
@@ -51,19 +51,6 @@
 
 #include "ldap-int.h"
 
-/* This xp_qsort fixes a memory problem (ABR) on Solaris for the client.
- * Server is welcome to use it too, but I wasn't sure if it
- * would be ok to use XP code here.  -slamm
- *
- * We don't want to require use of libxp when linking with libldap, so
- * I'll leave use of xp_qsort as a MOZILLA_CLIENT-only thing for now. --mcs
- */
-#if defined(MOZILLA_CLIENT) && defined(SOLARIS)
-#include "xp_qsort.h"
-#else
-#define XP_QSORT qsort
-#endif
-
 typedef struct keycmp {
     void                 *kc_arg;
     LDAP_KEYCMP_CALLBACK *kc_cmp;
@@ -142,7 +129,7 @@ ldap_keysort_entries(
 	}
 	last = e;
 
-	XP_QSORT( (void*)kt, count, (size_t)sizeof(keything_t*), ldapi_keycmp );
+	qsort( (void*)kt, count, (size_t)sizeof(keything_t*), ldapi_keycmp );
     
 	ep = chain;
 	for ( i = 0; i < count; i++ ) {
@@ -295,7 +282,7 @@ ldap_multisort_entries(
 	last = e;
 
 	et_cmp_fn = (LDAP_CHARCMP_CALLBACK *)cmp;
-	XP_QSORT( (void *) et, (size_t) count,
+	qsort( (void *) et, (size_t) count,
 		(size_t) sizeof(struct entrything), et_cmp );
 
 	ep = chain;
@@ -349,7 +336,7 @@ ldap_sort_values(
 	for ( nel = 0; vals[nel] != NULL; nel++ )
 		;	/* NULL */
 
-	XP_QSORT( vals, nel, sizeof(char *), (LDAP_VOIDCMP_CALLBACK *)cmp );
+	qsort( vals, nel, sizeof(char *), (LDAP_VOIDCMP_CALLBACK *)cmp );
 
 	return( LDAP_SUCCESS );
 }


### PR DESCRIPTION
I didn't include this in my initial PR because I assumed this part
was not relevant to UXP. I was asked to submit this while the MailNews rebase
was going on, but I was late with my patch and didn't quite grasp that this
specifically was still needed.

My counterpart at Mozilla, Petr Sumbara, has gotten his version of this
approved.

https://bugzilla.mozilla.org/show_bug.cgi?id=1568473

Also, I made a mistake that caused a compiler warning when adapting the ifdef 
style to UXP standards in commit 687a798. Removed some trailing whitespace as well.