### PR TITLE
Include nsIContentInlines.h in layout/base/PositionedEventTargeting.cpp for Mac build

### DIFF
--- a/layout/base/PositionedEventTargeting.cpp
+++ b/layout/base/PositionedEventTargeting.cpp
@@ -8,6 +8,7 @@
 #include "mozilla/EventStates.h"
 #include "mozilla/MouseEvents.h"
 #include "mozilla/Preferences.h"
+#include "nsIContentInlines.h"
 #include "nsLayoutUtils.h"
 #include "nsGkAtoms.h"
 #include "nsFontMetrics.h"


### PR DESCRIPTION
I've checked this with Pale Moon and Basilisk. It is required for both.