### PR TITLE
Kill marquee element; Debug Follow Up

### DIFF
--- a/parser/htmlparser/nsElementTable.cpp
+++ b/parser/htmlparser/nsElementTable.cpp
@@ -110,7 +110,6 @@ static const HTMLElement gHTMLElements[] = {
   ELEM(main,        true, true)
   ELEM(map,         ____, true)
   ELEM(mark,        ____, true)
-  ELEM(marquee,     ____, true)
   ELEM(menu,        true, true)
   ELEM(menuitem,    ____, true)
   ELEM(meta,        ____, ____)


### PR DESCRIPTION
The marquee element was still specified in debug code, causing build to fail without it's removal.