### PR TITLE
Fix warning about inline nsINode::GetFlattenedTreeParentNodeForStyle being undefined

### DIFF
--- a/dom/base/ElementInlines.h
+++ b/dom/base/ElementInlines.h
@@ -8,6 +8,7 @@
 #define mozilla_dom_ElementInlines_h
 
 #include "mozilla/dom/Element.h"
+#include "nsIContentInlines.h"
 #include "nsIDocument.h"
 
 namespace mozilla {


### PR DESCRIPTION
This warning creates a lot of noise both on Mac and Linux.

Tag #457 