### PR TITLE
Issue #1345 - Implement non-standard legacy CSSStyleSheet rules

### DIFF
--- a/dom/webidl/CSSStyleSheet.webidl
+++ b/dom/webidl/CSSStyleSheet.webidl
@@ -26,4 +26,12 @@ interface CSSStyleSheet : StyleSheet {
   unsigned long insertRule(DOMString rule, optional unsigned long index = 0);
   [Throws, NeedsSubjectPrincipal]
   void deleteRule(unsigned long index);
+
+  // Non-standard WebKit things, see https://github.com/w3c/csswg-drafts/pull/3900.
+  [Throws, NeedsSubjectPrincipal, BinaryName="cssRules"]
+  readonly attribute CSSRuleList rules;
+  [Throws, NeedsSubjectPrincipal, BinaryName="deleteRule"]
+  void removeRule(optional unsigned long index = 0);
+  [Throws, NeedsSubjectPrincipal]
+  long addRule(optional DOMString selector = "undefined", optional DOMString style = "undefined", optional unsigned long index);
 };

--- a/layout/style/StyleSheet.cpp
+++ b/layout/style/StyleSheet.cpp
@@ -259,6 +259,32 @@ StyleSheet::DeleteRule(uint32_t aIndex,
   FORWARD_INTERNAL(DeleteRuleInternal, (aIndex, aRv))
 }
 
+int32_t
+StyleSheet::AddRule(const nsAString& aSelector, const nsAString& aBlock,
+                    const Optional<uint32_t>& aIndex,
+                    nsIPrincipal& aSubjectPrincipal, ErrorResult& aRv)
+{
+  if (!AreRulesAvailable(aSubjectPrincipal, aRv)) {
+    return -1;
+  }
+
+  nsAutoString rule;
+  rule.Append(aSelector);
+  rule.AppendLiteral(" { ");
+  if (!aBlock.IsEmpty()) {
+    rule.Append(aBlock);
+    rule.Append(' ');
+  }
+  rule.Append('}');
+
+  auto index =
+      aIndex.WasPassed() ? aIndex.Value() : GetCssRules(aSubjectPrincipal, aRv)->Length();
+
+  FORWARD_INTERNAL(InsertRuleInternal, (rule, index, aRv));
+  // As per Microsoft documentation, always return -1.
+  return -1;
+}
+
 #undef FORWARD_INTERNAL
 
 void

--- a/layout/style/StyleSheet.h
+++ b/layout/style/StyleSheet.h
@@ -143,6 +143,9 @@ public:
   void DeleteRule(uint32_t aIndex,
                   nsIPrincipal& aSubjectPrincipal,
                   ErrorResult& aRv);
+  int32_t AddRule(const nsAString& aSelector, const nsAString& aBlock,
+                  const dom::Optional<uint32_t>& aIndex,
+                  nsIPrincipal& aSubjectPrincipal, ErrorResult& aRv);
 
   // WebIDL miscellaneous bits
   inline dom::ParentObject GetParentObject() const;


### PR DESCRIPTION
Implement non-standard `CSSStyleSheet.rules`, `CSSStyleSheet.addRule` and `CSSStyleSheet.removeRule`.

Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1545823, resolves #1345.