### PR TITLE
Make building of EME conditional

### DIFF
--- a/dom/media/AbstractMediaDecoder.h
+++ b/dom/media/AbstractMediaDecoder.h
@@ -31,7 +31,9 @@ class MediaResource;
 class ReentrantMonitor;
 class VideoFrameContainer;
 class MediaDecoderOwner;
+#ifdef MOZ_EME
 class CDMProxy;
+#endif
 
 typedef nsDataHashtable<nsCStringHashKey, nsCString> MetadataTags;
 

--- a/dom/media/MediaDecoder.cpp
+++ b/dom/media/MediaDecoder.cpp
@@ -387,7 +387,9 @@ MediaDecoder::MediaDecoder(MediaDecoderOwner* aOwner)
   , mLogicalPosition(0.0)
   , mDuration(std::numeric_limits<double>::quiet_NaN())
   , mResourceCallback(new ResourceCallback())
+#ifdef MOZ_EME
   , mCDMProxyPromise(mCDMProxyPromiseHolder.Ensure(__func__))
+#endif
   , mIgnoreProgressData(false)
   , mInfiniteStream(false)
   , mOwner(aOwner)
@@ -472,7 +474,9 @@ MediaDecoder::Shutdown()
 
   mResourceCallback->Disconnect();
 
+#ifdef MOZ_EME
   mCDMProxyPromiseHolder.RejectIfExists(true, __func__);
+#endif
 
   DiscardOngoingSeekIfExists();
 
@@ -1537,6 +1541,7 @@ MediaDecoder::CanPlayThrough()
   return GetStatistics().CanPlayThrough();
 }
 
+#ifdef MOZ_EME
 RefPtr<MediaDecoder::CDMProxyPromise>
 MediaDecoder::RequestCDMProxy() const
 {
@@ -1551,6 +1556,7 @@ MediaDecoder::SetCDMProxy(CDMProxy* aProxy)
 
   mCDMProxyPromiseHolder.ResolveIfExists(aProxy, __func__);
 }
+#endif
 
 bool
 MediaDecoder::IsOpusEnabled()

--- a/dom/media/MediaDecoder.h
+++ b/dom/media/MediaDecoder.h
@@ -8,7 +8,11 @@
 #define MediaDecoder_h_
 
 #include "mozilla/Atomics.h"
+
+#ifdef MOZ_EME
 #include "mozilla/CDMProxy.h"
+#endif
+
 #include "mozilla/MozPromise.h"
 #include "mozilla/ReentrantMonitor.h"
 #include "mozilla/StateMirroring.h"
@@ -432,6 +436,7 @@ private:
 
   MediaDecoderOwner* GetOwner() const override;
 
+#ifdef MOZ_EME
   typedef MozPromise<RefPtr<CDMProxy>, bool /* aIgnored */, /* IsExclusive = */ true> CDMProxyPromise;
 
   // Resolved when a CDMProxy is available and the capabilities are known or
@@ -439,6 +444,7 @@ private:
   RefPtr<CDMProxyPromise> RequestCDMProxy() const;
 
   void SetCDMProxy(CDMProxy* aProxy);
+#endif
 
   static bool IsOggEnabled();
   static bool IsOpusEnabled();
@@ -589,8 +595,10 @@ private:
 
   RefPtr<ResourceCallback> mResourceCallback;
 
+#ifdef MOZ_EME
   MozPromiseHolder<CDMProxyPromise> mCDMProxyPromiseHolder;
   RefPtr<CDMProxyPromise> mCDMProxyPromise;
+#endif
 
 protected:
   // The promise resolving/rejection is queued as a "micro-task" which will be

--- a/dom/media/MediaDecoderReader.h
+++ b/dom/media/MediaDecoderReader.h
@@ -24,7 +24,9 @@
 
 namespace mozilla {
 
+#ifdef MOZ_EME
 class CDMProxy;
+#endif
 class MediaDecoderReader;
 
 struct WaitForDataRejectValue
@@ -186,7 +188,9 @@ public:
   // when to call SetIdle().
   virtual void SetIdle() {}
 
+#ifdef MOZ_EME
   virtual void SetCDMProxy(CDMProxy* aProxy) {}
+#endif
 
   // Tell the reader that the data decoded are not for direct playback, so it
   // can accept more files, in particular those which have more channels than

--- a/dom/media/MediaDecoderReaderWrapper.h
+++ b/dom/media/MediaDecoderReaderWrapper.h
@@ -113,7 +113,9 @@ public:
     return mReader->CanonicalBuffered();
   }
 
