### PR TITLE
Fix border-radius on table row groups, rows, column groups, or columns

### DIFF
--- a/layout/base/nsCSSRendering.cpp
+++ b/layout/base/nsCSSRendering.cpp
@@ -1903,8 +1903,15 @@ nsCSSRendering::GetImageLayerClip(const nsStyleImageLayers::Layer& aLayer,
   nsRect clipBorderArea =
     ::BoxDecorationRectForBorder(aForFrame, aBorderArea, skipSides, &aBorder);
 
-  bool haveRoundedCorners = GetRadii(aForFrame, aBorder, aBorderArea,
-                                     clipBorderArea, aClipState->mRadii);
+  bool haveRoundedCorners = false;
+   nsIAtom* fType = aForFrame->GetType();
+   if (fType != nsGkAtoms::tableColGroupFrame &&
+       fType != nsGkAtoms::tableColFrame &&
+       fType != nsGkAtoms::tableRowFrame &&
+       fType != nsGkAtoms::tableRowGroupFrame) {
+     haveRoundedCorners = GetRadii(aForFrame, aBorder, aBorderArea,
+                                   clipBorderArea, aClipState->mRadii);
+   }
 
   bool isSolidBorder =
       aWillPaintBorder && IsOpaqueBorder(aBorder);

--- a/layout/reftests/table-bordercollapse/bug1375518-2.html
+++ b/layout/reftests/table-bordercollapse/bug1375518-2.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Table border collapse</title>
+<style>
+  div > span {
+    display: table-cell;
+    background-color: black;
+    height: 100px;
+    width: 100px;
+    border-radius: 50px;
+  }
+  div {
+    display: table;
+    border-collapse: collapse;
+  }
+</style>
+</head>
+<body>
+  <div><span></span></div>
+</body>
+</html>

--- a/layout/reftests/table-bordercollapse/bug1375518-3.html
+++ b/layout/reftests/table-bordercollapse/bug1375518-3.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Separated border model table</title>
+<style>
+  div > span {
+    display: table-cell;
+    background-color: black;
+    height: 100px;
+    width: 100px;
+    border-radius: 50px;
+  }
+  div {
+    display: table;
+    border-collapse: separate;
+  }
+</style>
+</head>
+<body>
+  <div><span></span></div>
+</body>
+</html>

--- a/layout/reftests/table-bordercollapse/bug1375518-4-ref.html
+++ b/layout/reftests/table-bordercollapse/bug1375518-4-ref.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<title>border-radius and separated border model tables</title>
+<style>
+
+body { background: white; color: black }
+
+table { border-collapse: separate; margin: 1em 2px; }
+table, td { border: 1px solid black; }
+
+.radius { border: 3px solid teal; background: aqua; color: black; }
+
+</style>
+
+<h1>border-radius and separated border model tables</h1>
+
+<table>
+  <tbody>
+    <tr><td>xx</td><td>xx</td><td>xx
+  </td></tr></tbody>
+  <tbody class="radius">
+    <tr><td>xx</td><td>xx</td><td>xx
+    </td></tr><tr><td>xx</td><td>xx</td><td>xx
+  </td></tr></tbody>
+  <tbody>
+    <tr><td>xx</td><td>xx</td><td>xx
+  </td></tr></tbody>
+</table>
+
+<table>
+  <tbody><tr class="radius"><td>xx</td><td>xx</td><td>xx
+  </td></tr><tr><td>xx</td><td>xx</td><td>xx
+</td></tr></tbody></table>
+
+<table>
+  <colgroup class="radius"><col><col></colgroup><colgroup><col>
+  </colgroup><tbody><tr><td>xx</td><td>xx</td><td>xx
+  </td></tr><tr><td>xx</td><td>xx</td><td>xx
+</td></tr></tbody></table>
+
+<table>
+  <colgroup><col><col class="radius"><col>
+  </colgroup><tbody><tr><td>xx</td><td>xx</td><td>xx
+  </td></tr><tr><td>xx</td><td>xx</td><td>xx
+</td></tr></tbody></table>

--- a/layout/reftests/table-bordercollapse/bug1375518-4.html
+++ b/layout/reftests/table-bordercollapse/bug1375518-4.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<title>border-radius and separated border model tables</title>
+<style>
+
+body { background: white; color: black }
+
+table { border-collapse: separate; margin: 1em 2px; }
+table, td { border: 1px solid black; }
+
+.radius { border: 3px solid teal; background: aqua; color: black; border-radius: 12px }
+
+</style>
+
+<h1>border-radius and separated border model tables</h1>
+
+<table>
+  <tbody>
+    <tr><td>xx</td><td>xx</td><td>xx
+  </td></tr></tbody>
+  <tbody class="radius">
+    <tr><td>xx</td><td>xx</td><td>xx
+    </td></tr><tr><td>xx</td><td>xx</td><td>xx
+  </td></tr></tbody>
+  <tbody>
+    <tr><td>xx</td><td>xx</td><td>xx
+  </td></tr></tbody>
+</table>
+
+<table>
+  <tbody><tr class="radius"><td>xx</td><td>xx</td><td>xx
+  </td></tr><tr><td>xx</td><td>xx</td><td>xx
+</td></tr></tbody></table>
+
+<table>
+  <colgroup class="radius"><col><col></colgroup><colgroup><col>
+  </colgroup><tbody><tr><td>xx</td><td>xx</td><td>xx
+  </td></tr><tr><td>xx</td><td>xx</td><td>xx
+</td></tr></tbody></table>
+
+<table>
+  <colgroup><col><col class="radius"><col>
+  </colgroup><tbody><tr><td>xx</td><td>xx</td><td>xx
+  </td></tr><tr><td>xx</td><td>xx</td><td>xx
+</td></tr></tbody></table>

--- a/layout/reftests/table-bordercollapse/bug1375518-5-ref.html
+++ b/layout/reftests/table-bordercollapse/bug1375518-5-ref.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<title>border-radius and border-collapse tables</title>
+<style>
+
+body { background: white; color: black }
+
+table { border-collapse: collapse; margin: 1em 2px; }
+td { border: 1px solid black; }
+
+.radius { border: 3px solid teal; background: aqua; color: black; }
+
+</style>
+
+<h1>border-radius and border-collapse tables</h1>
+
+<table>
+  <tbody>
+    <tr><td>xx<td>xx<td>xx
+  </tbody>
+  <tbody class="radius">
+    <tr><td>xx<td>xx<td>xx
+    <tr><td>xx<td>xx<td>xx
+  </tbody>
+  <tbody>
+    <tr><td>xx<td>xx<td>xx
+  </tbody>
+</table>
+
+<table>
+  <tr class="radius"><td>xx<td>xx<td>xx
+  <tr><td>xx<td>xx<td>xx
+</table>
+
+<table>
+  <colgroup class="radius"><col><col><colgroup><col>
+  <tr><td>xx<td>xx<td>xx
+  <tr><td>xx<td>xx<td>xx
+</table>
+
+<table>
+  <col><col class="radius"><col>
+  <tr><td>xx<td>xx<td>xx
+  <tr><td>xx<td>xx<td>xx
+</table>

--- a/layout/reftests/table-bordercollapse/bug1375518-5.html
+++ b/layout/reftests/table-bordercollapse/bug1375518-5.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<title>border-radius and border-collapse tables</title>
+<style>
+
+body { background: white; color: black }
+
+table { border-collapse: collapse; margin: 1em 2px; }
+td { border: 1px solid black; }
+
+.radius { border: 3px solid teal; background: aqua; color: black; border-radius: 12px }
+
+</style>
+
+<h1>border-radius and border-collapse tables</h1>
+
+<table>
+  <tbody>
+    <tr><td>xx<td>xx<td>xx
+  </tbody>
+  <tbody class="radius">
+    <tr><td>xx<td>xx<td>xx
+    <tr><td>xx<td>xx<td>xx
+  </tbody>
+  <tbody>
+    <tr><td>xx<td>xx<td>xx
+  </tbody>
+</table>
+
+<table>
+  <tr class="radius"><td>xx<td>xx<td>xx
+  <tr><td>xx<td>xx<td>xx
+</table>
+
+<table>
+  <colgroup class="radius"><col><col><colgroup><col>
+  <tr><td>xx<td>xx<td>xx
+  <tr><td>xx<td>xx<td>xx
+</table>
+
+<table>
+  <col><col class="radius"><col>
+  <tr><td>xx<td>xx<td>xx
+  <tr><td>xx<td>xx<td>xx
+</table>

--- a/layout/reftests/table-bordercollapse/bug1375518-ref.html
+++ b/layout/reftests/table-bordercollapse/bug1375518-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Table border collapse</title>
+<style>
+  div {
+    background-color: black;
+    height: 100px;
+    width: 100px;
+    border-radius: 50px;
+  }
+</style>
+</head>
+<body>
+  <div></div>
+</body>
+</html>

--- a/layout/reftests/table-bordercollapse/bug1375518.html
+++ b/layout/reftests/table-bordercollapse/bug1375518.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Table border collapse</title>
+<style>
+  table {
+    border-collapse: collapse;
+    height: 100px;
+    width: 100px;
+  }
+  td {
+    background-color: black;
+    border-radius: 50px;
+  }
+</style>
+</head>
+<body>
+  <table>
+    <tr>
+      <td></td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/layout/reftests/table-bordercollapse/reftest.list
+++ b/layout/reftests/table-bordercollapse/reftest.list
@@ -1,3 +1,8 @@
+== bug1375518.html bug1375518-ref.html
+== bug1375518-2.html bug1375518-ref.html
+== bug1375518-3.html bug1375518-ref.html
+== bug1375518-4.html bug1375518-4-ref.html
+== bug1375518-5.html bug1375518-5-ref.html
 == bc_dyn_cell1.html bc_dyn_cell1_ref.html
 == bc_dyn_cell2.html bc_dyn_cell2_ref.html
 == bc_dyn_cell3.html bc_dyn_cell3_ref.html

--- a/layout/tables/nsTableCellFrame.cpp
+++ b/layout/tables/nsTableCellFrame.cpp
@@ -1108,18 +1108,6 @@ nsBCTableCellFrame::GetUsedBorder() const
   return GetBorderWidth(wm).GetPhysicalMargin(wm);
 }
 
