### PR TITLE
Fix building `%OS_SLICE%` on non-Windows platforms

### DIFF
--- a/netwerk/protocol/http/moz.build
+++ b/netwerk/protocol/http/moz.build
@@ -99,9 +99,9 @@ IPDL_SOURCES += [
     'PHttpChannel.ipdl',
 ]
 
-EXTRA_JS_MODULES += ['UserAgentOverrides.jsm']
+EXTRA_JS_MODULES += ['UserAgentUpdates.jsm']
 
-EXTRA_PP_JS_MODULES += ['UserAgentUpdates.jsm']
+EXTRA_PP_JS_MODULES += ['UserAgentOverrides.jsm']
 
 include('/ipc/chromium/chromium-config.mozbuild')
 


### PR DESCRIPTION
Build `%OS_SLICE%` according the [logic](https://github.com/MoonchildProductions/UXP/blob/13a8e788810c006e964cc3a87c0ddb9ca1eb9114/netwerk/protocol/http/nsHttpHandler.cpp#L711-L731) from `nsHttpHandler.cpp`. 

Note, that `mCompatDevice` and `mDeviceModelId` are always empty in UXP (we should probably consider removing them from `nsHttpHandler.cpp` as well).

This need to be verified on Linux and OS X.

Tag #1473.