### PR TITLE
Add missing MP3Demuxer.h to MediaDecoderReader.h

### DIFF
--- a/dom/media/MediaDecoderReader.h
+++ b/dom/media/MediaDecoderReader.h
@@ -17,6 +17,7 @@
 #include "MediaMetadataManager.h"
 #include "MediaQueue.h"
 #include "MediaTimer.h"
+#include "MP3Demuxer.h"
 #include "AudioCompactor.h"
 #include "Intervals.h"
 #include "TimeUnits.h"


### PR DESCRIPTION
Follow up for dom/media work on Issue #80. Fixes non-optimized build bustage.