-/* virtual */ bool
-nsBCTableCellFrame::GetBorderRadii(const nsSize& aFrameSize,
-                                   const nsSize& aBorderArea,
-                                   Sides aSkipSides,
-                                   nscoord aRadii[8]) const
-{
-  NS_FOR_CSS_HALF_CORNERS(corner) {
-    aRadii[corner] = 0;
-  }
-  return false;
-}
-
 #ifdef DEBUG_FRAME_DUMP
 nsresult
 nsBCTableCellFrame::GetFrameName(nsAString& aResult) const

--- a/layout/tables/nsTableCellFrame.h
+++ b/layout/tables/nsTableCellFrame.h
@@ -340,10 +340,6 @@ public:
   virtual nsIAtom* GetType() const override;
 
   virtual nsMargin GetUsedBorder() const override;
-  virtual bool GetBorderRadii(const nsSize& aFrameSize,
-                              const nsSize& aBorderArea,
-                              Sides aSkipSides,
-                              nscoord aRadii[8]) const override;
 
   // Get the *inner half of the border only*, in twips.
   virtual LogicalMargin GetBorderWidth(WritingMode aWM) const override;


### PR DESCRIPTION
Resolves #1545 

Based to https://bugzilla.mozilla.org/show_bug.cgi?id=1375518

Steps to reproduce:

Apply border-radius to an element displayed as table-cell, contained within a border-collapsed table-row element.

https://bug1375518.bmoattachments.org/attachment.cgi?id=8883713

Results before PR:

The border-radius doesn't apply.

Results with PR:

The border radius applies.