### PR TITLE
Remove unnecessary MOZ_ASSERT from widget/gtk/nsNativeMenuService.cpp

### DIFF
--- a/widget/gtk/nsNativeMenuService.cpp
+++ b/widget/gtk/nsNativeMenuService.cpp
@@ -160,7 +160,6 @@ nsNativeMenuService::~nsNativeMenuService() {
         gPangoLayout = nullptr;
     }
 
-    MOZ_ASSERT(sService == this);
     sService = nullptr;
 }
 


### PR DESCRIPTION
Tag #1578 

The `MOZ_ASSERT` was tripping in debug builds, crashing the browser. This isn't included in older versions of the Ubuntu patchset, nor does it cause any issues by NOT having it, so to avoid stability issues it has been removed.