### PR TITLE
De-unify layout

### DIFF
--- a/layout/base/MaskLayerImageCache.h
+++ b/layout/base/MaskLayerImageCache.h
@@ -10,6 +10,7 @@
 #include "nsAutoPtr.h"
 #include "nsPresContext.h"
 #include "mozilla/gfx/Matrix.h"
+#include "mozilla/layers/ShadowLayers.h"
 
 namespace mozilla {
 

--- a/layout/base/MobileViewportManager.h
+++ b/layout/base/MobileViewportManager.h
@@ -7,8 +7,11 @@
 #define MobileViewportManager_h_
 
 #include "mozilla/Maybe.h"
+#include "nsIDocument.h"
 #include "nsIDOMEventListener.h"
+#include "nsIDOMEventTarget.h"
 #include "nsIObserver.h"
+#include "nsViewportInfo.h"
 #include "Units.h"
 
 class nsIDOMEventTarget;

--- a/layout/base/PositionedEventTargeting.cpp
+++ b/layout/base/PositionedEventTargeting.cpp
@@ -8,6 +8,7 @@
 #include "mozilla/EventStates.h"
 #include "mozilla/MouseEvents.h"
 #include "mozilla/Preferences.h"
+#include "nsIContentInlines.h"
 #include "nsLayoutUtils.h"
 #include "nsGkAtoms.h"
 #include "nsFontMetrics.h"

--- a/layout/base/RestyleManager.cpp
+++ b/layout/base/RestyleManager.cpp
@@ -241,11 +241,6 @@ RestyleManager::AnimationsWithDestroyedFrame::StopAnimationsWithoutFrame(
   }
 }
 
-static inline dom::Element*
-ElementForStyleContext(nsIContent* aParentContent,
-                       nsIFrame* aFrame,
-                       CSSPseudoElementType aPseudoType);
-
 // Forwarded nsIDocumentObserver method, to handle restyling (and
 // passing the notification to the frame).
 void
@@ -1009,7 +1004,7 @@ RestyleManager::TryInitiatingTransition(nsPresContext* aPresContext,
   return *aNewStyleContext != sc;
 }
 
-static dom::Element*
+dom::Element*
 ElementForStyleContext(nsIContent* aParentContent,
                        nsIFrame* aFrame,
                        CSSPseudoElementType aPseudoType)

--- a/layout/base/RestyleManager.h
+++ b/layout/base/RestyleManager.h
@@ -191,6 +191,7 @@ public:
       MOZ_ASSERT(false, "unexpected aPseudoType");
       return nullptr;
     }
+    
   private:
     RestyleManager* mRestyleManager;
     AutoRestore<ReframingStyleContexts*> mRestorePointer;
@@ -879,6 +880,11 @@ private:
   nsPresContext* const mPresContext;
   AutoTArray<mozilla::dom::Element*, 4> mAncestors;
 };
+
+dom::Element*
+ElementForStyleContext(nsIContent* aParentContent,
+                       nsIFrame* aFrame,
+                       CSSPseudoElementType aPseudoType);
 
 } // namespace mozilla
 

--- a/layout/base/RestyleManagerBase.cpp
+++ b/layout/base/RestyleManagerBase.cpp
@@ -5,8 +5,26 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "mozilla/RestyleManagerBase.h"
+#include "mozilla/RestyleManager.h"
 #include "mozilla/StyleSetHandle.h"
+#include "mozilla/StyleSetHandleInlines.h" // for Ptr::HasStateDependentStyle
+#include "ActiveLayerTracker.h"
+#include "nsCSSFrameConstructor.h"
+#include "nsCSSRendering.h"
 #include "nsIFrame.h"
