### PR TITLE
Add `%OS_SLICE%` macro to SSUAO to refine OS info

### DIFF
--- a/netwerk/protocol/http/UserAgentOverrides.jsm
+++ b/netwerk/protocol/http/UserAgentOverrides.jsm
@@ -18,6 +18,9 @@ const PREF_OVERRIDES_ENABLED = "general.useragent.site_specific_overrides";
 const DEFAULT_UA = Cc["@mozilla.org/network/protocol;1?name=http"]
                      .getService(Ci.nsIHttpProtocolHandler)
                      .userAgent;
+const OS_SLICE = Cc["@mozilla.org/network/protocol;1?name=http"]
+                   .getService(Ci.nsIHttpProtocolHandler)
+                   .oscpu + ";";
 const MAX_OVERRIDE_FOR_HOST_CACHE_SIZE = 250;
 
 XPCOMUtils.defineLazyServiceGetter(this, "ppmm",
@@ -143,7 +146,7 @@ function getUserAgentFromOverride(override)
   if (search && replace) {
     userAgent = DEFAULT_UA.replace(new RegExp(search, "g"), replace);
   } else {
-    userAgent = override;
+    userAgent = override.replace(/%OS_SLICE%/g, OS_SLICE);
   }
   gBuiltUAs.set(override, userAgent);
   return userAgent;


### PR DESCRIPTION
This allows SSUAO to provide more accurate OS information. To take advantage of this improvement, you must replace `@OS_SLICE@` with `%OS_SLICE%` in the application `uaoverrides.inc`. You can also use `%OS_SLICE%` macro in dynamic SSUAO rules.