### PR TITLE
Remove no longer existing test headers from WebIDL

### DIFF
--- a/dom/webidl/moz.build
+++ b/dom/webidl/moz.build
@@ -647,10 +647,10 @@ WEBIDL_FILES += [
 # We only expose our prefable test interfaces in debug builds, just to be on
 # the safe side.
 if CONFIG['MOZ_DEBUG']:
-    WEBIDL_FILES += ['TestFunctions.webidl',
-                     'TestInterfaceJS.webidl',
-                     'TestInterfaceJSDictionaries.webidl',
-                     'TestInterfaceJSMaplikeSetlikeIterable.webidl']
+    WEBIDL_FILES += [
+         'TestInterfaceJS.webidl',
+         'TestInterfaceJSDictionaries.webidl',
+    ]
 
 if CONFIG['MOZ_SECUREELEMENT']:
     WEBIDL_FILES += [


### PR DESCRIPTION
Although the headers were removed, they are still referenced in WebIDL causing compiler to fail for debug builds.