### PR TITLE
Un-bust building of NSS after update to 3.48 on Solaris.

### DIFF
--- a/security/nss/coreconf/SunOS5.mk
+++ b/security/nss/coreconf/SunOS5.mk
@@ -65,7 +65,7 @@ endif
 
 RANLIB      = echo
 CPU_ARCH    = sparc
-OS_DEFINES += -DSVR4 -DSYSV -D__svr4 -D__svr4__ -DSOLARIS -D_REENTRANT
+OS_DEFINES += -DSVR4 -DSYSV -D__svr4 -D__svr4__ -DSOLARIS -D_REENTRANT -D__EXTENSIONS__
 
 ifeq ($(OS_TEST),i86pc)
 ifeq ($(USE_64),1)


### PR DESCRIPTION
Resolves #1501 