+#ifdef MOZ_EME
   void SetCDMProxy(CDMProxy* aProxy) { mReader->SetCDMProxy(aProxy); }
+#endif
 
   void SetVideoBlankDecode(bool aIsBlankDecode);
 

--- a/dom/media/MediaDecoderStateMachine.h
+++ b/dom/media/MediaDecoderStateMachine.h
@@ -768,10 +768,12 @@ private:
   // Playback will not start when audio is offloading.
   bool mAudioOffloading;
 
+#ifdef MOZ_EME
   void OnCDMProxyReady(RefPtr<CDMProxy> aProxy);
   void OnCDMProxyNotReady();
   RefPtr<CDMProxy> mCDMProxy;
   MozPromiseRequestHolder<MediaDecoder::CDMProxyPromise> mCDMProxyPromise;
+#endif
 
 private:
   // The buffered range. Mirrored from the decoder thread.

--- a/dom/media/MediaFormatReader.cpp
+++ b/dom/media/MediaFormatReader.cpp
@@ -4,7 +4,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#ifdef MOZ_EME
 #include "mozilla/CDMProxy.h"
+#endif
+
 #include "mozilla/ClearOnShutdown.h"
 #include "mozilla/dom/HTMLMediaElement.h"
 #include "mozilla/Preferences.h"
@@ -611,7 +614,6 @@ private:
   nsTArray<uint8_t> mInitData;
   nsString mInitDataType;
 };
-#endif
 
 void
 MediaFormatReader::SetCDMProxy(CDMProxy* aProxy)
@@ -624,6 +626,7 @@ MediaFormatReader::SetCDMProxy(CDMProxy* aProxy)
   });
   OwnerThread()->Dispatch(r.forget());
 }
