### PR TITLE
Correct z-ordering for some table parts

### DIFF
--- a/layout/reftests/table-bordercollapse/bug1394226-notref.html
+++ b/layout/reftests/table-bordercollapse/bug1394226-notref.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Table border collapse</title>
+<style>
+  table {
+    border-collapse: collapse;
+  }
+  tr.odd {
+    background-color: LightCyan;
+  }
+  tr.even {
+    background-color: LightSkyBlue;
+  }
+  td {
+    border: 5px solid DarkBlue;
+  }
+  .inner td {
+    border: 5px solid red;
+  }
+  .inner tr:first-child td {
+    border-top: 5px solid DarkBlue;
+  }
+  .inner tr td:first-child {
+    border-left: 5px solid DarkBlue;
+  }
+  .inner tr:last-child td {
+    border-bottom: 5px solid DarkBlue;
+  }
+  .inner tr td:last-child {
+    border-right: 5px solid DarkBlue;
+  }
+  div {
+    height: 10px;
+  }
+</style>
+</head>
+<body>
+  <div></div>
+  <table>
+    <caption></caption>
+    <tr class="odd">
+      <td>Cell 1-1</td>
+      <td>Cell 1-2</td>
+    </tr>
+    <tr class="even">
+      <td>Cell 2-1</td>
+      <td>Cell 2-2
+        <table class="inner">
+          <tr class="odd">
+            <td>Cell 2-2/1-1</td>
+            <td>Cell 2-2/1-2</td>
+          </tr>
+          <tr class="even">
+            <td>Cell 2-2/2-1</td>
+            <td>Cell 2-2/2-2</td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/layout/reftests/table-bordercollapse/bug1394226-ref.html
+++ b/layout/reftests/table-bordercollapse/bug1394226-ref.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Table border collapse</title>
+<style>
+  table {
+    border-collapse: collapse;
+  }
+  tr.odd {
+    background-color: LightCyan;
+  }
+  tr.even {
+    background-color: LightSkyBlue;
+  }
+  td {
+    border: 5px solid DarkBlue;
+  }
+  div {
+    height: 10px;
+  }
+</style>
+</head>
+<body>
+  <div></div>
+  <table>
+    <tr class="odd">
+      <td>Cell 1-1</td>
+      <td>Cell 1-2</td>
+    </tr>
+    <tr class="even">
+      <td>Cell 2-1</td>
+      <td>Cell 2-2
+        <table>
+          <tr class="odd">
+            <td>Cell 2-2/1-1</td>
+            <td>Cell 2-2/1-2</td>
+          </tr>
+          <tr class="even">
+            <td>Cell 2-2/2-1</td>
+            <td>Cell 2-2/2-2</td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/layout/reftests/table-bordercollapse/bug1394226.html
+++ b/layout/reftests/table-bordercollapse/bug1394226.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Table border collapse</title>
+<style>
+  table {
+    border-collapse: collapse;
+  }
+  tr.odd {
+    background-color: LightCyan;
+  }
+  tr.even {
+    background-color: LightSkyBlue;
+  }
+  td {
+    border: 5px solid DarkBlue;
+  }
+  caption {
+    height: 10px
+  }
+</style>
+</head>
+<body>
+  <table>
+    <caption></caption>
+    <tr class="odd">
+      <td>Cell 1-1</td>
+      <td>Cell 1-2</td>
+    </tr>
+    <tr class="even">
+      <td>Cell 2-1</td>
+      <td>Cell 2-2
+        <table>
+          <tr class="odd">
+            <td>Cell 2-2/1-1</td>
+            <td>Cell 2-2/1-2</td>
+          </tr>
+          <tr class="even">
+            <td>Cell 2-2/2-1</td>
+            <td>Cell 2-2/2-2</td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/layout/reftests/table-bordercollapse/reftest.list
+++ b/layout/reftests/table-bordercollapse/reftest.list
@@ -3,6 +3,8 @@
 == bug1375518-3.html bug1375518-ref.html
 == bug1375518-4.html bug1375518-4-ref.html
 == bug1375518-5.html bug1375518-5-ref.html
+== bug1394226.html bug1394226-ref.html
+!= bug1394226.html bug1394226-notref.html
 == bc_dyn_cell1.html bc_dyn_cell1_ref.html
 == bc_dyn_cell2.html bc_dyn_cell2_ref.html
 == bc_dyn_cell3.html bc_dyn_cell3_ref.html

--- a/layout/tables/nsTableWrapperFrame.cpp
+++ b/layout/tables/nsTableWrapperFrame.cpp
@@ -187,8 +187,11 @@ nsTableWrapperFrame::BuildDisplayList(nsDisplayListBuilder*   aBuilder,
   BuildDisplayListForChild(aBuilder, mCaptionFrames.FirstChild(), captionSet);
 
   // Now we have to sort everything by content order, since the caption
-  // may be somewhere inside the table
-  set.BlockBorderBackgrounds()->SortByContentOrder(GetContent());
+  // may be somewhere inside the table.
+  // We don't sort BlockBorderBackgrounds and BorderBackgrounds because the
+  // display items in those lists should stay out of content order in order to
+  // follow the rules in https://www.w3.org/TR/CSS21/zindex.html#painting-order
+  // and paint the caption background after all of the rest.
   set.Floats()->SortByContentOrder(GetContent());
   set.Content()->SortByContentOrder(GetContent());
   set.PositionedDescendants()->SortByContentOrder(GetContent());


### PR DESCRIPTION
Resolves  #1547

Based to https://bugzilla.mozilla.org/show_bug.cgi?id=1394226

Steps to reproduce:

A table is nested inside another table.
The borders of all tables are collapsed.
All rows have a background color.
All cells have a border.
The outer table has a caption.

https://bug1394226.bmoattachments.org/attachment.cgi?id=8901571

Results before PR:

The borders of the cells of the inner table are not visible if the outer table has a caption.

Results with PR:

The borders of the cells of the inner table are visible even if the outer table has a caption.