+#include "nsIFrameInlines.h" // for IsAbsPosContainingBlock
+#include "nsPlaceholderFrame.h"
+#include "nsStyleChangeList.h"
+#include "nsStyleStructInlines.h" // for HasTransform
+#include "nsSVGEffects.h"
+#include "nsSVGIntegrationUtils.h"
+#include "nsSVGUtils.h"
+#include "nsViewportFrame.h"
+#include "StickyScrollContainer.h"
+#include "SVGTextFrame.h"
+
+using namespace mozilla;
+using namespace mozilla::layers;
 
 namespace mozilla {
 

--- a/layout/base/ServoRestyleManager.cpp
+++ b/layout/base/ServoRestyleManager.cpp
@@ -9,6 +9,7 @@
 #include "mozilla/ServoStyleSet.h"
 #include "mozilla/dom/ChildIterator.h"
 #include "nsContentUtils.h"
+#include "nsCSSFrameConstructor.h"
 #include "nsPrintfCString.h"
 #include "nsStyleChangeList.h"
 

--- a/layout/base/TouchManager.cpp
+++ b/layout/base/TouchManager.cpp
@@ -12,6 +12,8 @@
 #include "nsPresShell.h"
 #include "nsView.h"
 
+using namespace mozilla::dom;
+
 namespace mozilla {
 
 nsDataHashtable<nsUint32HashKey, TouchManager::TouchInfo>* TouchManager::sCaptureTouchList;

--- a/layout/base/moz.build
+++ b/layout/base/moz.build
@@ -119,7 +119,7 @@ EXPORTS.mozilla += [
     'StaticPresData.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'AccessibleCaret.cpp',
     'AccessibleCaretEventHub.cpp',
     'AccessibleCaretManager.cpp',
@@ -151,9 +151,11 @@ UNIFIED_SOURCES += [
     'nsLayoutDebugger.cpp',
     'nsLayoutHistoryState.cpp',
     'nsLayoutUtils.cpp',
+    'nsPresArena.cpp',
     'nsPresContext.cpp',
     'nsPresShell.cpp',
     'nsQuoteList.cpp',
+    'nsRefreshDriver.cpp',
     'nsStyleChangeList.cpp',
     'nsStyleSheetService.cpp',
     'PaintTracker.cpp',
@@ -167,13 +169,6 @@ UNIFIED_SOURCES += [
     'StaticPresData.cpp',
     'TouchManager.cpp',
     'ZoomConstraintsClient.cpp',
-]
-
-# nsPresArena.cpp needs to be built separately because it uses plarena.h.
-# nsRefreshDriver.cpp needs to be built separately because of name clashes in the OS X headers
-SOURCES += [
-    'nsPresArena.cpp',
-    'nsRefreshDriver.cpp',
 ]
 
 if CONFIG['ENABLE_TESTS']:

--- a/layout/base/nsFrameTraversal.cpp
+++ b/layout/base/nsFrameTraversal.cpp
@@ -10,6 +10,7 @@
 #include "nsPlaceholderFrame.h"
 #include "nsContainerFrame.h"
 
+using namespace mozilla;
 
 class nsFrameIterator : public nsIFrameEnumerator
 {

--- a/layout/base/nsLayoutUtils.cpp
+++ b/layout/base/nsLayoutUtils.cpp
@@ -118,6 +118,7 @@
 #include "mozilla/StyleSetHandleInlines.h"
 #include "RegionBuilder.h"
 #include "SVGSVGElement.h"
+#include "nsDocument.h"
 
 #ifdef MOZ_XUL
 #include "nsXULPopupManager.h"

--- a/layout/base/nsPresShell.cpp
+++ b/layout/base/nsPresShell.cpp
@@ -58,6 +58,7 @@
 #include "nsNameSpaceManager.h"  // for Pref-related rule management (bugs 22963,20760,31816)
 #include "nsFrame.h"
 #include "FrameLayerBuilder.h"
+#include "FrameMetrics.h" // for ViewID
 #include "nsViewManager.h"
 #include "nsView.h"
 #include "nsCRTGlue.h"
@@ -162,11 +163,12 @@
 
 #endif
 
-#include "mozilla/layers/CompositorBridgeChild.h"
 #include "GeckoProfiler.h"
 #include "gfxPlatform.h"
 #include "Layers.h"
 #include "LayerTreeInvalidation.h"
+#include "ClientLayerManager.h"
+#include "mozilla/layers/CompositorBridgeChild.h"
 #include "mozilla/css/ImageLoader.h"
 #include "mozilla/dom/DocumentTimeline.h"
 #include "mozilla/Preferences.h"
@@ -220,6 +222,8 @@ using namespace mozilla::layers;
 using namespace mozilla::gfx;
 using namespace mozilla::layout;
 using PaintFrameFlags = nsLayoutUtils::PaintFrameFlags;
+
+typedef FrameMetrics::ViewID ViewID;
 
 CapturingContentInfo nsIPresShell::gCaptureInfo =
   { false /* mAllowed */, false /* mPointerLock */, false /* mRetargetToElement */,

--- a/layout/generic/CSSAlignUtils.h
+++ b/layout/generic/CSSAlignUtils.h
@@ -9,6 +9,7 @@
 #define mozilla_CSSAlignUtils_h
 
 #include "mozilla/WritingModes.h"
+#include "ReflowInput.h"
 
 namespace mozilla {
 

--- a/layout/generic/ReflowOutput.cpp
+++ b/layout/generic/ReflowOutput.cpp
@@ -8,6 +8,8 @@
 #include "mozilla/ReflowOutput.h"
 #include "mozilla/ReflowInput.h"
 
+using namespace mozilla;
+
 void
 nsOverflowAreas::UnionWith(const nsOverflowAreas& aOther)
 {

--- a/layout/generic/RubyUtils.h
+++ b/layout/generic/RubyUtils.h
@@ -10,6 +10,7 @@
 #include "nsTArray.h"
 #include "nsGkAtoms.h"
 #include "nsCSSAnonBoxes.h"
+#include "nsIFrame.h"
 
 #define RTC_ARRAY_SIZE 1
 

--- a/layout/generic/ScrollSnap.h
+++ b/layout/generic/ScrollSnap.h
@@ -6,6 +6,8 @@
 #ifndef mozilla_layout_ScrollSnap_h_
 #define mozilla_layout_ScrollSnap_h_
 
+#include "nsIScrollableFrame.h"
+
 namespace mozilla {
 
 namespace layers {

--- a/layout/generic/moz.build
+++ b/layout/generic/moz.build
@@ -123,7 +123,7 @@ EXPORTS.mozilla.layout += [
     'FrameChildList.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'AsyncScrollBase.cpp',
     'BlockReflowInput.cpp',
     'CSSAlignUtils.cpp',
@@ -157,9 +157,11 @@ UNIFIED_SOURCES += [
     'nsIntervalSet.cpp',
     'nsLeafFrame.cpp',
     'nsLineBox.cpp',
+    'nsLineLayout.cpp',
     'nsPageContentFrame.cpp',
     'nsPageFrame.cpp',
     'nsPlaceholderFrame.cpp',
+    'nsPluginFrame.cpp',
     'nsRubyBaseContainerFrame.cpp',
     'nsRubyBaseFrame.cpp',
     'nsRubyContentFrame.cpp',
@@ -183,13 +185,6 @@ UNIFIED_SOURCES += [
     'ScrollVelocityQueue.cpp',
     'StickyScrollContainer.cpp',
     'TextOverflow.cpp',
-]
-
-# nsLineLayout.cpp needs to be built separately because it uses plarena.h.
-# nsPluginFrame.cpp needs to be built separately because of name clashes in the OS X headers.
-SOURCES += [
-    'nsLineLayout.cpp',
-    'nsPluginFrame.cpp',
 ]
 
 include('/ipc/chromium/chromium-config.mozbuild')

--- a/layout/generic/nsAbsoluteContainingBlock.cpp
+++ b/layout/generic/nsAbsoluteContainingBlock.cpp
@@ -18,6 +18,7 @@
 #include "nsPresContext.h"
 #include "nsCSSFrameConstructor.h"
 #include "nsGridContainerFrame.h"
+#include "nsPlaceholderFrame.h"
 
 #include "mozilla/Sprintf.h"
 

--- a/layout/generic/nsBRFrame.cpp
+++ b/layout/generic/nsBRFrame.cpp
@@ -6,6 +6,7 @@
 /* rendering object for HTML <br> elements */
 
 #include "nsCOMPtr.h"
+#include "nsContainerframe.h"
 #include "nsFontMetrics.h"
 #include "nsFrame.h"
 #include "nsPresContext.h"

--- a/layout/generic/nsBRFrame.cpp
+++ b/layout/generic/nsBRFrame.cpp
@@ -6,7 +6,7 @@
 /* rendering object for HTML <br> elements */
 
 #include "nsCOMPtr.h"
-#include "nsContainerframe.h"
+#include "nsContainerFrame.h"
 #include "nsFontMetrics.h"
 #include "nsFrame.h"
 #include "nsPresContext.h"

--- a/layout/generic/nsContainerFrame.cpp
+++ b/layout/generic/nsContainerFrame.cpp
@@ -29,10 +29,12 @@
 #include "nsBoxLayoutState.h"
 #include "nsCSSFrameConstructor.h"
 #include "nsBlockFrame.h"
+#include "nsBulletFrame.h"
 #include "nsPlaceholderFrame.h"
 #include "mozilla/AutoRestore.h"
 #include "nsIFrameInlines.h"
 #include "nsPrintfCString.h"
+#include "nsAttrValueInlines.h"
 #include <algorithm>
 
 using namespace mozilla;

--- a/layout/generic/nsFrame.cpp
+++ b/layout/generic/nsFrame.cpp
@@ -53,6 +53,7 @@
 #include "nsGkAtoms.h"
 #include "nsHtml5Atoms.h"
 #include "nsCSSAnonBoxes.h"
+#include "nsGenericHTMLElement.h"
 
 #include "nsFrameTraversal.h"
 #include "nsRange.h"

--- a/layout/generic/nsRubyBaseContainerFrame.cpp
+++ b/layout/generic/nsRubyBaseContainerFrame.cpp
@@ -22,6 +22,7 @@
 #include "RubyUtils.h"
 
 using namespace mozilla;
+using namespace mozilla::gfx;
 
 //----------------------------------------------------------------------
 

--- a/layout/generic/nsTextFrameUtils.cpp
+++ b/layout/generic/nsTextFrameUtils.cpp
@@ -13,6 +13,8 @@
 #include "nsUnicharUtils.h"
 #include <algorithm>
 
+using namespace mozilla;
+
 static bool IsDiscardable(char16_t ch, uint32_t* aFlags)
 {
   // Unlike IS_DISCARDABLE, we don't discard \r. \r will be ignored by gfxTextRun

--- a/layout/generic/nsTextRunTransformations.cpp
+++ b/layout/generic/nsTextRunTransformations.cpp
@@ -20,6 +20,7 @@
 #include "IrishCasing.h"
 
 using namespace mozilla;
+using namespace mozilla::gfx;
 
 // Unicode characters needing special casing treatment in tr/az languages
 #define LATIN_CAPITAL_LETTER_I_WITH_DOT_ABOVE  0x0130

--- a/layout/generic/nsTextRunTransformations.h
+++ b/layout/generic/nsTextRunTransformations.h
@@ -12,6 +12,8 @@
 #include "gfxTextRun.h"
 #include "nsStyleContext.h"
 
+using namespace mozilla;
+
 class nsTransformedTextRun;
 
 struct nsTransformedCharStyle final {

--- a/layout/generic/nsViewportFrame.cpp
+++ b/layout/generic/nsViewportFrame.cpp
@@ -16,6 +16,7 @@
 #include "nsAbsoluteContainingBlock.h"
 #include "GeckoProfiler.h"
 #include "nsIMozBrowserFrame.h"
+#include "nsPlaceholderFrame.h"
 
 using namespace mozilla;
 typedef nsAbsoluteContainingBlock::AbsPosReflowFlags AbsPosReflowFlags;

--- a/layout/printing/ipc/RemotePrintJobParent.cpp
+++ b/layout/printing/ipc/RemotePrintJobParent.cpp
@@ -18,7 +18,6 @@
 #include "nsIDeviceContextSpec.h"
 #include "nsIPrintSettings.h"
 #include "nsIWebProgressListener.h"
-#include "PrintTranslator.h"
 
 namespace mozilla {
 namespace layout {

--- a/layout/printing/ipc/RemotePrintJobParent.h
+++ b/layout/printing/ipc/RemotePrintJobParent.h
@@ -13,11 +13,11 @@
 #include "nsCOMPtr.h"
 #include "mozilla/RefPtr.h"
 #include "mozilla/UniquePtr.h"
+#include "mozilla/layout/PrintTranslator.h"
 
 class nsDeviceContext;
 class nsIPrintSettings;
 class nsIWebProgressListener;
-class PrintTranslator;
 
 namespace mozilla {
 namespace layout {

--- a/layout/printing/moz.build
+++ b/layout/printing/moz.build
@@ -13,11 +13,12 @@ XPIDL_SOURCES += [
 EXPORTS.mozilla.layout += [
     'ipc/RemotePrintJobChild.h',
     'ipc/RemotePrintJobParent.h',
+    'PrintTranslator.h',
 ]
 
 XPIDL_MODULE = 'layout_printing'
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'ipc/RemotePrintJobChild.cpp',
     'ipc/RemotePrintJobParent.cpp',
     'nsPagePrintTimer.cpp',

--- a/layout/printing/nsPrintData.cpp
+++ b/layout/printing/nsPrintData.cpp
@@ -7,9 +7,11 @@
 
 #include "nsIStringBundle.h"
 #include "nsIServiceManager.h"
+#include "nsPIDOMWindow.h"
 #include "nsPrintObject.h"
 #include "nsPrintPreviewListener.h"
 #include "nsIWebProgressListener.h"
+#include "nsIWidget.h"
 #include "mozilla/Services.h"
 
 //-----------------------------------------------------

--- a/layout/printing/nsPrintEngine.cpp
+++ b/layout/printing/nsPrintEngine.cpp
@@ -16,6 +16,7 @@
 #include "nsPIDOMWindow.h"
 #include "nsIDocShell.h"
 #include "nsIURI.h"
+#include "nsIFile.h"
 #include "nsITextToSubURI.h"
 #include "nsError.h"
 
@@ -143,7 +144,7 @@ using namespace mozilla::dom;
 #define DUMP_LAYOUT_LEVEL 9 // this turns on the dumping of each doucment's layout info
 
 #ifndef PR_PL
-static mozilla::LazyLogModule gPrintingLog("printing")
+static mozilla::LazyLogModule gPrintingLog("printing");
 
 #define PR_PL(_p1)  MOZ_LOG(gPrintingLog, mozilla::LogLevel::Debug, _p1);
 #endif

--- a/layout/printing/nsPrintObject.cpp
+++ b/layout/printing/nsPrintObject.cpp
@@ -6,6 +6,7 @@
 #include "nsPrintObject.h"
 #include "nsIContentViewer.h"
 #include "nsIDOMDocument.h"
+#include "nsIDOMElement.h"
 #include "nsContentUtils.h" // for nsAutoScriptBlocker
 #include "nsIInterfaceRequestorUtils.h"
 #include "nsPIDOMWindow.h"
@@ -14,6 +15,9 @@
 #include "nsIDocShellTreeItem.h"
 #include "nsIBaseWindow.h"
 #include "nsIDocument.h"
+#include "nsIWidget.h"
+#include "mozilla/Unused.h"
+#include "mozilla/dom/Element.h"
 
 //---------------------------------------------------
 //-- nsPrintObject Class Impl

--- a/layout/style/CSSLexer.h
+++ b/layout/style/CSSLexer.h
@@ -9,6 +9,7 @@
 #include "mozilla/UniquePtr.h"
 #include "nsCSSScanner.h"
 #include "mozilla/dom/CSSLexerBinding.h"
+#include "mozilla/dom/NonRefcountedDOMObject.h"
 
 namespace mozilla {
 namespace dom {

--- a/layout/style/CSSStyleSheet.cpp
+++ b/layout/style/CSSStyleSheet.cpp
@@ -47,6 +47,7 @@
 #include "mozilla/RuleProcessorCache.h"
 #include "nsIStyleSheetLinkingElement.h"
 #include "nsDOMWindowUtils.h"
+#include "nsStyleSet.h"
 
 using namespace mozilla;
 using namespace mozilla::dom;

--- a/layout/style/Declaration.cpp
+++ b/layout/style/Declaration.cpp
@@ -14,6 +14,7 @@
 #include "mozilla/css/Declaration.h"
 #include "nsPrintfCString.h"
 #include "gfxFontConstants.h"
+#include "nsCSSRules.h"
 #include "nsStyleUtil.h"
 
 namespace mozilla {

--- a/layout/style/DocumentStyleRootIterator.h
+++ b/layout/style/DocumentStyleRootIterator.h
@@ -8,6 +8,7 @@
 #define DocumentStyleRootIterator_h
 
 #include "nsTArray.h"
+#include "mozilla/dom/Element.h"
 
 class nsIContent;
 class nsIDocument;

--- a/layout/style/RuleProcessorCache.cpp
+++ b/layout/style/RuleProcessorCache.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include "nsCSSRuleProcessor.h"
 #include "nsThreadUtils.h"
+#include "CSSStyleSheet.h"
 
 using namespace mozilla;
 

--- a/layout/style/ServoStyleSet.cpp
+++ b/layout/style/ServoStyleSet.cpp
@@ -6,6 +6,7 @@
 
 #include "mozilla/ServoStyleSet.h"
 
+#include "ServoBindings.h"
 #include "mozilla/ServoRestyleManager.h"
 #include "mozilla/dom/ChildIterator.h"
 #include "nsCSSAnonBoxes.h"

--- a/layout/style/ServoStyleSheet.cpp
+++ b/layout/style/ServoStyleSheet.cpp
@@ -4,8 +4,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "ServoBindings.h"
 #include "mozilla/ServoStyleSheet.h"
 #include "mozilla/StyleBackendType.h"
+#include "CSSRuleList.h"
+
+using namespace mozilla::dom;
 
 namespace mozilla {
 

--- a/layout/style/StyleRule.cpp
+++ b/layout/style/StyleRule.cpp
@@ -36,6 +36,7 @@ class nsIDOMCSSStyleDeclaration;
 class nsIDOMCSSStyleSheet;
 
 using namespace mozilla;
+using namespace mozilla::dom;
 
 #define NS_IF_CLONE(member_)                                                  \
   PR_BEGIN_MACRO                                                              \

--- a/layout/style/StyleSheet.cpp
+++ b/layout/style/StyleSheet.cpp
@@ -6,6 +6,7 @@
 
 #include "mozilla/StyleSheet.h"
 
+#include "mozilla/dom/BindingDeclarations.h" // for Optional<>
 #include "mozilla/dom/CSSRuleList.h"
 #include "mozilla/dom/ShadowRoot.h"
 #include "mozilla/ServoStyleSheet.h"
@@ -15,6 +16,8 @@
 #include "mozAutoDocUpdate.h"
 #include "nsIMediaList.h"
 #include "nsNullPrincipal.h"
+
+using namespace mozilla::dom;
 
 namespace mozilla {
 

--- a/layout/style/moz.build
+++ b/layout/style/moz.build
@@ -140,7 +140,7 @@ EXPORTS.mozilla.css += [
     'StyleRule.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'AnimationCollection.cpp',
     'AnimationCommon.cpp',
     'CounterStyleManager.cpp',
@@ -171,6 +171,7 @@ UNIFIED_SOURCES += [
     'nsCSSProps.cpp',
     'nsCSSPseudoClasses.cpp',
     'nsCSSPseudoElements.cpp',
+    'nsCSSRuleProcessor.cpp',
     'nsCSSRules.cpp',
     'nsCSSScanner.cpp',
     'nsCSSValue.cpp',
@@ -183,6 +184,7 @@ UNIFIED_SOURCES += [
     'nsFontFaceUtils.cpp',
     'nsHTMLCSSStyleSheet.cpp',
     'nsHTMLStyleSheet.cpp',
+    'nsLayoutStylesheetCache.cpp',
     'nsMediaFeatures.cpp',
     'nsNthIndexCache.cpp',
     'nsROCSSPrimitiveValue.cpp',
@@ -206,14 +208,6 @@ UNIFIED_SOURCES += [
     'StyleRule.cpp',
     'StyleSheet.cpp',
     'SVGAttrAnimationRuleProcessor.cpp',
-]
-
-# nsCSSRuleProcessor.cpp needs to be built separately because it uses plarena.h.
-# nsLayoutStylesheetCache.cpp needs to be built separately because it uses
-# nsExceptionHandler.h, which includes windows.h.
-SOURCES += [
-    'nsCSSRuleProcessor.cpp',
-    'nsLayoutStylesheetCache.cpp',
 ]
 
 EXTRA_COMPONENTS += [

--- a/layout/style/nsCSSProps.h
+++ b/layout/style/nsCSSProps.h
@@ -345,7 +345,7 @@ public:
     // KTableEntry objects can be initialized either with an int16_t value
     // or a value of an enumeration type that can fit within an int16_t.
 
-    constexpr KTableEntry(nsCSSKeyword aKeyword, int16_t aValue)
+    KTableEntry(nsCSSKeyword aKeyword, int16_t aValue)
       : mKeyword(aKeyword)
       , mValue(aValue)
     {
@@ -353,7 +353,7 @@ public:
 
     template<typename T,
              typename = typename std::enable_if<std::is_enum<T>::value>::type>
-    constexpr KTableEntry(nsCSSKeyword aKeyword, T aValue)
+    KTableEntry(nsCSSKeyword aKeyword, T aValue)
       : mKeyword(aKeyword)
       , mValue(static_cast<int16_t>(aValue))
     {

--- a/layout/style/nsCSSPseudoClassList.h
+++ b/layout/style/nsCSSPseudoClassList.h
@@ -38,6 +38,8 @@
  * automatically defined to CSS_PSEUDO_CLASS.
  */
 
+#include "nsCSSPseudoElements.h"
+
 // OUTPUT_CLASS=nsCSSPseudoClasses
 // MACRO_NAME=CSS_PSEUDO_CLASS
 

--- a/layout/style/nsCSSPseudoClasses.cpp
+++ b/layout/style/nsCSSPseudoClasses.cpp
@@ -13,6 +13,7 @@
 #include "nsString.h"
 
 using namespace mozilla;
+using namespace mozilla::css;
 
 // define storage for all atoms
 #define CSS_PSEUDO_CLASS(_name, _value, _flags, _pref) \

--- a/layout/style/nsCSSPseudoClasses.h
+++ b/layout/style/nsCSSPseudoClasses.h
@@ -9,6 +9,8 @@
 #define nsCSSPseudoClasses_h___
 
 #include "nsStringFwd.h"
+#include "mozilla/CSSEnabledState.h"
+#include "nsStyleStruct.h"
 
 // The following two flags along with the pref defines where this pseudo
 // class can be used:

--- a/layout/style/nsCSSRules.h
+++ b/layout/style/nsCSSRules.h
@@ -41,7 +41,6 @@ namespace mozilla {
 
 namespace dom {
 class DocGroup;
-class DocGroup;
 } // namespace dom
 
 class ErrorResult;

--- a/layout/style/nsCSSScanner.cpp
+++ b/layout/style/nsCSSScanner.cpp
@@ -14,6 +14,8 @@
 #include "mozilla/Likely.h"
 #include <algorithm>
 
+using mozilla::IsNaN;
+
 /* Character class tables and related helper functions. */
 
 static const uint8_t IS_HEX_DIGIT  = 0x01;

--- a/layout/style/nsCSSValue.cpp
+++ b/layout/style/nsCSSValue.cpp
@@ -6,11 +6,12 @@
 
 /* representation of simple property values within CSS declarations */
 
+#include "mozilla/ArrayUtils.h"
+
 #include "nsCSSValue.h"
 
 #include "mozilla/StyleSheetInlines.h"
 #include "mozilla/Likely.h"
-#include "mozilla/MemoryReporting.h"
 #include "mozilla/Move.h"
 #include "mozilla/css/ImageLoader.h"
 #include "CSSCalc.h"
@@ -18,8 +19,6 @@
 #include "imgIRequest.h"
 #include "imgRequestProxy.h"
 #include "nsIDocument.h"
-#include "nsIPrincipal.h"
-#include "nsCSSProps.h"
 #include "nsNetUtil.h"
 #include "nsPresContext.h"
 #include "nsStyleUtil.h"
@@ -27,7 +26,9 @@
 #include "nsStyleSet.h"
 #include "nsContentUtils.h"
 
+
 using namespace mozilla;
+using namespace mozilla::css;
 
 static bool
 IsLocalRefURL(nsStringBuffer* aString)

--- a/layout/style/nsComputedDOMStyle.cpp
+++ b/layout/style/nsComputedDOMStyle.cpp
@@ -54,6 +54,8 @@
 using namespace mozilla;
 using namespace mozilla::dom;
 
+typedef nsCSSProps::KTableEntry KTableEntry;
+
 #if defined(DEBUG_bzbarsky) || defined(DEBUG_caillon)
 #define DEBUG_ComputedDOMStyle
 #endif

--- a/layout/style/nsDOMCSSAttrDeclaration.cpp
+++ b/layout/style/nsDOMCSSAttrDeclaration.cpp
@@ -10,6 +10,7 @@
 #include "mozilla/css/Declaration.h"
 #include "mozilla/css/StyleRule.h"
 #include "mozilla/dom/Element.h"
+#include "mozilla/dom/DocGroup.h"
 #include "nsIDocument.h"
 #include "nsIDOMMutationEvent.h"
 #include "nsIURI.h"
@@ -17,8 +18,12 @@
 #include "nsWrapperCacheInlines.h"
 #include "nsIFrame.h"
 #include "ActiveLayerTracker.h"
+#include "ServoDeclarationBlock.h"
+#include "StyleSetHandle.h"
+#include "DeclarationBlockInlines.h"
 
 using namespace mozilla;
+using namespace mozilla::dom;
 
 nsDOMCSSAttributeDeclaration::nsDOMCSSAttributeDeclaration(dom::Element* aElement,
                                                            bool aIsSMILOverride)

--- a/layout/style/nsMediaFeatures.cpp
+++ b/layout/style/nsMediaFeatures.cpp
@@ -19,6 +19,7 @@
 #include "nsDeviceContext.h"
 #include "nsIBaseWindow.h"
 #include "nsIDocument.h"
+#include "nsIWidget.h"
 #include "nsContentUtils.h"
 #include "mozilla/StyleSheet.h"
 #include "mozilla/StyleSheetInlines.h"

--- a/layout/style/nsStyleContext.cpp
+++ b/layout/style/nsStyleContext.cpp
@@ -12,6 +12,8 @@
 #include "nsCSSAnonBoxes.h"
 #include "nsCSSPseudoElements.h"
 #include "nsStyleConsts.h"
+#include "nsStyleStruct.h"
+#include "nsStyleStructInlines.h"
 #include "nsString.h"
 #include "nsPresContext.h"
 #include "nsIStyleRule.h"
@@ -35,6 +37,7 @@
 #include "mozilla/ReflowInput.h"
 #include "nsLayoutUtils.h"
 #include "nsCoord.h"
+#include "nsFontMetrics.h"
 
 // Ensure the binding function declarations in nsStyleContext.h matches
 // those in ServoBindings.h.

--- a/layout/style/nsStyleStruct.cpp
+++ b/layout/style/nsStyleStruct.cpp
@@ -40,6 +40,7 @@
 #include <algorithm>
 
 using namespace mozilla;
+using namespace mozilla::dom;
 
 static_assert((((1 << nsStyleStructID_Length) - 1) &
                ~(NS_STYLE_INHERIT_MASK)) == 0,

--- a/layout/svg/SVGTextFrame.cpp
+++ b/layout/svg/SVGTextFrame.cpp
@@ -37,6 +37,7 @@
 #include "nsTextNode.h"
 #include "SVGAnimatedNumberList.h"
 #include "SVGContentUtils.h"
+#include "SVGContextPaint.h"
 #include "SVGLengthList.h"
 #include "SVGNumberList.h"
 #include "SVGPathElement.h"

--- a/layout/svg/moz.build
+++ b/layout/svg/moz.build
@@ -21,7 +21,7 @@ EXPORTS.mozilla += [
     'SVGContextPaint.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'nsCSSClipPathInstance.cpp',
     'nsCSSFilterInstance.cpp',
     'nsFilterInstance.cpp',

--- a/layout/svg/nsFilterInstance.cpp
+++ b/layout/svg/nsFilterInstance.cpp
@@ -28,6 +28,7 @@
 using namespace mozilla;
 using namespace mozilla::dom;
 using namespace mozilla::gfx;
+using namespace mozilla::image;
 
 FilterDescription
 nsFilterInstance::GetFilterDescription(nsIContent* aFilteredElement,

--- a/layout/svg/nsISVGChildFrame.h
+++ b/layout/svg/nsISVGChildFrame.h
@@ -8,6 +8,7 @@
 
 #include "gfxRect.h"
 #include "nsQueryFrame.h"
+#include "imgIContainer.h"
 
 class gfxContext;
 class gfxMatrix;

--- a/layout/svg/nsSVGContainerFrame.cpp
+++ b/layout/svg/nsSVGContainerFrame.cpp
@@ -17,6 +17,7 @@
 #include "SVGTextFrame.h"
 
 using namespace mozilla;
+using namespace mozilla::image;
 
 NS_QUERYFRAME_HEAD(nsSVGContainerFrame)
   NS_QUERYFRAME_ENTRY(nsSVGContainerFrame)

--- a/layout/svg/nsSVGFilterInstance.cpp
+++ b/layout/svg/nsSVGFilterInstance.cpp
@@ -13,6 +13,7 @@
 #include "mozilla/dom/HTMLCanvasElement.h"
 #include "mozilla/dom/SVGFilterElement.h"
 #include "nsReferencedElement.h"
+#include "nsSVGEffects.h"
 #include "nsSVGFilterFrame.h"
 #include "nsSVGUtils.h"
 #include "SVGContentUtils.h"

--- a/layout/svg/nsSVGIntegrationUtils.h
+++ b/layout/svg/nsSVGIntegrationUtils.h
@@ -10,6 +10,7 @@
 #include "gfxRect.h"
 #include "nsRegionFwd.h"
 #include "mozilla/gfx/Rect.h"
+#include "imgIContainer.h"
 
 class gfxContext;
 class gfxDrawable;

--- a/layout/svg/nsSVGMarkerFrame.cpp
+++ b/layout/svg/nsSVGMarkerFrame.cpp
@@ -15,6 +15,7 @@
 
 using namespace mozilla::dom;
 using namespace mozilla::gfx;
+using namespace mozilla::image;
 
 nsContainerFrame*
 NS_NewSVGMarkerFrame(nsIPresShell* aPresShell, nsStyleContext* aContext)

--- a/layout/svg/nsSVGOuterSVGFrame.cpp
+++ b/layout/svg/nsSVGOuterSVGFrame.cpp
@@ -18,9 +18,12 @@
 #include "mozilla/dom/SVGSVGElement.h"
 #include "mozilla/dom/SVGViewElement.h"
 #include "nsSubDocumentFrame.h"
+#include "gfxMatrix.h"
 
 using namespace mozilla;
 using namespace mozilla::dom;
+using namespace mozilla::gfx;
+using namespace mozilla::image;
 
 //----------------------------------------------------------------------
 // Implementation helpers

--- a/layout/svg/nsSVGSwitchFrame.cpp
+++ b/layout/svg/nsSVGSwitchFrame.cpp
@@ -11,6 +11,7 @@
 #include "nsSVGUtils.h"
 
 using namespace mozilla::gfx;
+using namespace mozilla::image;
 
 class nsSVGSwitchFrame : public nsSVGGFrame
 {

--- a/layout/svg/nsSVGUtils.cpp
+++ b/layout/svg/nsSVGUtils.cpp
@@ -58,6 +58,7 @@
 using namespace mozilla;
 using namespace mozilla::dom;
 using namespace mozilla::gfx;
+using namespace mozilla::image;
 
 static bool sSVGPathCachingEnabled;
 static bool sSVGDisplayListHitTestingEnabled;

--- a/layout/tables/FixedTableLayoutStrategy.cpp
+++ b/layout/tables/FixedTableLayoutStrategy.cpp
@@ -15,6 +15,10 @@
 #include "nsTableCellFrame.h"
 #include <algorithm>
 
+#include "mozilla/WritingModes.h"
+
+using namespace mozilla;
+
 FixedTableLayoutStrategy::FixedTableLayoutStrategy(nsTableFrame *aTableFrame)
   : nsITableLayoutStrategy(nsITableLayoutStrategy::Fixed)
   , mTableFrame(aTableFrame)

--- a/layout/tables/SpanningCellSorter.cpp
+++ b/layout/tables/SpanningCellSorter.cpp
@@ -12,6 +12,8 @@
 #include "nsQuickSort.h"
 #include "nsIPresShell.h"
 
+using mozilla::fallible;
+
 //#define DEBUG_SPANNING_CELL_SORTER
 
 SpanningCellSorter::SpanningCellSorter()

--- a/layout/tables/moz.build
+++ b/layout/tables/moz.build
@@ -13,7 +13,7 @@ EXPORTS += [
     'nsITableCellLayout.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'BasicTableLayoutStrategy.cpp',
     'FixedTableLayoutStrategy.cpp',
     'nsCellMap.cpp',

--- a/layout/tables/nsTableFrame.cpp
+++ b/layout/tables/nsTableFrame.cpp
@@ -41,6 +41,7 @@
 #include "nsCSSFrameConstructor.h"
 #include "mozilla/StyleSetHandle.h"
 #include "mozilla/StyleSetHandleInlines.h"
+#include "mozilla/gfx/Helpers.h"
 #include "nsDisplayList.h"
 #include "nsIScrollableFrame.h"
 #include "nsCSSProps.h"
@@ -48,6 +49,7 @@
 #include <algorithm>
 
 using namespace mozilla;
+using namespace mozilla::gfx;
 using namespace mozilla::image;
 using namespace mozilla::layout;
 

--- a/layout/xul/ContainerBoxObject.h
+++ b/layout/xul/ContainerBoxObject.h
@@ -8,6 +8,7 @@
 #define mozilla_dom_ContainerBoxObject_h
 
 #include "mozilla/dom/BoxObject.h"
+#include "nsIDocShell.h"
 
 namespace mozilla {
 namespace dom {

--- a/layout/xul/grid/moz.build
+++ b/layout/xul/grid/moz.build
@@ -19,7 +19,7 @@ EXPORTS += [
     'nsIGridPart.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'nsGrid.cpp',
     'nsGridCell.cpp',
     'nsGridLayout2.cpp',

--- a/layout/xul/moz.build
+++ b/layout/xul/moz.build
@@ -44,7 +44,7 @@ EXPORTS.mozilla.dom += [
     'ScrollBoxObject.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'BoxObject.cpp',
     'nsBox.cpp',
     'nsBoxFrame.cpp',
@@ -64,7 +64,7 @@ UNIFIED_SOURCES += [
 ]
 
 if CONFIG['MOZ_XUL']:
-    UNIFIED_SOURCES += [
+    SOURCES += [
         'ContainerBoxObject.cpp',
         'ListBoxObject.cpp',
         'MenuBoxObject.cpp',

--- a/layout/xul/nsButtonBoxFrame.cpp
+++ b/layout/xul/nsButtonBoxFrame.cpp
@@ -12,6 +12,7 @@
 #include "nsPresContext.h"
 #include "nsIPresShell.h"
 #include "nsIDOMElement.h"
+#include "nsIDOMEvent.h"
 #include "nsDisplayList.h"
 #include "nsContentUtils.h"
 #include "mozilla/dom/Element.h"

--- a/layout/xul/nsMenuBarListener.cpp
+++ b/layout/xul/nsMenuBarListener.cpp
@@ -21,6 +21,7 @@
 #include "mozilla/BasicEvents.h"
 #include "mozilla/Preferences.h"
 #include "mozilla/TextEvents.h"
+#include "mozilla/dom/Event.h"
 
 using namespace mozilla;
 

--- a/layout/xul/nsMenuFrame.cpp
+++ b/layout/xul/nsMenuFrame.cpp
@@ -48,6 +48,7 @@
 #include <algorithm>
 
 using namespace mozilla;
+using namespace mozilla::dom;
 
 #define NS_MENU_POPUP_LIST_INDEX 0
 

--- a/layout/xul/nsMenuPopupFrame.cpp
+++ b/layout/xul/nsMenuPopupFrame.cpp
@@ -18,6 +18,7 @@
 #include "nsMenuBarFrame.h"
 #include "nsPopupSetFrame.h"
 #include "nsPIDOMWindow.h"
+#include "nsIDOMEvent.h"
 #include "nsIDOMKeyEvent.h"
 #include "nsIDOMScreen.h"
 #include "nsIPresShell.h"
@@ -45,6 +46,7 @@
 #include "nsThemeConstants.h"
 #include "nsTransitionManager.h"
 #include "nsDisplayList.h"
+#include "nsIDOMXULMenuListElement.h"
 #include "nsIDOMXULSelectCntrlItemEl.h"
 #include "mozilla/EventDispatcher.h"
 #include "mozilla/EventStateManager.h"
@@ -53,6 +55,7 @@
 #include "mozilla/LookAndFeel.h"
 #include "mozilla/MouseEvents.h"
 #include "mozilla/dom/Element.h"
+#include "mozilla/dom/Event.h"
 #include "mozilla/dom/PopupBoxObject.h"
 #include <algorithm>
 

--- a/layout/xul/nsResizerFrame.h
+++ b/layout/xul/nsResizerFrame.h
@@ -8,8 +8,11 @@
 #include "mozilla/Attributes.h"
 #include "mozilla/EventForwards.h"
 #include "nsTitleBarFrame.h"
+#include "Units.h"
 
 class nsIBaseWindow;
+
+using namespace mozilla;
 
 class nsResizerFrame : public nsTitleBarFrame 
 {

--- a/layout/xul/tree/moz.build
+++ b/layout/xul/tree/moz.build
@@ -27,7 +27,7 @@ EXPORTS.mozilla.dom += [
     'TreeBoxObject.h'
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'nsTreeBodyFrame.cpp',
     'nsTreeColFrame.cpp',
     'nsTreeColumns.cpp',


### PR DESCRIPTION
This is the high-priority de-unification of /layout part of #80 , blocking further WebComponents work.

/layout seems to be particularly fragile in terms of unified building, so it really needs to be built using other applications than Basilisk which I used for this work so far and on other operating systems to catch anything that Windows builds might not have brought to light.