### PR TITLE
Deunify netwerk

### DIFF
--- a/netwerk/base/PollableEvent.cpp
+++ b/netwerk/base/PollableEvent.cpp
@@ -9,6 +9,7 @@
 #include "mozilla/Assertions.h"
 #include "mozilla/DebugOnly.h"
 #include "mozilla/Logging.h"
+#include "mozilla/net/DNS.h"
 #include "prerror.h"
 #include "prio.h"
 #include "private/pprio.h"
@@ -20,6 +21,8 @@
 #include <fcntl.h>
 #define USEPIPE 1
 #endif
+
+using namespace mozilla::net;
 
 namespace mozilla {
 namespace net {

--- a/netwerk/base/Predictor.cpp
+++ b/netwerk/base/Predictor.cpp
@@ -35,6 +35,7 @@
 #include "nsStreamUtils.h"
 #include "nsString.h"
 #include "nsThreadUtils.h"
+#include "nsHttpRequestHead.h"
 #include "mozilla/Logging.h"
 
 #include "mozilla/Preferences.h"
@@ -51,6 +52,7 @@
 #include "mozilla/dom/ContentParent.h"
 
 using namespace mozilla;
+using namespace mozilla::dom;
 
 namespace mozilla {
 namespace net {

--- a/netwerk/base/ProxyAutoConfig.cpp
+++ b/netwerk/base/ProxyAutoConfig.cpp
@@ -16,6 +16,7 @@
 #include "jsfriendapi.h"
 #include "prnetdb.h"
 #include "nsITimer.h"
+#include "mozilla/Mutex.h"
 #include "mozilla/net/DNS.h"
 #include "nsServiceManagerUtils.h"
 #include "nsNetCID.h"

--- a/netwerk/base/ThrottleQueue.cpp
+++ b/netwerk/base/ThrottleQueue.cpp
@@ -6,6 +6,7 @@
 
 #include "ThrottleQueue.h"
 #include "nsISeekableStream.h"
+#include "nsIEventTarget.h"
 #include "nsIAsyncInputStream.h"
 #include "nsStreamUtils.h"
 #include "nsNetUtil.h"

--- a/netwerk/base/ThrottleQueue.h
+++ b/netwerk/base/ThrottleQueue.h
@@ -8,8 +8,10 @@
 #define mozilla_net_ThrottleQueue_h
 
 #include "mozilla/TimeStamp.h"
+#include "nsCOMPtr.h"
 #include "nsIThrottledInputChannel.h"
 #include "nsITimer.h"
+#include "nsTArray.h"
 
 namespace mozilla {
 namespace net {

--- a/netwerk/base/moz.build
+++ b/netwerk/base/moz.build
@@ -182,7 +182,7 @@ EXPORTS.mozilla.net += [
     'ReferrerPolicy.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'ArrayBufferInputStream.cpp',
     'BackgroundFileSaver.cpp',
     'CaptivePortalService.cpp',

--- a/netwerk/base/nsAsyncStreamCopier.cpp
+++ b/netwerk/base/nsAsyncStreamCopier.cpp
@@ -14,6 +14,7 @@
 #include "mozilla/Logging.h"
 
 using namespace mozilla;
+using namespace mozilla::net;
 
 #undef LOG
 //

--- a/netwerk/base/nsBaseChannel.cpp
+++ b/netwerk/base/nsBaseChannel.cpp
@@ -21,8 +21,11 @@
 #include "nsProxyRelease.h"
 #include "nsXULAppAPI.h"
 #include "nsContentSecurityManager.h"
-#include "LoadInfo.h"
+#include "mozilla/LoadInfo.h"
 #include "nsServiceManagerUtils.h"
+
+using namespace mozilla;
+using namespace mozilla::net;
 
 // This class is used to suspend a request across a function scope.
 class ScopedRequestSuspender {
@@ -87,7 +90,7 @@ nsBaseChannel::Redirect(nsIChannel *newChannel, uint32_t redirectFlags,
     nsSecurityFlags secFlags = mLoadInfo->GetSecurityFlags() &
                                ~nsILoadInfo::SEC_FORCE_INHERIT_PRINCIPAL;
     nsCOMPtr<nsILoadInfo> newLoadInfo =
-      static_cast<mozilla::LoadInfo*>(mLoadInfo.get())->CloneWithNewSecFlags(secFlags);
+      static_cast<LoadInfo*>(mLoadInfo.get())->CloneWithNewSecFlags(secFlags);
 
     nsCOMPtr<nsIPrincipal> uriPrincipal;
     nsIScriptSecurityManager *sm = nsContentUtils::GetSecurityManager();

--- a/netwerk/base/nsChannelClassifier.cpp
+++ b/netwerk/base/nsChannelClassifier.cpp
@@ -17,6 +17,7 @@
 #include "nsIDOMDocument.h"
 #include "nsIHttpChannelInternal.h"
 #include "nsIIOService.h"
+#include "nsILoadContext.h"
 #include "nsIParentChannel.h"
 #include "nsIPermissionManager.h"
 #include "nsIPrivateBrowsingTrackingProtectionWhitelist.h"

--- a/netwerk/base/nsInputStreamPump.cpp
+++ b/netwerk/base/nsInputStreamPump.cpp
@@ -19,6 +19,9 @@
 #include "nsNetCID.h"
 #include <algorithm>
 
+using namespace mozilla;
+using namespace mozilla::net;
+
 static NS_DEFINE_CID(kStreamTransportServiceCID, NS_STREAMTRANSPORTSERVICE_CID);
 
 //

--- a/netwerk/base/nsMIMEInputStream.cpp
+++ b/netwerk/base/nsMIMEInputStream.cpp
@@ -24,6 +24,7 @@
 
 using namespace mozilla::ipc;
 using mozilla::Maybe;
+using mozilla::Nothing;
 
 class nsMIMEInputStream : public nsIMIMEInputStream,
                           public nsISeekableStream,

--- a/netwerk/base/nsStandardURL.cpp
+++ b/netwerk/base/nsStandardURL.cpp
@@ -26,6 +26,7 @@
 #include "nsContentUtils.h"
 #include "prprf.h"
 #include "nsReadableUtils.h"
+#include "nsPrintfCString.h"
 
 using mozilla::dom::EncodingUtils;
 using namespace mozilla::ipc;

--- a/netwerk/base/nsSyncStreamListener.cpp
+++ b/netwerk/base/nsSyncStreamListener.cpp
@@ -8,6 +8,8 @@
 #include "nsThreadUtils.h"
 #include <algorithm>
 
+using namespace mozilla::net;
+
 nsresult
 nsSyncStreamListener::Init()
 {

--- a/netwerk/base/nsTemporaryFileInputStream.cpp
+++ b/netwerk/base/nsTemporaryFileInputStream.cpp
@@ -4,8 +4,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "nsTemporaryFileInputStream.h"
+
+#include "mozilla/ipc/InputStreamUtils.h"
+#include "mozilla/Mutex.h"
 #include "nsStreamUtils.h"
+#include "private/pprio.h"
 #include <algorithm>
+
+using namespace mozilla;
+using namespace mozilla::ipc;
 
 typedef mozilla::ipc::FileDescriptor::PlatformHandleType FileHandleType;
 

--- a/netwerk/cache/moz.build
+++ b/netwerk/cache/moz.build
@@ -21,7 +21,7 @@ EXPORTS += [
     'nsDeleteDir.h'
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'nsApplicationCacheService.cpp',
     'nsCache.cpp',
     'nsCacheEntry.cpp',

--- a/netwerk/cache/nsDiskCacheDeviceSQL.cpp
+++ b/netwerk/cache/nsDiskCacheDeviceSQL.cpp
@@ -10,6 +10,7 @@
 #include "mozilla/Attributes.h"
 #include "mozilla/Sprintf.h"
 #include "mozilla/ThreadLocal.h"
+#include "mozilla/Unused.h"
 
 #include "nsCache.h"
 #include "nsDiskCache.h"
@@ -57,6 +58,7 @@ using namespace mozilla::storage;
 using mozilla::NeckoOriginAttributes;
 
 static const char OFFLINE_CACHE_DEVICE_ID[] = { "offline" };
+static NS_DEFINE_CID(kCacheServiceCID, NS_CACHESERVICE_CID);
 
 #define LOG(args) CACHE_LOG_DEBUG(args)
 

--- a/netwerk/cache2/CacheFile.h
+++ b/netwerk/cache2/CacheFile.h
@@ -10,6 +10,7 @@
 #include "CacheFileMetadata.h"
 #include "nsRefPtrHashtable.h"
 #include "nsClassHashtable.h"
+#include "nsICacheEntry.h"
 #include "mozilla/Mutex.h"
 
 class nsIInputStream;

--- a/netwerk/cache2/CacheFileContextEvictor.cpp
+++ b/netwerk/cache2/CacheFileContextEvictor.cpp
@@ -8,6 +8,7 @@
 #include "CacheIndex.h"
 #include "CacheIndexIterator.h"
 #include "CacheFileUtils.h"
+#include "CacheObserver.h"
 #include "nsIFile.h"
 #include "LoadContextInfo.h"
 #include "nsThreadUtils.h"

--- a/netwerk/cache2/CacheFileUtils.cpp
+++ b/netwerk/cache2/CacheFileUtils.cpp
@@ -5,6 +5,7 @@
 #include "CacheIndex.h"
 #include "CacheLog.h"
 #include "CacheFileUtils.h"
+#include "CacheObserver.h"
 #include "LoadContextInfo.h"
 #include "mozilla/Tokenizer.h"
 #include "nsCOMPtr.h"

--- a/netwerk/cache2/CacheHashUtils.cpp
+++ b/netwerk/cache2/CacheHashUtils.cpp
@@ -6,6 +6,7 @@
 
 #include "mozilla/BasePrincipal.h"
 #include "plstr.h"
+#include "mozilla/SHA1.h"
 
 namespace mozilla {
 namespace net {

--- a/netwerk/cache2/CacheIOThread.cpp
+++ b/netwerk/cache2/CacheIOThread.cpp
@@ -4,6 +4,8 @@
 
 #include "CacheIOThread.h"
 #include "CacheFileIOManager.h"
+#include "CacheObserver.h"
+#include "CacheLog.h"
 
 #include "nsIRunnable.h"
 #include "nsISupportsImpl.h"

--- a/netwerk/cache2/moz.build
+++ b/netwerk/cache2/moz.build
@@ -21,7 +21,8 @@ EXPORTS += [
     'CacheStorageService.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
+    'AppCacheStorage.cpp',
     'CacheEntry.cpp',
     'CacheFile.cpp',
     'CacheFileChunk.cpp',
@@ -41,11 +42,6 @@ UNIFIED_SOURCES += [
     'CacheStorage.cpp',
     'CacheStorageService.cpp',
     'OldWrappers.cpp',
-]
-
-# AppCacheStorage.cpp cannot be built in unified mode because it uses plarena.h.
-SOURCES += [
-    'AppCacheStorage.cpp',
 ]
 
 LOCAL_INCLUDES += [

--- a/netwerk/cookie/moz.build
+++ b/netwerk/cookie/moz.build
@@ -21,13 +21,10 @@ if CONFIG['NECKO_COOKIES']:
         'CookieServiceChild.h',
         'CookieServiceParent.h',
     ]
-    UNIFIED_SOURCES += [
+    SOURCES += [
         'CookieServiceChild.cpp',
         'CookieServiceParent.cpp',
         'nsCookie.cpp',
-    ]
-    # nsCookieService.cpp can't be unified because of symbol conflicts
-    SOURCES += [
         'nsCookieService.cpp',
     ]
     LOCAL_INCLUDES += [

--- a/netwerk/dns/mdns/libmdns/moz.build
+++ b/netwerk/dns/mdns/libmdns/moz.build
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'cocoa':
-    UNIFIED_SOURCES += [
+    SOURCES += [
         'MDNSResponderOperator.cpp',
         'MDNSResponderReply.cpp',
         'nsDNSServiceDiscovery.cpp',
@@ -31,7 +31,7 @@ else:
         'fallback/MulticastDNS.jsm',
     ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'nsDNSServiceInfo.cpp',
     'nsMulticastDNSModule.cpp',
 ]

--- a/netwerk/dns/moz.build
+++ b/netwerk/dns/moz.build
@@ -29,11 +29,6 @@ EXPORTS.mozilla.net += [
 ]
 
 SOURCES += [
-    'nsEffectiveTLDService.cpp', # Excluded from UNIFIED_SOURCES due to special build flags.
-    'nsHostResolver.cpp', # Redefines LOG
-]
-
-UNIFIED_SOURCES += [
     'ChildDNSService.cpp',
     'DNS.cpp',
     'DNSListenerProxy.cpp',
@@ -41,6 +36,8 @@ UNIFIED_SOURCES += [
     'DNSRequestParent.cpp',
     'GetAddrInfo.cpp',
     'nsDNSService2.cpp',
+    'nsEffectiveTLDService.cpp',
+    'nsHostResolver.cpp',
     'nsIDNService.cpp',
     'punycode.c',
 ]

--- a/netwerk/ipc/NeckoParent.cpp
+++ b/netwerk/ipc/NeckoParent.cpp
@@ -45,6 +45,8 @@
 #include "nsINetworkPredictor.h"
 #include "nsINetworkPredictorVerifier.h"
 #include "nsISpeculativeConnect.h"
+#include "nsIOService.h"
+#include "mozilla/ipc/URIUtils.h"
 
 using mozilla::DocShellOriginAttributes;
 using mozilla::NeckoOriginAttributes;

--- a/netwerk/ipc/moz.build
+++ b/netwerk/ipc/moz.build
@@ -12,7 +12,7 @@ EXPORTS.mozilla.net += [
     'NeckoParent.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'ChannelEventQueue.cpp',
     'NeckoChild.cpp',
     'NeckoCommon.cpp',

--- a/netwerk/protocol/about/moz.build
+++ b/netwerk/protocol/about/moz.build
@@ -14,7 +14,7 @@ EXPORTS += [
     'nsAboutProtocolUtils.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'nsAboutBlank.cpp',
     'nsAboutCache.cpp',
     'nsAboutCacheEntry.cpp',

--- a/netwerk/protocol/about/nsAboutCache.h
+++ b/netwerk/protocol/about/nsAboutCache.h
@@ -9,6 +9,7 @@
 #include "nsIAboutModule.h"
 #include "nsICacheStorageVisitor.h"
 #include "nsICacheStorage.h"
+#include "nsIChannel.h"
 
 #include "nsString.h"
 #include "nsIOutputStream.h"

--- a/netwerk/protocol/about/nsAboutCacheEntry.h
+++ b/netwerk/protocol/about/nsAboutCacheEntry.h
@@ -9,6 +9,7 @@
 #include "nsIAboutModule.h"
 #include "nsICacheEntryOpenCallback.h"
 #include "nsICacheEntry.h"
+#include "nsIChannel.h"
 #include "nsIStreamListener.h"
 #include "nsString.h"
 #include "nsCOMPtr.h"

--- a/netwerk/protocol/about/nsAboutProtocolHandler.cpp
+++ b/netwerk/protocol/about/nsAboutProtocolHandler.cpp
@@ -20,6 +20,7 @@
 #include "nsIWritablePropertyBag2.h"
 #include "nsIChannel.h"
 #include "nsIScriptError.h"
+#include "nsContentUtils.h"
 
 namespace mozilla {
 namespace net {

--- a/netwerk/protocol/data/moz.build
+++ b/netwerk/protocol/data/moz.build
@@ -8,7 +8,7 @@ EXPORTS.mozilla.net += [
     'DataChannelParent.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'DataChannelChild.cpp',
     'DataChannelParent.cpp',
     'nsDataChannel.cpp',

--- a/netwerk/protocol/data/nsDataChannel.cpp
+++ b/netwerk/protocol/data/nsDataChannel.cpp
@@ -16,6 +16,7 @@
 #include "nsEscape.h"
 
 using namespace mozilla;
+using namespace mozilla::net;
 
 nsresult
 nsDataChannel::OpenContentStream(bool async, nsIInputStream **result,

--- a/netwerk/protocol/device/moz.build
+++ b/netwerk/protocol/device/moz.build
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'nsDeviceChannel.cpp',
     'nsDeviceProtocolHandler.cpp',
 ]

--- a/netwerk/protocol/file/moz.build
+++ b/netwerk/protocol/file/moz.build
@@ -15,7 +15,7 @@ XPIDL_SOURCES += [
 
 XPIDL_MODULE = 'necko_file'
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'nsFileChannel.cpp',
     'nsFileProtocolHandler.cpp',
 ]

--- a/netwerk/protocol/file/nsFileProtocolHandler.cpp
+++ b/netwerk/protocol/file/nsFileProtocolHandler.cpp
@@ -28,6 +28,8 @@
 #define DESKTOP_ENTRY_SECTION "Desktop Entry"
 #endif
 
+using namespace mozilla::net;
+
 //-----------------------------------------------------------------------------
 
 nsFileProtocolHandler::nsFileProtocolHandler()

--- a/netwerk/protocol/ftp/moz.build
+++ b/netwerk/protocol/ftp/moz.build
@@ -20,7 +20,7 @@ EXPORTS.mozilla.net += [
     'FTPChannelParent.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'FTPChannelChild.cpp',
     'FTPChannelParent.cpp',
     'nsFTPChannel.cpp',

--- a/netwerk/protocol/ftp/nsFTPChannel.cpp
+++ b/netwerk/protocol/ftp/nsFTPChannel.cpp
@@ -14,6 +14,9 @@ using namespace mozilla;
 using namespace mozilla::net;
 extern LazyLogModule gFTPLog;
 
+#undef LOG
+#define LOG(args) MOZ_LOG(gFTPLog, mozilla::LogLevel::Debug, args)
+
 // There are two transport connections established for an 
 // ftp connection. One is used for the command channel , and
 // the other for the data channel. The command channel is the first

--- a/netwerk/protocol/ftp/nsFTPChannel.h
+++ b/netwerk/protocol/ftp/nsFTPChannel.h
@@ -18,6 +18,7 @@
 #include "nsIProxyInfo.h"
 #include "nsIProxiedChannel.h"
 #include "nsIResumableChannel.h"
+#include "ADivertableParentChannel.h"
 
 class nsIURI;
 using mozilla::net::ADivertableParentChannel;

--- a/netwerk/protocol/http/Http2Push.cpp
+++ b/netwerk/protocol/http/Http2Push.cpp
@@ -19,6 +19,7 @@
 #include "nsHttpChannel.h"
 #include "nsIHttpPushListener.h"
 #include "nsString.h"
+#include "nsSocketTransportService2.h"
 
 namespace mozilla {
 namespace net {

--- a/netwerk/protocol/http/HttpBaseChannel.cpp
+++ b/netwerk/protocol/http/HttpBaseChannel.cpp
@@ -11,6 +11,7 @@
 #include "mozilla/net/HttpBaseChannel.h"
 
 #include "nsHttpHandler.h"
+#include "nsHttpChannel.h"
 #include "nsMimeTypes.h"
 #include "nsNetCID.h"
 #include "nsNetUtil.h"

--- a/netwerk/protocol/http/HttpChannelChild.cpp
+++ b/netwerk/protocol/http/HttpChannelChild.cpp
@@ -18,6 +18,7 @@
 #include "mozilla/net/NeckoChild.h"
 #include "mozilla/net/HttpChannelChild.h"
 
+#include "AltDataOutputStreamChild.h"
 #include "nsISupportsPrimitives.h"
 #include "nsChannelClassifier.h"
 #include "nsStringStream.h"

--- a/netwerk/protocol/http/HttpChannelParent.cpp
+++ b/netwerk/protocol/http/HttpChannelParent.cpp
@@ -24,6 +24,7 @@
 #include "nsIAssociatedContentSecurity.h"
 #include "nsIApplicationCacheService.h"
 #include "mozilla/ipc/InputStreamUtils.h"
+#include "mozilla/ipc/IPCStreamUtils.h"
 #include "mozilla/ipc/URIUtils.h"
 #include "SerializedLoadContext.h"
 #include "nsIAuthInformation.h"
@@ -40,6 +41,8 @@
 #include "nsIWindowWatcher.h"
 #include "nsIDocument.h"
 #include "nsStringStream.h"
+#include "nsIStorageStream.h"
+#include "nsStreamUtils.h"
 
 using mozilla::BasePrincipal;
 using namespace mozilla::dom;

--- a/netwerk/protocol/http/HttpChannelParentListener.cpp
+++ b/netwerk/protocol/http/HttpChannelParentListener.cpp
@@ -16,6 +16,7 @@
 #include "nsIHttpHeaderVisitor.h"
 #include "nsIRedirectChannelRegistrar.h"
 #include "nsIPromptFactory.h"
+#include "nsIWindowWatcher.h"
 #include "nsQueryObject.h"
 
 using mozilla::Unused;

--- a/netwerk/protocol/http/moz.build
+++ b/netwerk/protocol/http/moz.build
@@ -43,18 +43,11 @@ EXPORTS.mozilla.net += [
     'TimingStruct.h',
 ]
 
-# ASpdySession.cpp and nsHttpAuthCache cannot be built in unified mode because
-# they use plarena.h.
 SOURCES += [
-    'AlternateServices.cpp',
-    'ASpdySession.cpp',
-    'nsHttpAuthCache.cpp',
-    'nsHttpChannelAuthProvider.cpp', # redefines GetAuthType
-]
-
-UNIFIED_SOURCES += [
     'AltDataOutputStreamChild.cpp',
     'AltDataOutputStreamParent.cpp',
+    'AlternateServices.cpp',
+    'ASpdySession.cpp',
     'CacheControlParser.cpp',
     'ConnectionDiagnostics.cpp',
     'Http2Compression.cpp',
@@ -70,14 +63,17 @@ UNIFIED_SOURCES += [
     'nsCORSListenerProxy.cpp',
     'nsHttp.cpp',
     'nsHttpActivityDistributor.cpp',
+    'nsHttpAuthCache.cpp',
     'nsHttpAuthManager.cpp',
     'nsHttpBasicAuth.cpp',
     'nsHttpChannel.cpp',
+    'nsHttpChannelAuthProvider.cpp',
     'nsHttpChunkedDecoder.cpp',
     'nsHttpConnection.cpp',
     'nsHttpConnectionInfo.cpp',
     'nsHttpConnectionMgr.cpp',
     'nsHttpDigestAuth.cpp',
+    'nsHttpHandler.cpp',
     'nsHttpHeaderArray.cpp',
     'nsHttpNTLMAuth.cpp',
     'nsHttpPipeline.cpp',
@@ -87,11 +83,6 @@ UNIFIED_SOURCES += [
     'NullHttpChannel.cpp',
     'NullHttpTransaction.cpp',
     'TunnelUtils.cpp',
-]
-
-# These files cannot be built in unified mode because of OS X headers.
-SOURCES += [
-    'nsHttpHandler.cpp',
 ]
 
 IPDL_SOURCES += [

--- a/netwerk/protocol/http/nsHttpChannel.cpp
+++ b/netwerk/protocol/http/nsHttpChannel.cpp
@@ -24,6 +24,7 @@
 #include "nsICryptoHash.h"
 #include "nsINetworkInterceptController.h"
 #include "nsINSSErrorsService.h"
+#include "nsIScriptError.h"
 #include "nsIStringBundle.h"
 #include "nsIStreamListenerTee.h"
 #include "nsISeekableStream.h"

--- a/netwerk/protocol/http/nsHttpChannel.h
+++ b/netwerk/protocol/http/nsHttpChannel.h
@@ -35,7 +35,10 @@ class nsIHttpChannelAuthProvider;
 class nsInputStreamPump;
 class nsISSLStatus;
 
-namespace mozilla { namespace net {
+namespace mozilla {
+namespace net {
+
+bool WillRedirect(nsHttpResponseHead * response);
 
 class Http2PushedStream;
 

--- a/netwerk/protocol/res/moz.build
+++ b/netwerk/protocol/res/moz.build
@@ -11,7 +11,7 @@ XPIDL_SOURCES += [
 
 XPIDL_MODULE = 'necko_res'
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'ExtensionProtocolHandler.cpp',
     'nsResProtocolHandler.cpp',
     'SubstitutingProtocolHandler.cpp',

--- a/netwerk/protocol/viewsource/moz.build
+++ b/netwerk/protocol/viewsource/moz.build
@@ -10,7 +10,7 @@ XPIDL_SOURCES += [
 
 XPIDL_MODULE = 'necko_viewsource'
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'nsViewSourceChannel.cpp',
     'nsViewSourceHandler.cpp',
 ]

--- a/netwerk/protocol/wyciwyg/moz.build
+++ b/netwerk/protocol/wyciwyg/moz.build
@@ -15,7 +15,7 @@ EXPORTS.mozilla.net += [
     'WyciwygChannelParent.h',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'nsWyciwyg.cpp',
     'nsWyciwygChannel.cpp',
     'nsWyciwygProtocolHandler.cpp',

--- a/netwerk/socket/moz.build
+++ b/netwerk/socket/moz.build
@@ -18,7 +18,7 @@ LOCAL_INCLUDES += [
     '/netwerk/base',
 ]
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'nsSocketProviderService.cpp',
     'nsSOCKSIOLayer.cpp',
     'nsSOCKSSocketProvider.cpp',
@@ -29,7 +29,7 @@ if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'windows':
     XPIDL_SOURCES += [
         'nsINamedPipeService.idl',
     ]
-    UNIFIED_SOURCES += [
+    SOURCES += [
         'nsNamedPipeIOLayer.cpp',
         'nsNamedPipeService.cpp'
     ]

--- a/netwerk/socket/nsSOCKSSocketProvider.cpp
+++ b/netwerk/socket/nsSOCKSSocketProvider.cpp
@@ -12,6 +12,7 @@
 #include "nsError.h"
 
 using mozilla::NeckoOriginAttributes;
+using namespace mozilla::net;
 
 //////////////////////////////////////////////////////////////////////////
 

--- a/netwerk/srtp/src/moz.build
+++ b/netwerk/srtp/src/moz.build
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'crypto/cipher/aes.c',
     'crypto/cipher/aes_cbc.c',
     'crypto/cipher/aes_icm.c',

--- a/netwerk/streamconv/converters/moz.build
+++ b/netwerk/streamconv/converters/moz.build
@@ -10,7 +10,7 @@ XPIDL_SOURCES += [
 
 XPIDL_MODULE = 'necko_http'
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'mozTXTToHTMLConv.cpp',
     'nsDirIndex.cpp',
     'nsDirIndexParser.cpp',
@@ -22,13 +22,13 @@ UNIFIED_SOURCES += [
 ]
 
 if 'ftp' in CONFIG['NECKO_PROTOCOLS']:
-    UNIFIED_SOURCES += [
+    SOURCES += [
         'nsFTPDirListingConv.cpp',
         'ParseFTPList.cpp',
     ]
 
 if CONFIG['MOZ_WIDGET_TOOLKIT'] != 'cocoa':
-    UNIFIED_SOURCES += [
+    SOURCES += [
         'nsBinHexDecoder.cpp',
     ]
 

--- a/netwerk/streamconv/converters/nsHTTPCompressConv.cpp
+++ b/netwerk/streamconv/converters/nsHTTPCompressConv.cpp
@@ -15,8 +15,10 @@
 #include "nsThreadUtils.h"
 #include "mozilla/Preferences.h"
 #include "mozilla/Logging.h"
+#include "mozilla/UniquePtrExtensions.h"
 #include "nsIForcePendingChannel.h"
 #include "nsIRequest.h"
+#include <inttypes.h>
 
 // brotli headers
 #include "state.h"

--- a/netwerk/wifi/moz.build
+++ b/netwerk/wifi/moz.build
@@ -12,16 +12,13 @@ XPIDL_SOURCES += [
 
 XPIDL_MODULE = 'necko_wifi'
 
-UNIFIED_SOURCES += [
+SOURCES += [
     'nsWifiAccessPoint.cpp',
-]
-
-UNIFIED_SOURCES += [
     'nsWifiMonitor.cpp',
 ]
 
 if CONFIG['OS_ARCH'] == 'Darwin':
-    UNIFIED_SOURCES += [
+    SOURCES += [
         'nsWifiScannerMac.cpp',
     ]
     SOURCES += [
@@ -32,23 +29,23 @@ if CONFIG['OS_ARCH'] == 'Darwin':
     # to accept the warnings when targeting the newer SDKs.
     SOURCES['osx_corewlan.mm'].flags += ['-Wno-error=objc-method-access']
 elif CONFIG['OS_ARCH'] in ('DragonFly', 'FreeBSD'):
-    UNIFIED_SOURCES += [
+    SOURCES += [
         'nsWifiScannerFreeBSD.cpp',
     ]
 elif CONFIG['OS_ARCH'] == 'WINNT':
-    UNIFIED_SOURCES += [
+    SOURCES += [
         'nsWifiScannerWin.cpp',
         'win_wifiScanner.cpp',
         'win_wlanLibrary.cpp',
     ]
 elif CONFIG['OS_ARCH'] == 'SunOS':
     CXXFLAGS += CONFIG['GLIB_CFLAGS']
-    UNIFIED_SOURCES += [
+    SOURCES += [
         'nsWifiScannerSolaris.cpp',
     ]
 
 if CONFIG['NECKO_WIFI_DBUS']:
-    UNIFIED_SOURCES += [
+    SOURCES += [
         'nsWifiScannerDBus.cpp',
     ]
     CXXFLAGS += ['-Wno-error=shadow']


### PR DESCRIPTION
This de-unifies `/network` and subdirs with the exception of `/netwerk/protocol/websocket` because that's an entangled IPC mess that I wasn't able to figure out within a reasonable amount of time.

Tag #80 

Only tested with Basilisk/Win64. No energy to do the Linux carousel today, maybe y'all can help with that ;)