### PR TITLE
Supress warning about inlining `new` and `delete` in mozalloc

### DIFF
--- a/old-configure.in
+++ b/old-configure.in
@@ -798,6 +798,8 @@ case "$target" in
     MKCSHLIB='$(CC) $(CFLAGS) $(DSO_PIC_CFLAGS) $(DSO_LDOPTS) -o $@'
     MOZ_OPTIMIZE_FLAGS="-O3"
     CXXFLAGS="$CXXFLAGS -stdlib=libc++"
+    # Suppress the clang warning for the inline 'new' and 'delete' in mozalloc
+    CXXFLAGS="$CXXFLAGS -Wno-inline-new-delete"
     DLL_SUFFIX=".dylib"
     DSO_LDOPTS=''
     STRIP_FLAGS="$STRIP_FLAGS -x -S"


### PR DESCRIPTION
This fixes a lot of unnecessary warning spew on Mac.

Same warning option is defined much below in the file but that never gets executed on Mac. Putting it here fixes the endless warnings about `new` and `delete` inline.

Tag #457 