### PR TITLE
Issue #618 - Remove eager instantiation - Debug follow up

### DIFF
--- a/dom/base/nsJSUtils.cpp
+++ b/dom/base/nsJSUtils.cpp
@@ -315,7 +315,8 @@ nsJSUtils::ModuleInstantiate(JSContext* aCx, JS::Handle<JSObject*> aModule)
 
   MOZ_ASSERT(aCx == nsContentUtils::GetCurrentJSContext());
   MOZ_ASSERT(NS_IsMainThread());
-  MOZ_ASSERT(nsContentUtils::IsInMicroTask());
+  MOZ_ASSERT(CycleCollectedJSContext::Get() &&
+             CycleCollectedJSContext::Get()->MicroTaskLevel());
 
   NS_ENSURE_TRUE(xpc::Scriptability::Get(aModule).Allowed(), NS_OK);
 


### PR DESCRIPTION
The added debug assertion did not take into account microtask refactoring done in BZ 1405821.
Resulting in error: no member named 'IsInMicroTask' in 'nsContentUtils'.

This resolves the compiler error.