### PR TITLE
Implement URLSearchParams's sort()

### DIFF
--- a/dom/url/URLSearchParams.cpp
+++ b/dom/url/URLSearchParams.cpp
@@ -448,6 +448,15 @@ URLSearchParams::GetValueAtIndex(uint32_t aIndex) const
   return mParams->GetValueAtIndex(aIndex);
 }
 
+void
+URLSearchParams::Sort(ErrorResult& aRv)
+{
+  aRv = mParams->Sort();
+  if (!aRv.Failed()) {
+    NotifyObserver();
+  }
+}
+
 // Helper functions for structured cloning
 inline bool
 ReadString(JSStructuredCloneReader* aReader, nsString& aString)
@@ -470,6 +479,39 @@ ReadString(JSStructuredCloneReader* aReader, nsString& aString)
   }
 
   return true;
+}
+
+nsresult
+URLParams::Sort()
+{
+  // Unfortunately we cannot use nsTArray<>.Sort() because it doesn't keep the
+  // correct order of the values for equal keys.
+
+  // Let's sort the keys, without duplicates.
+  FallibleTArray<nsString> keys;
+  for (const Param& param : mParams) {
+    if (!keys.Contains(param.mKey) &&
+        !keys.InsertElementSorted(param.mKey, fallible)) {
+      return NS_ERROR_OUT_OF_MEMORY;
+    }
+  }
+
+  FallibleTArray<Param> params;
+
+  // Here we recreate the array starting from the sorted keys.
+  for (uint32_t keyId = 0, keysLength = keys.Length(); keyId < keysLength;
+       ++keyId) {
+    const nsString& key = keys[keyId];
+    for (const Param& param : mParams) {
+      if (param.mKey.Equals(key) &&
+          !params.AppendElement(param, fallible)) {
+        return NS_ERROR_OUT_OF_MEMORY;
+      }
+    }
+  }
+
+  mParams.SwapElements(params);
+  return NS_OK;
 }
 
 inline bool

--- a/dom/url/URLSearchParams.h
+++ b/dom/url/URLSearchParams.h
@@ -70,7 +70,7 @@ public:
 
   void Get(const nsAString& aName, nsString& aRetval);
 
-  void GetAll(const nsAString& aName, nsTArray<nsString >& aRetval);
+  void GetAll(const nsAString& aName, nsTArray<nsString>& aRetval);
 
   void Set(const nsAString& aName, const nsAString& aValue);
 
@@ -102,6 +102,8 @@ public:
     MOZ_ASSERT(aIndex < mParams.Length());
     return mParams[aIndex].mValue;
   }
+
+  nsresult Sort();
 
   bool
   ReadStructuredClone(JSStructuredCloneReader* aReader);
@@ -170,6 +172,8 @@ public:
   uint32_t GetIterableLength() const;
   const nsAString& GetKeyAtIndex(uint32_t aIndex) const;
   const nsAString& GetValueAtIndex(uint32_t aIndex) const;
+
+  void Sort(ErrorResult& aRv);
 
   void Stringify(nsString& aRetval) const
   {

--- a/dom/webidl/URLSearchParams.webidl
+++ b/dom/webidl/URLSearchParams.webidl
@@ -22,6 +22,10 @@ interface URLSearchParams {
   sequence<USVString> getAll(USVString name);
   boolean has(USVString name);
   void set(USVString name, USVString value);
+
+  [Throws]
+  void sort();
+
   iterable<USVString, USVString>;
   stringifier;
 };


### PR DESCRIPTION
Based to https://bugzilla.mozilla.org/show_bug.cgi?id=1331864

https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/sort

Mozilla document for URLSearchParams's sort()

Also from that document to test this working as intended outside of issue #1449
Run what is shown in Examples on Scratchpad and see result on web console matching a=2&a=1&b=3&c=4

https://url.spec.whatwg.org/#dom-urlsearchparams-sort

URLSearchParams's sort() from 1331864 makes https://www.udemy.com/home/my-courses/learning/ menu work after login from issue #1449 

Also this makes UXP platform spec compliant.

Because these changes should have own issue instead #1449 

Resolves #1528, also resolves #1449