+#endif // MOZ_EME
 
 bool
 MediaFormatReader::IsWaitingOnCDMResource() {

--- a/dom/media/MediaFormatReader.h
+++ b/dom/media/MediaFormatReader.h
@@ -20,7 +20,9 @@
 
 namespace mozilla {
 
+#ifdef MOZ_EME
 class CDMProxy;
+#endif
 
 class MediaFormatReader final : public MediaDecoderReader
 {
@@ -91,7 +93,9 @@ public:
     return mTrackDemuxersMayBlock;
   }
 
+#ifdef MOZ_EME
   void SetCDMProxy(CDMProxy* aProxy) override;
+#endif
 
   // Returns a string describing the state of the decoder data.
   // Used for debugging purposes.
@@ -584,7 +588,9 @@ private:
   RefPtr<VideoFrameContainer> mVideoFrameContainer;
   layers::ImageContainer* GetImageContainer();
 
+#ifdef MOZ_EME
   RefPtr<CDMProxy> mCDMProxy;
+#endif
 
   RefPtr<GMPCrashHelper> mCrashHelper;
 

--- a/dom/media/fmp4/MP4Decoder.cpp
+++ b/dom/media/fmp4/MP4Decoder.cpp
@@ -10,7 +10,9 @@
 #include "MP4Demuxer.h"
 #include "mozilla/Preferences.h"
 #include "nsCharSeparatedTokenizer.h"
+#ifdef MOZ_EME
 #include "mozilla/CDMProxy.h"
+#endif
 #include "mozilla/Logging.h"
 #include "mozilla/SharedThreadPool.h"
 #include "nsMimeTypes.h"

--- a/dom/media/gmp/GMPChild.cpp
+++ b/dom/media/gmp/GMPChild.cpp
@@ -22,7 +22,9 @@
 #include "GMPUtils.h"
 #include "prio.h"
 #include "base/task.h"
+#ifdef MOZ_EME
 #include "widevine-adapter/WidevineAdapter.h"
+#endif
 
 using namespace mozilla::ipc;
 
@@ -254,9 +256,13 @@ GMPChild::AnswerStartPlugin(const nsString& aAdapter)
     return false;
   }
 
+#ifdef MOZ_EME
   bool isWidevine = aAdapter.EqualsLiteral("widevine");
 
   GMPAdapter* adapter = (isWidevine) ? new WidevineAdapter() : nullptr;
+#else
+  GMPAdapter* adapter = nullptr;
+#endif
   if (!mGMPLoader->Load(libPath.get(),
                         libPath.Length(),
                         mNodeId.BeginWriting(),

--- a/dom/media/gmp/GMPDecryptorParent.cpp
+++ b/dom/media/gmp/GMPDecryptorParent.cpp
@@ -43,11 +43,13 @@ GMPDecryptorParent::~GMPDecryptorParent()
 bool
 GMPDecryptorParent::RecvSetDecryptorId(const uint32_t& aId)
 {
+#ifdef MOZ_EME
   if (!mIsOpen) {
     NS_WARNING("Trying to use a dead GMP decrypter!");
     return false;
   }
   mCallback->SetDecryptorId(aId);
+#endif
   return true;
 }
 
@@ -202,6 +204,7 @@ bool
 GMPDecryptorParent::RecvSetSessionId(const uint32_t& aCreateSessionId,
                                      const nsCString& aSessionId)
 {
+#ifdef MOZ_EME
   LOGD(("GMPDecryptorParent[%p]::RecvSetSessionId(token=%u, sessionId='%s')",
         this, aCreateSessionId, aSessionId.get()));
 
@@ -210,6 +213,7 @@ GMPDecryptorParent::RecvSetSessionId(const uint32_t& aCreateSessionId,
     return false;
   }
   mCallback->SetSessionId(aCreateSessionId, aSessionId);
+#endif
   return true;
 }
 
@@ -217,6 +221,7 @@ bool
 GMPDecryptorParent::RecvResolveLoadSessionPromise(const uint32_t& aPromiseId,
                                                   const bool& aSuccess)
 {
+#ifdef MOZ_EME
   LOGD(("GMPDecryptorParent[%p]::RecvResolveLoadSessionPromise(promiseId=%u)",
         this, aPromiseId));
 
@@ -225,12 +230,14 @@ GMPDecryptorParent::RecvResolveLoadSessionPromise(const uint32_t& aPromiseId,
     return false;
   }
   mCallback->ResolveLoadSessionPromise(aPromiseId, aSuccess);
+#endif
   return true;
 }
 
 bool
 GMPDecryptorParent::RecvResolvePromise(const uint32_t& aPromiseId)
 {
+#ifdef MOZ_EME
   LOGD(("GMPDecryptorParent[%p]::RecvResolvePromise(promiseId=%u)",
         this, aPromiseId));
 
@@ -239,6 +246,7 @@ GMPDecryptorParent::RecvResolvePromise(const uint32_t& aPromiseId)
     return false;
   }
   mCallback->ResolvePromise(aPromiseId);
+#endif
   return true;
 }
 
@@ -266,6 +274,7 @@ GMPDecryptorParent::RecvRejectPromise(const uint32_t& aPromiseId,
                                       const GMPDOMException& aException,
                                       const nsCString& aMessage)
 {
+#ifdef MOZ_EME
   LOGD(("GMPDecryptorParent[%p]::RecvRejectPromise(promiseId=%u, exception=%d, msg='%s')",
         this, aPromiseId, aException, aMessage.get()));
 
@@ -274,10 +283,11 @@ GMPDecryptorParent::RecvRejectPromise(const uint32_t& aPromiseId,
     return false;
   }
   mCallback->RejectPromise(aPromiseId, GMPExToNsresult(aException), aMessage);
+#endif
   return true;
 }
 
-
+#ifdef MOZ_EME
 static dom::MediaKeyMessageType
 ToMediaKeyMessageType(GMPSessionMessageType aMessageType) {
   switch (aMessageType) {
@@ -288,12 +298,14 @@ ToMediaKeyMessageType(GMPSessionMessageType aMessageType) {
     default: return dom::MediaKeyMessageType::License_request;
   };
 };
+#endif
 
 bool
 GMPDecryptorParent::RecvSessionMessage(const nsCString& aSessionId,
                                        const GMPSessionMessageType& aMessageType,
                                        nsTArray<uint8_t>&& aMessage)
 {
+#ifdef MOZ_EME
   LOGD(("GMPDecryptorParent[%p]::RecvSessionMessage(sessionId='%s', type=%d, msg='%s')",
         this, aSessionId.get(), aMessageType, ToBase64(aMessage).get()));
 
@@ -302,6 +314,7 @@ GMPDecryptorParent::RecvSessionMessage(const nsCString& aSessionId,
     return false;
   }
   mCallback->SessionMessage(aSessionId, ToMediaKeyMessageType(aMessageType), aMessage);
+#endif
   return true;
 }
 
@@ -309,6 +322,7 @@ bool
 GMPDecryptorParent::RecvExpirationChange(const nsCString& aSessionId,
                                          const double& aExpiryTime)
 {
+#ifdef MOZ_EME
   LOGD(("GMPDecryptorParent[%p]::RecvExpirationChange(sessionId='%s', expiry=%lf)",
         this, aSessionId.get(), aExpiryTime));
 
@@ -317,12 +331,14 @@ GMPDecryptorParent::RecvExpirationChange(const nsCString& aSessionId,
     return false;
   }
   mCallback->ExpirationChange(aSessionId, aExpiryTime);
+#endif
   return true;
 }
 
 bool
 GMPDecryptorParent::RecvSessionClosed(const nsCString& aSessionId)
 {
+#ifdef MOZ_EME
   LOGD(("GMPDecryptorParent[%p]::RecvSessionClosed(sessionId='%s')",
         this, aSessionId.get()));
 
@@ -331,6 +347,7 @@ GMPDecryptorParent::RecvSessionClosed(const nsCString& aSessionId)
     return false;
   }
   mCallback->SessionClosed(aSessionId);
+#endif
   return true;
 }
 
@@ -340,6 +357,7 @@ GMPDecryptorParent::RecvSessionError(const nsCString& aSessionId,
                                      const uint32_t& aSystemCode,
                                      const nsCString& aMessage)
 {
+#ifdef MOZ_EME
   LOGD(("GMPDecryptorParent[%p]::RecvSessionError(sessionId='%s', exception=%d, sysCode=%d, msg='%s')",
         this, aSessionId.get(),
         aException, aSystemCode, aMessage.get()));
@@ -352,9 +370,11 @@ GMPDecryptorParent::RecvSessionError(const nsCString& aSessionId,
                           GMPExToNsresult(aException),
                           aSystemCode,
                           aMessage);
+#endif
   return true;
 }
 
+#ifdef MOZ_EME
 static dom::MediaKeyStatus
 ToMediaKeyStatus(GMPMediaKeyStatus aStatus) {
   switch (aStatus) {
@@ -368,11 +388,13 @@ ToMediaKeyStatus(GMPMediaKeyStatus aStatus) {
     default: return dom::MediaKeyStatus::Internal_error;
   }
 }
+#endif
 
 bool
 GMPDecryptorParent::RecvBatchedKeyStatusChanged(const nsCString& aSessionId,
                                                 InfallibleTArray<GMPKeyInformation>&& aKeyInfos)
 {
+#ifdef MOZ_EME
   LOGD(("GMPDecryptorParent[%p]::RecvBatchedKeyStatusChanged(sessionId='%s', KeyInfos len='%d')",
         this, aSessionId.get(), aKeyInfos.Length()));
 
@@ -392,9 +414,11 @@ GMPDecryptorParent::RecvBatchedKeyStatusChanged(const nsCString& aSessionId,
     }
     mCallback->BatchedKeyStatusChanged(aSessionId, cdmKeyInfos);
   }
+#endif
   return true;
 }
 
+#ifdef MOZ_EME
 DecryptStatus
 ToDecryptStatus(GMPErr aError)
 {
@@ -405,12 +429,14 @@ ToDecryptStatus(GMPErr aError)
     default: return GenericErr;
   }
 }
+#endif
 
 bool
 GMPDecryptorParent::RecvDecrypted(const uint32_t& aId,
                                   const GMPErr& aErr,
                                   InfallibleTArray<uint8_t>&& aBuffer)
 {
+#ifdef MOZ_EME
   LOGV(("GMPDecryptorParent[%p]::RecvDecrypted(id=%d, err=%d)",
         this, aId, aErr));
 
@@ -419,6 +445,7 @@ GMPDecryptorParent::RecvDecrypted(const uint32_t& aId,
     return false;
   }
   mCallback->Decrypted(aId, ToDecryptStatus(aErr), aBuffer);
+#endif
   return true;
 }
 

--- a/dom/media/gmp/GMPDecryptorProxy.h
+++ b/dom/media/gmp/GMPDecryptorProxy.h
@@ -6,7 +6,9 @@
 #ifndef GMPDecryptorProxy_h_
 #define GMPDecryptorProxy_h_
 
+#ifdef MOZ_EME
 #include "mozilla/DecryptorProxyCallback.h"
+#endif
 #include "GMPCallbackBase.h"
 #include "gmp-decryption.h"
 #include "nsString.h"
@@ -15,8 +17,13 @@ namespace mozilla {
 class CryptoSample;
 } // namespace mozilla
 
+#ifdef MOZ_EME
 class GMPDecryptorProxyCallback : public DecryptorProxyCallback,
                                   public GMPCallbackBase {
+#else
+class GMPDecryptorProxyCallback : public GMPCallbackBase {
+#endif
+
 public:
   virtual ~GMPDecryptorProxyCallback() {}
 };

--- a/dom/media/gmp/GMPParent.cpp
+++ b/dom/media/gmp/GMPParent.cpp
@@ -760,10 +760,10 @@ GMPParent::ReadChromiumManifestFile(nsIFile* aFile)
 RefPtr<GenericPromise>
 GMPParent::ParseChromiumManifest(nsString aJSON)
 {
+#ifdef MOZ_EME
   LOGD("%s: for '%s'", __FUNCTION__, NS_LossyConvertUTF16toASCII(aJSON).get());
 
   MOZ_ASSERT(NS_IsMainThread());
-#ifdef MOZ_EME
   mozilla::dom::WidevineCDMManifest m;
   if (!m.Init(aJSON)) {
     return GenericPromise::CreateAndReject(NS_ERROR_FAILURE, __func__);

--- a/dom/media/gmp/GMPParent.cpp
+++ b/dom/media/gmp/GMPParent.cpp
@@ -30,8 +30,10 @@ using mozilla::ipc::GeckoChildProcessHost;
 #include "WMFDecoderModule.h"
 #endif
 
+#ifdef MOZ_EME
 #include "mozilla/dom/WidevineCDMManifestBinding.h"
 #include "widevine-adapter/WidevineAdapter.h"
+#endif
 
 namespace mozilla {
 
@@ -654,6 +656,7 @@ GMPParent::ReadGMPMetaData()
     return ReadGMPInfoFile(infoFile);
   }
 
+#ifdef MOZ_EME
   // Maybe this is the Widevine adapted plugin?
   nsCOMPtr<nsIFile> manifestFile;
   rv = mDirectory->Clone(getter_AddRefs(manifestFile));
@@ -662,6 +665,9 @@ GMPParent::ReadGMPMetaData()
   }
   manifestFile->AppendRelativePath(NS_LITERAL_STRING("manifest.json"));
   return ReadChromiumManifestFile(manifestFile);
+#else
+  return GenericPromise::CreateAndReject(NS_ERROR_FAILURE, __func__);
+#endif
 }
 
 RefPtr<GenericPromise>
@@ -757,6 +763,7 @@ GMPParent::ParseChromiumManifest(nsString aJSON)
   LOGD("%s: for '%s'", __FUNCTION__, NS_LossyConvertUTF16toASCII(aJSON).get());
 
   MOZ_ASSERT(NS_IsMainThread());
+#ifdef MOZ_EME
   mozilla::dom::WidevineCDMManifest m;
   if (!m.Init(aJSON)) {
     return GenericPromise::CreateAndReject(NS_ERROR_FAILURE, __func__);
@@ -791,6 +798,10 @@ GMPParent::ParseChromiumManifest(nsString aJSON)
 #endif
 
   return GenericPromise::CreateAndResolve(true, __func__);
+#else  // !MOZ_EME
+  MOZ_ASSERT_UNREACHABLE("don't call me if EME isn't enabled");
+  return GenericPromise::CreateAndReject(NS_ERROR_FAILURE, __func__);
+#endif // !MOZ_EME
 }
 
 bool

--- a/dom/media/gmp/moz.build
+++ b/dom/media/gmp/moz.build
@@ -35,8 +35,6 @@ EXPORTS += [
     'GMPAudioDecoderProxy.h',
     'GMPAudioHost.h',
     'GMPCallbackBase.h',
-    'GMPCDMCallbackProxy.h',
-    'GMPCDMProxy.h',
     'GMPChild.h',
     'GMPContentChild.h',
     'GMPContentParent.h',
@@ -73,6 +71,12 @@ EXPORTS += [
     'GMPVideoPlaneImpl.h',
 ]
 
+if CONFIG['MOZ_EME']:
+    EXPORTS += [
+        'GMPCDMCallbackProxy.h',
+        'GMPCDMProxy.h',
+    ]
+
 # We link GMPLoader into xul on B2G/Fennec as its code does not need to be
 # covered by a DRM vendor's voucher.
 if CONFIG['OS_TARGET'] == 'Android':
@@ -87,8 +91,6 @@ UNIFIED_SOURCES += [
     'GMPAudioDecoderChild.cpp',
     'GMPAudioDecoderParent.cpp',
     'GMPAudioHost.cpp',
-    'GMPCDMCallbackProxy.cpp',
-    'GMPCDMProxy.cpp',
     'GMPChild.cpp',
     'GMPContentChild.cpp',
     'GMPContentParent.cpp',
@@ -119,6 +121,12 @@ UNIFIED_SOURCES += [
     'GMPVideoi420FrameImpl.cpp',
     'GMPVideoPlaneImpl.cpp',
 ]
+
+if CONFIG['MOZ_EME']:
+    UNIFIED_SOURCES += [
+        'GMPCDMCallbackProxy.cpp',
+        'GMPCDMProxy.cpp',
+    ]
 
 DIRS += [
     'rlz',

--- a/dom/media/gmp/moz.build
+++ b/dom/media/gmp/moz.build
@@ -128,10 +128,10 @@ if CONFIG['MOZ_EME']:
         'GMPCDMProxy.cpp',
     ]
 
-DIRS += [
-    'rlz',
-    'widevine-adapter',
-]
+DIRS += ['rlz']
+
+if CONFIG['MOZ_EME']:
+    DIRS += ['widevine-adapter']
 
 IPDL_SOURCES += [
   'GMPTypes.ipdlh',

--- a/dom/media/gtest/MockMediaDecoderOwner.h
+++ b/dom/media/gtest/MockMediaDecoderOwner.h
@@ -34,8 +34,10 @@ public:
   void DownloadProgressed() override {}
   void UpdateReadyState() override {}
   void FirstFrameLoaded() override {}
+#ifdef MOZ_EME
   void DispatchEncrypted(const nsTArray<uint8_t>& aInitData,
                          const nsAString& aInitDataType) override {}
+#endif
   bool IsActive() const override { return true; }
   bool IsHidden() const override { return false; }
   void DownloadSuspended() override {}

--- a/dom/media/gtest/moz.build
+++ b/dom/media/gtest/moz.build
@@ -28,6 +28,11 @@ UNIFIED_SOURCES += [
     'TestWebMBuffered.cpp',
 ]
 
+if CONFIG['MOZ_EME']:
+    UNIFIED_SOURCES += [
+        'TestEME.cpp',
+    ]
+
 if CONFIG['MOZ_WEBM_ENCODER']:
     UNIFIED_SOURCES += [
         'TestVideoTrackEncoder.cpp',

--- a/dom/media/mediasource/TrackBuffersManager.cpp
+++ b/dom/media/mediasource/TrackBuffersManager.cpp
@@ -84,7 +84,7 @@ private:
   nsTArray<uint8_t> mInitData;
   nsString mInitDataType;
 };
-#endif
+#endif // MOZ_EME
 
 TrackBuffersManager::TrackBuffersManager(MediaSourceDecoder* aParentDecoder,
                                          const nsACString& aType)

--- a/dom/media/moz.build
+++ b/dom/media/moz.build
@@ -20,7 +20,6 @@ with Files('GetUserMedia*'):
     BUG_COMPONENT = component_av
 
 DIRS += [
-    'eme',
     'encoder',
     'flac',
     'gmp',
@@ -48,6 +47,9 @@ if CONFIG['MOZ_FMP4']:
 
 if CONFIG['MOZ_WEBRTC']:
     DIRS += ['bridge']
+
+if CONFIG['MOZ_EME']:
+    DIRS += ['eme']
 
 TEST_DIRS += [
     'gtest',

--- a/dom/media/platforms/PDMFactory.cpp
+++ b/dom/media/platforms/PDMFactory.cpp
@@ -24,7 +24,6 @@
 #endif
 #include "GMPDecoderModule.h"
 
-#include "mozilla/CDMProxy.h"
 #include "mozilla/ClearOnShutdown.h"
 #include "mozilla/SharedThreadPool.h"
 #include "mozilla/StaticPtr.h"
@@ -37,7 +36,11 @@
 #include "H264Converter.h"
 
 #include "AgnosticDecoderModule.h"
+
+#ifdef MOZ_EME
+#include "mozilla/CDMProxy.h"
 #include "EMEDecoderModule.h"
+#endif
 
 #include "DecoderDoctorDiagnostics.h"
 
@@ -450,11 +453,13 @@ PDMFactory::GetDecoder(const TrackInfo& aTrackInfo,
   return pdm.forget();
 }
 
+#ifdef MOZ_EME
 void
 PDMFactory::SetCDMProxy(CDMProxy* aProxy)
 {
   RefPtr<PDMFactory> m = new PDMFactory();
   mEMEPDM = new EMEDecoderModule(aProxy, m);
 }
+#endif
 
 }  // namespace mozilla

--- a/dom/media/platforms/PDMFactory.h
+++ b/dom/media/platforms/PDMFactory.h
@@ -11,7 +11,9 @@
 #include "mozilla/Function.h"
 #include "mozilla/StaticMutex.h"
 
+#ifdef MOZ_EME
 class CDMProxy;
+#endif
 
 namespace mozilla {
 
@@ -38,12 +40,14 @@ public:
   bool Supports(const TrackInfo& aTrackInfo,
                 DecoderDoctorDiagnostics* aDiagnostics) const;
 
+#ifdef MOZ_EME
   // Creates a PlatformDecoderModule that uses a CDMProxy to decrypt or
   // decrypt-and-decode EME encrypted content. If the CDM only decrypts and
   // does not decode, we create a PDM and use that to create MediaDataDecoders
   // that we use on on aTaskQueue to decode the decrypted stream.
   // This is called on the decode task queue.
   void SetCDMProxy(CDMProxy* aProxy);
+#endif
 
   static constexpr int kYUV400 = 0;
   static constexpr int kYUV420 = 1;

--- a/dom/media/platforms/moz.build
+++ b/dom/media/platforms/moz.build
@@ -30,10 +30,12 @@ UNIFIED_SOURCES += [
 ]
 
 DIRS += [
-    'agnostic/eme',
     'agnostic/gmp',
     'omx'
 ]
+
+if CONFIG['MOZ_EME']:
+    DIRS += ['agnostic/eme']
 
 if CONFIG['MOZ_WMF']:
     DIRS += [ 'wmf' ];

--- a/dom/webidl/moz.build
+++ b/dom/webidl/moz.build
@@ -285,15 +285,7 @@ WEBIDL_FILES = [
     'MediaDeviceInfo.webidl',
     'MediaDevices.webidl',
     'MediaElementAudioSourceNode.webidl',
-    'MediaEncryptedEvent.webidl',
     'MediaError.webidl',
-    'MediaKeyError.webidl',
-    'MediaKeyMessageEvent.webidl',
-    'MediaKeys.webidl',
-    'MediaKeySession.webidl',
-    'MediaKeysRequestStatus.webidl',
-    'MediaKeyStatusMap.webidl',
-    'MediaKeySystemAccess.webidl',
     'MediaList.webidl',
     'MediaQueryList.webidl',
     'MediaRecorder.webidl',
@@ -565,7 +557,6 @@ WEBIDL_FILES = [
     'WebKitCSSMatrix.webidl',
     'WebSocket.webidl',
     'WheelEvent.webidl',
-    'WidevineCDMManifest.webidl',
     'WifiOptions.webidl',
     'WindowOrWorkerGlobalScope.webidl',
     'WindowRoot.webidl',
@@ -591,6 +582,19 @@ WEBIDL_FILES = [
     'XULDocument.webidl',
     'XULElement.webidl',
 ]
+
+if CONFIG['MOZ_EME']:
+    WEBIDL_FILES += [
+        'MediaEncryptedEvent.webidl',
+        'MediaKeyError.webidl',
+        'MediaKeyMessageEvent.webidl',
+        'MediaKeys.webidl',
+        'MediaKeySession.webidl',
+        'MediaKeysRequestStatus.webidl',
+        'MediaKeyStatusMap.webidl',
+        'MediaKeySystemAccess.webidl',
+        'WidevineCDMManifest.webidl',
+    ]
 
 if CONFIG['MOZ_AUDIO_CHANNEL_MANAGER']:
     WEBIDL_FILES += [


### PR DESCRIPTION
This makes the EME ductwork and interfaces not be built when EME is disabled at build time, splitting EME off from GMP as well as is possible.

Some of the decryptor ductwork had to remain in place because of the way GMP infra is built around it, but will effectively be nops.

This resolves #26