### PR TITLE
Update js/src/builtin/TestingFunctions.cpp for /s (dotAll) regular expression changes

### DIFF
--- a/js/src/builtin/TestingFunctions.cpp
+++ b/js/src/builtin/TestingFunctions.cpp
@@ -3975,6 +3975,7 @@ ParseRegExp(JSContext* cx, unsigned argc, Value* vp)
                                 flags & MultilineFlag, match_only,
                                 flags & UnicodeFlag, flags & IgnoreCaseFlag,
                                 flags & GlobalFlag, flags & StickyFlag,
+                                flags & DotAllFlag,
                                 &data))
     {
         return false;


### PR DESCRIPTION
Tag #1284. This fixes debug builds. 