### PR TITLE
Add dirty rect intersection checks so that we don't build unnecessary table part display items

### DIFF
--- a/layout/tables/nsTableFrame.cpp
+++ b/layout/tables/nsTableFrame.cpp
@@ -1192,6 +1192,7 @@ PaintRowBackground(nsTableRowFrame* aRow,
                    nsIFrame* aFrame,
                    nsDisplayListBuilder* aBuilder,
                    const nsDisplayListSet& aLists,
+                   const nsRect& aDirtyRect,
                    const nsPoint& aOffset = nsPoint())
 {
   // Compute background rect by iterating over all cell frames.
@@ -1201,6 +1202,9 @@ PaintRowBackground(nsTableRowFrame* aRow,
     }
 
     auto cellRect = cell->GetRectRelativeToSelf() + cell->GetNormalPosition() + aOffset;
+    if (!aDirtyRect.Intersects(cellRect)) {
+      continue;
+    }
     nsDisplayBackgroundImage::AppendBackgroundItemsToTop(aBuilder, aFrame, cellRect,
                                                          aLists.BorderBackground(),
                                                          true, nullptr,
@@ -1213,10 +1217,14 @@ static void
 PaintRowGroupBackground(nsTableRowGroupFrame* aRowGroup,
                         nsIFrame* aFrame,
                         nsDisplayListBuilder* aBuilder,
-                        const nsDisplayListSet& aLists)
+                        const nsDisplayListSet& aLists,
+                        const nsRect& aDirtyRect)
 {
   for (nsTableRowFrame* row = aRowGroup->GetFirstRow(); row; row = row->GetNextRow()) {
-    PaintRowBackground(row, aFrame, aBuilder, aLists, row->GetNormalPosition());
+     if (!aDirtyRect.Intersects(nsRect(row->GetNormalPosition(), row->GetSize()))) {
+       continue;
+     }
+    PaintRowBackground(row, aFrame, aBuilder, aLists, aDirtyRect, row->GetNormalPosition());
   }
 }
 
@@ -1229,6 +1237,10 @@ PaintRowGroupBackgroundByColIdx(nsTableRowGroupFrame* aRowGroup,
                                 const nsPoint& aOffset)
 {
   for (nsTableRowFrame* row = aRowGroup->GetFirstRow(); row; row = row->GetNextRow()) {
+    auto rowPos = row->GetNormalPosition() + aOffset;
+    if (!aDirtyRect.Intersects(nsRect(rowPos, row->GetSize()))) {
+      continue;
+    }
     for (nsTableCellFrame* cell = row->GetFirstCell(); cell; cell = cell->GetNextCell()) {
       if (!cell->ShouldPaintBackground(aBuilder)) {
         continue;
@@ -1237,7 +1249,11 @@ PaintRowGroupBackgroundByColIdx(nsTableRowGroupFrame* aRowGroup,
       int32_t curColIdx;
       cell->GetColIndex(curColIdx);
       if (aColIdx.Contains(curColIdx)) {
-        auto cellRect = cell->GetRectRelativeToSelf() + cell->GetNormalPosition() + row->GetNormalPosition() + aOffset;
+        auto cellPos = cell->GetNormalPosition() + rowPos;
+        auto cellRect = nsRect(cellPos, cell->GetSize());
+        if (!aDirtyRect.Intersects(cellRect)) {
+          continue;
+        }
         nsDisplayBackgroundImage::AppendBackgroundItemsToTop(aBuilder, aFrame, cellRect,
                                                              aLists.BorderBackground(),
                                                              true, nullptr,
@@ -1284,10 +1300,10 @@ nsTableFrame::DisplayGenericTablePart(nsDisplayListBuilder* aBuilder,
   // See spec at https://drafts.csswg.org/css-tables-3/#drawing-cell-backgrounds
   if (aFrame->GetType() == nsGkAtoms::tableRowGroupFrame) {
     nsTableRowGroupFrame* rowGroup = static_cast<nsTableRowGroupFrame*>(aFrame);
-    PaintRowGroupBackground(rowGroup, aFrame, aBuilder, aLists);
+    PaintRowGroupBackground(rowGroup, aFrame, aBuilder, aLists, aDirtyRect);
   } else if (aFrame->GetType() == nsGkAtoms::tableRowFrame) {
     nsTableRowFrame* row = static_cast<nsTableRowFrame*>(aFrame);
-    PaintRowBackground(row, aFrame, aBuilder, aLists);
+    PaintRowBackground(row, aFrame, aBuilder, aLists, aDirtyRect);
   } else if (aFrame->GetType() == nsGkAtoms::tableColGroupFrame) {
     // Compute background rect by iterating all cell frame.
     nsTableColGroupFrame* colGroup = static_cast<nsTableColGroupFrame*>(aFrame);
@@ -1302,7 +1318,10 @@ nsTableFrame::DisplayGenericTablePart(nsDisplayListBuilder* aBuilder,
     table->OrderRowGroups(rowGroups);
     for (nsTableRowGroupFrame* rowGroup : rowGroups) {
       auto offset = rowGroup->GetNormalPosition() - colGroup->GetNormalPosition();
-      PaintRowGroupBackgroundByColIdx(rowGroup, aFrame, aBuilder, aLists, colIdx, offset);
+      if (!aDirtyRect.Intersects(nsRect(offset, rowGroup->GetSize()))) {
+        continue;
+      }
+      PaintRowGroupBackgroundByColIdx(rowGroup, aFrame, aBuilder, aLists, aDirtyRect, colIdx, offset);
     }
   } else if (aFrame->GetType() == nsGkAtoms::tableColFrame) {
     // Compute background rect by iterating all cell frame.
@@ -1317,7 +1336,10 @@ nsTableFrame::DisplayGenericTablePart(nsDisplayListBuilder* aBuilder,
       auto offset = rowGroup->GetNormalPosition() -
                     col->GetNormalPosition() -
                     col->GetTableColGroupFrame()->GetNormalPosition();
-      PaintRowGroupBackgroundByColIdx(rowGroup, aFrame, aBuilder, aLists, colIdx, offset);
+      if (!aDirtyRect.Intersects(nsRect(offset, rowGroup->GetSize()))) {
+        continue;
+      }
+      PaintRowGroupBackgroundByColIdx(rowGroup, aFrame, aBuilder, aLists, aDirtyRect, colIdx, offset);
     }
   } else if (isVisible) {
     nsDisplayBackgroundImage::AppendBackgroundItemsToTop(aBuilder, aFrame,


### PR DESCRIPTION
Second optimization done to #1355.

Hit testing in large tables has become extremely slow. This PR will fix that.

This is based on https://bugzilla.mozilla.org/show_bug.cgi?id=1369141

This is a regression from Issue #146

Steps to reproduce:

   1.  Go to https://hg.mozilla.org/releases/mozilla-beta/annotate/cf76e00dcd6f/layout/painting/FrameLayerBuilder.cpp and wait for it to load.
  2.  Move your mouse around over the code on the page.
  3.  Watch how the row highlight changes.

It's very janky.

This second optimization does not change performance on Maze test but is performance improvement to regression in: https://hg.mozilla.org/releases/mozilla-beta/annotate/cf76e00dcd6f/layout/painting/FrameLayerBuilder.cpp also caused by #146