### PR TITLE
Add a link to details on using Firefox extensions in Pale Moon

### DIFF
--- a/toolkit/locales/en-US/chrome/mozapps/extensions/extensions.properties
+++ b/toolkit/locales/en-US/chrome/mozapps/extensions/extensions.properties
@@ -32,6 +32,7 @@ notification.softblocked=%1$S is known to cause issues.
 notification.softblocked.link=More Information
 #LOCALIZATION NOTE (notification.compatibility) %1$S is the add-on name, %2$S is brand name
 notification.compatibility=%1$S was not designed for %2$S. It may not function properly or cease to function.
+notification.compatibility.link=More Information
 #LOCALIZATION NOTE (notification.outdated) %1$S is the add-on name
 notification.outdated=An important update is available for %1$S.
 notification.outdated.link=Update Now
@@ -82,6 +83,7 @@ details.notification.blocked=%1$S has been disabled due to security or stability
 details.notification.blocked.link=More Information
 #LOCALIZATION NOTE (details.notification.compatibility) %1$S is the add-on name, %2$S is brand name
 details.notification.compatibility=%1$S was not designed for %2$S. It may not function properly or cease to function.
+details.notification.compatibility.link=More Information
 #LOCALIZATION NOTE (details.notification.softblocked) %1$S is the add-on name
 details.notification.softblocked=%1$S is known to cause issues.
 details.notification.softblocked.link=More Information

--- a/toolkit/mozapps/extensions/content/extensions.js
+++ b/toolkit/mozapps/extensions/content/extensions.js
@@ -3067,6 +3067,10 @@ var gDetailView = {
           "details.notification.compatibility",
           [this._addon.name, gStrings.brandShortName], 2
         );
+        var warningLink = document.getElementById("detail-warning-link");
+        warningLink.value = gStrings.ext.GetStringFromName("details.notification.compatibility.link");
+        warningLink.href = Services.urlFormatter.formatURLPref("extensions.compatibility.url");
+        warningLink.hidden = false;
 #endif
       } else {
         this.node.removeAttribute("notification");

--- a/toolkit/mozapps/extensions/content/extensions.xml
+++ b/toolkit/mozapps/extensions/content/extensions.xml
@@ -1363,6 +1363,10 @@
                     "notification.compatibility",
                     [this.mAddon.name, gStrings.brandShortName], 2
                   );
+                  this._warningLink.value = gStrings.ext.GetStringFromName("notification.compatibility.link");
+                  this._warningLink.href = Services.urlFormatter.formatURLPref("extensions.compatibility.url");
+                  this._warningLink.hidden = false;
+                  this._warningBtn.hidden = true;
                 }
               }
 #endif


### PR DESCRIPTION
This provides a link to "[About using Firefox extensions on Pale Moon](https://forum.palemoon.org/viewtopic.php?f=46&t=23697)" in add-on manager warnings.

![palemoon_2020-02-19_16-39-02](https://user-images.githubusercontent.com/340855/74870072-c3cac380-5361-11ea-9a9c-8c885db4746a.png)

Tag #1445, depends on https://github.com/MoonchildProductions/Pale-Moon/pull/1727.