### PR TITLE
Fix the wrong position when we calculate the position for position:absolute child

### DIFF
--- a/layout/generic/nsAbsoluteContainingBlock.cpp
+++ b/layout/generic/nsAbsoluteContainingBlock.cpp
@@ -658,8 +658,8 @@ nsAbsoluteContainingBlock::ReflowAbsoluteFrame(nsIFrame*                aDelegat
 
   // Get the border values
   WritingMode outerWM = aReflowInput.GetWritingMode();
-  const LogicalMargin border(outerWM,
-                             aReflowInput.mStyleBorder->GetComputedBorder());
+  const LogicalMargin border(outerWM, aDelegatingFrame->GetUsedBorder());
+
   LogicalMargin margin =
     kidReflowInput.ComputedLogicalMargin().ConvertTo(outerWM, wm);
 

--- a/layout/reftests/table-bordercollapse/bug1379306-ref.html
+++ b/layout/reftests/table-bordercollapse/bug1379306-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<title>Table Cell Testcase, bug 1379306</title>
+<style>
+  table.collapse {
+    border-collapse: collapse;
+  }
+  td {
+    border: 20px solid #aaa;
+    width: 120px;
+    height: 150px;
+  }
+  .first {
+    background-color: #000;
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    height: 10px;
+    width: 20px
+  }
+</style>
+<h1>Table Cell Testcase, bug 1379306</h1>
+
+<div style="position: relative;">
+  <table class="collapse">
+    <tr>
+      <td>
+        <div class="first"></div>
+      </td>
+    </tr>
+  </table>
+</div>

--- a/layout/reftests/table-bordercollapse/bug1379306.html
+++ b/layout/reftests/table-bordercollapse/bug1379306.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<title>Table Cell Testcase, bug 1379306</title>
+<style>
+  table.collapse {
+    border-collapse: collapse;
+  }
+  td {
+    border: 20px solid #aaa;
+    width: 120px;
+    height: 150px;
+    position: relative;
+  }
+  div {
+    background-color: #000;
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 10px;
+    width: 20px
+  }
+</style>
+<h1>Table Cell Testcase, bug 1379306</h1>
+
+<table class="collapse">
+  <tr>
+    <td>
+      <div></div>
+    </td>
+  </tr>
+</table>

--- a/layout/reftests/table-bordercollapse/reftest.list
+++ b/layout/reftests/table-bordercollapse/reftest.list
@@ -3,6 +3,7 @@
 == bug1375518-3.html bug1375518-ref.html
 == bug1375518-4.html bug1375518-4-ref.html
 == bug1375518-5.html bug1375518-5-ref.html
+== bug1379306.html bug1379306-ref.html
 == bug1394226.html bug1394226-ref.html
 != bug1394226.html bug1394226-notref.html
 == bc_dyn_cell1.html bc_dyn_cell1_ref.html

--- a/layout/reftests/table-html/bug1379306-2-ref.html
+++ b/layout/reftests/table-html/bug1379306-2-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<title>Table Row Testcase, bug 1379306</title>
+<style>
+
+table { background: yellow }
+td { height: 50px; width: 200px; background: aqua; }
+div { background: fuchsia; height: 10px; width: 20px }
+
+tr { position: relative; border: 30px solid blue; }
+div { position: absolute; top: 0; left: 0 }
+
+</style>
+<h1>Table Row Testcase, bug 1379306</h1>
+
+<table>
+  <tr>
+    <td>
+      <div></div>
+    </td>
+  </tr>
+</table>

--- a/layout/reftests/table-html/bug1379306-2.html
+++ b/layout/reftests/table-html/bug1379306-2.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<title>Testcase, bug 1379306</title>
+<style>
+
+table { background: yellow }
+td { height: 50px; width: 200px; background: aqua; }
+div { background: fuchsia; height: 10px; width: 20px }
+
+tr { position: relative; border: 10px solid blue }
+div { position: absolute; top: 0; left: 0 }
+
+</style>
+<h1>Table Row Testcase, bug 1379306</h1>
+
+<table>
+  <tr>
+    <td>
+      <div></div>
+    </td>
+  </tr>
+</table>

--- a/layout/reftests/table-html/bug1379306-3-ref.html
+++ b/layout/reftests/table-html/bug1379306-3-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<title>Testcase, bug 1379306</title>
+<style>
+
+table { background: yellow }
+td { height: 50px; width: 200px; background: aqua; }
+div { background: fuchsia; height: 10px; width: 20px }
+
+tbody { position: relative; border: 30px solid blue }
+div { position: absolute; top: 0; left: 0 }
+
+</style>
+<h1>Table Row Group Testcase, bug 1379306</h1>
+
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <div></div>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/layout/reftests/table-html/bug1379306-3.html
+++ b/layout/reftests/table-html/bug1379306-3.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<title>Testcase, bug 1379306</title>
+<style>
+
+table { background: yellow }
+td { height: 50px; width: 200px; background: aqua; }
+div { background: fuchsia; height: 10px; width: 20px }
+
+tbody { position: relative; border: 10px solid blue }
+div { position: absolute; top: 0; left: 0 }
+
+</style>
+<h1>Table Row Group Testcase, bug 1379306</h1>
+
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <div></div>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/layout/reftests/table-html/reftest.list
+++ b/layout/reftests/table-html/reftest.list
@@ -1,2 +1,4 @@
 == cell-align-stopped-at-table-1-standards.html cell-align-stopped-at-table-1-standards-ref.html
 == cell-align-stopped-at-table-1-quirks.html cell-align-stopped-at-table-1-quirks-ref.html
+== bug1379306-2.html bug1379306-2-ref.html
+== bug1379306-3.html bug1379306-3-ref.html


### PR DESCRIPTION
Resolves #1575 

Based to https://bugzilla.mozilla.org/show_bug.cgi?id=1379306

Steps to reproduce:

https://codepen.io/vr8088/pen/yLeBVbN

The table is set to "border-collapse: collapse"
A child td has "position: relative" and a non-zero border width
The td contains an element set to "position: absolute"

Results before PR: The element is positioned relative to the td plus a small offset in the x and y directions. The size of this offset seems to depend on the td's border width.

Results with PR: The element with "position: absolute" is positioned relative to the position of the td (= of the first not-static ancestor element).

Also testcases from 1379306, all of those do work with this PR.

@wolfbeast can review this.