### PR TITLE
SunOS LDAP cleanup

### DIFF
--- a/ldap/c-sdk/common.mozbuild
+++ b/ldap/c-sdk/common.mozbuild
@@ -17,6 +17,8 @@ elif CONFIG['OS_TARGET'] in ('OpenBSD', 'FreeBSD', 'NetBSD'):
     DEFINES[CONFIG['OS_TARGET'].upper()] = True
 elif CONFIG['OS_ARCH'] == 'WINNT':
     DEFINES['_WINDOWS'] = True
+elif CONFIG['OS_ARCH'] == 'SunOS':
+    DEFINES['__USE_DRAFT6_PROTOTYPES__'] = True
 
 DEFINES['_PR_PTHREADS'] = True
 DEFINES['NET_SSL'] = True

--- a/ldap/c-sdk/include/portable.h
+++ b/ldap/c-sdk/include/portable.h
@@ -59,7 +59,7 @@
  */
 
 #ifndef SYSV
-#if defined( hpux ) || defined( SOLARIS ) || defined ( sgi ) || defined( SVR4 )
+#if defined( hpux ) || defined(XP_SOLARIS) || defined ( sgi ) || defined( SVR4 )
 #define SYSV
 #endif
 #endif
@@ -191,7 +191,7 @@
  */
 #if !defined(NSLDAPI_CONNECT_MUST_NOT_BE_INTERRUPTED) && \
 	( defined(AIX) || defined(IRIX) || defined(HPUX) || defined(SUNOS4) \
-	|| defined(SOLARIS) || defined(OSF1) ||defined(freebsd)) 
+	|| defined(XP_SOLARIS) || defined(OSF1) ||defined(freebsd)) 
 #define NSLDAPI_CONNECT_MUST_NOT_BE_INTERRUPTED
 #endif
 

--- a/ldap/c-sdk/libldap/tmplout.c
+++ b/ldap/c-sdk/libldap/tmplout.c
@@ -43,15 +43,10 @@
 #include "ldap-int.h"
 #include "disptmpl.h"
 
-#if defined(_WINDOWS) || defined(aix) || defined(SCOOS) || defined(OSF1) || defined(SOLARIS)
+#if defined(_WINDOWS) || defined(aix) || defined(SCOOS) || defined(OSF1) || defined(XP_SOLARIS)
 #include <time.h> /* for struct tm and ctime */
 #endif
 
-
-/* This is totally lame, since it should be coming from time.h, but isn't. */
-#if defined(SOLARIS) 
-char *ctime_r(const time_t *, char *, int);
-#endif
 
 static int do_entry2text( LDAP *ld, char *buf, char *base, LDAPMessage *entry,
 	struct ldap_disptmpl *tmpl, char **defattrs, char ***defvals,


### PR DESCRIPTION
I meant to do this a long time ago, but basically it accounts for the new XP_SOLARIS build flag that never made it into the MailNews code. Additionally, it enables a compatibility flag for Solaris 11.4 that allows us to use the three-argument implementation of ctime_r still used by Solaris 11.3 and illumos (which also appears equivalent to the NSLDAPI_CTIME implementation used by libldap internally). Also, the ctime_r function has been added to the time.h header library for a while now, not sure why Mozilla thought we didn't have a ctime_r implementation.

Resolves #1615 