### PR TITLE
Issue #65 - Fix unprocessed directives in WebRequest.jsm

### DIFF
--- a/toolkit/modules/moz.build
+++ b/toolkit/modules/moz.build
@@ -11,7 +11,6 @@ EXTRA_JS_MODULES += [
     'addons/WebNavigation.jsm',
     'addons/WebNavigationContent.js',
     'addons/WebNavigationFrames.jsm',
-    'addons/WebRequest.jsm',
     'addons/WebRequestCommon.jsm',
     'addons/WebRequestContent.js',
     'addons/WebRequestUpload.jsm',
@@ -85,6 +84,7 @@ EXTRA_JS_MODULES.third_party.jsesc += ['third_party/jsesc/jsesc.js']
 EXTRA_JS_MODULES.sessionstore += ['sessionstore/Utils.jsm']
 
 EXTRA_PP_JS_MODULES += [
+    'addons/WebRequest.jsm',
     'NewTabUtils.jsm',
     'ResetProfile.jsm',
     'Troubleshoot.jsm',


### PR DESCRIPTION
Fix unprocessed directives in `WebRequest.jsm` left after https://github.com/MoonchildProductions/UXP/commit/6a3907dae474c7e1f31df13a26605278d3500a0d, see also https://github.com/MoonchildProductions/UXP/issues/1497#issuecomment-607389362.