### PR TITLE
Deunify editor

### DIFF
--- a/editor/composer/moz.build
+++ b/editor/composer/moz.build
@@ -14,7 +14,7 @@ XPIDL_SOURCES += [
 
 XPIDL_MODULE = 'composer'
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'nsComposerCommands.cpp',
     'nsComposerCommandsUpdater.cpp',
     'nsComposerController.cpp',

--- a/editor/composer/nsEditingSession.h
+++ b/editor/composer/nsEditingSession.h
@@ -27,6 +27,7 @@
 
 #include "nsString.h"                   // for nsCString
 
+class nsPIDOMWindowOuter;
 class mozIDOMWindowProxy;
 class nsIDOMWindow;
 class nsISupports;

--- a/editor/libeditor/HTMLEditorDataTransfer.cpp
+++ b/editor/libeditor/HTMLEditorDataTransfer.cpp
@@ -9,6 +9,7 @@
 #include <string.h>
 
 #include "HTMLEditUtils.h"
+#include "TextEditRules.h"
 #include "TextEditUtils.h"
 #include "WSRunObject.h"
 #include "mozilla/dom/DataTransfer.h"

--- a/editor/libeditor/HTMLStyleEditor.cpp
+++ b/editor/libeditor/HTMLStyleEditor.cpp
@@ -6,6 +6,7 @@
 #include "mozilla/HTMLEditor.h"
 
 #include "HTMLEditUtils.h"
+#include "TextEditRules.h"
 #include "TextEditUtils.h"
 #include "TypeInState.h"
 #include "mozilla/Assertions.h"

--- a/editor/libeditor/moz.build
+++ b/editor/libeditor/moz.build
@@ -30,7 +30,7 @@ EXPORTS.mozilla += [
     'TextEditRules.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'ChangeAttributeTransaction.cpp',
     'ChangeStyleTransaction.cpp',
     'CompositionTransaction.cpp',

--- a/editor/txmgr/moz.build
+++ b/editor/txmgr/moz.build
@@ -19,7 +19,7 @@ EXPORTS += [
     'nsTransactionManagerCID.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'nsTransactionItem.cpp',
     'nsTransactionList.cpp',
     'nsTransactionManager.cpp',

--- a/editor/txtsvc/moz.build
+++ b/editor/txtsvc/moz.build
@@ -18,7 +18,7 @@ EXPORTS += [
     'nsTextServicesCID.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'nsFilteredContentIterator.cpp',
     'nsTextServicesDocument.cpp',
 ]


### PR DESCRIPTION
This removes unified building from /editor.

Tested with Basilisk/Win64 and Pale Moon/Linux64 (gcc7)
Ping @g4jc @athenian200 for non-standard build environments.
Ping @adeshkp for Mac.
I don't think this will cause any issues anywhere, it's not as much of a mess as other parts of the tree.

Tag #80 