### PR TITLE
Include MDNSResponderOperator.h in libmdns/nsDNSServiceDiscovery.h for Mac

### DIFF
--- a/netwerk/dns/mdns/libmdns/nsDNSServiceDiscovery.h
+++ b/netwerk/dns/mdns/libmdns/nsDNSServiceDiscovery.h
@@ -6,6 +6,7 @@
 #ifndef mozilla_netwerk_dns_mdns_libmdns_nsDNSServiceDiscovery_h
 #define mozilla_netwerk_dns_mdns_libmdns_nsDNSServiceDiscovery_h
 
+#include "MDNSResponderOperator.h"
 #include "nsIDNSServiceDiscovery.h"
 #include "nsCOMPtr.h"
 #include "mozilla/RefPtr.h"


### PR DESCRIPTION
This is needed for forward declaration of `BrowseOperator` and `RegisterOperator`.

Tag #80 