### PR TITLE
Issue #1258 - Remove remaining chat core bits

### DIFF
--- a/mailnews/base/src/nsMessengerOSXIntegration.mm
+++ b/mailnews/base/src/nsMessengerOSXIntegration.mm
@@ -249,14 +249,6 @@ nsMessengerOSXIntegration::Observe(nsISupports* aSubject, const char* aTopic, co
     return mailSession->AddFolderListener(this, nsIFolderListener::boolPropertyChanged | nsIFolderListener::intPropertyChanged);
   }
 
-  if (!strcmp(aTopic, kUnreadImCountChangedTopic)) {
-    nsresult rv;
-    nsCOMPtr<nsISupportsPRInt32> unreadCount = do_QueryInterface(aSubject, &rv);
-    NS_ENSURE_SUCCESS(rv, rv);
-
-    return BadgeDockIcon();
-  }
-
   return NS_OK;
 }
 


### PR DESCRIPTION
This fixes Interlink build on Mac.