### PR TITLE
Convert Intrinsic Ratio from nsSize to Float

### DIFF
--- a/image/ClippedImage.cpp
+++ b/image/ClippedImage.cpp
@@ -242,13 +242,13 @@ ClippedImage::GetIntrinsicSize(nsSize* aSize)
 }
 
 NS_IMETHODIMP
-ClippedImage::GetIntrinsicRatio(nsSize* aRatio)
+ClippedImage::GetIntrinsicRatio(AspectRatio* aRatio)
 {
   if (!ShouldClip()) {
     return InnerImage()->GetIntrinsicRatio(aRatio);
   }
 
-  *aRatio = nsSize(mClip.width, mClip.height);
+  *aRatio = AspectRatio::FromSize(mClip.width, mClip.height);
   return NS_OK;
 }
 

--- a/image/ClippedImage.h
+++ b/image/ClippedImage.h
@@ -35,7 +35,7 @@ public:
   NS_IMETHOD GetWidth(int32_t* aWidth) override;
   NS_IMETHOD GetHeight(int32_t* aHeight) override;
   NS_IMETHOD GetIntrinsicSize(nsSize* aSize) override;
-  NS_IMETHOD GetIntrinsicRatio(nsSize* aRatio) override;
+  NS_IMETHOD GetIntrinsicRatio(AspectRatio* aRatio) override;
   NS_IMETHOD_(already_AddRefed<SourceSurface>)
     GetFrame(uint32_t aWhichFrame, uint32_t aFlags) override;
   NS_IMETHOD_(already_AddRefed<SourceSurface>)

--- a/image/DynamicImage.cpp
+++ b/image/DynamicImage.cpp
@@ -136,10 +136,10 @@ DynamicImage::GetIntrinsicSize(nsSize* aSize)
 }
 
 NS_IMETHODIMP
-DynamicImage::GetIntrinsicRatio(nsSize* aSize)
+DynamicImage::GetIntrinsicRatio(AspectRatio* aRatio)
 {
-  IntSize intSize(mDrawable->Size());
-  *aSize = nsSize(intSize.width, intSize.height);
+  auto size = mDrawable->Size();
+  *aRatio = AspectRatio::FromSize(size);
   return NS_OK;
 }
 

--- a/image/ImageWrapper.cpp
+++ b/image/ImageWrapper.cpp
@@ -146,9 +146,9 @@ ImageWrapper::GetIntrinsicSize(nsSize* aSize)
 }
 
 NS_IMETHODIMP
-ImageWrapper::GetIntrinsicRatio(nsSize* aSize)
+ImageWrapper::GetIntrinsicRatio(AspectRatio* aRatio)
 {
-  return mInnerImage->GetIntrinsicRatio(aSize);
+  return mInnerImage->GetIntrinsicRatio(aRatio);
 }
 
 NS_IMETHODIMP_(Orientation)

--- a/image/OrientedImage.cpp
+++ b/image/OrientedImage.cpp
@@ -59,12 +59,12 @@ OrientedImage::GetIntrinsicSize(nsSize* aSize)
 }
 
 NS_IMETHODIMP
-OrientedImage::GetIntrinsicRatio(nsSize* aRatio)
+OrientedImage::GetIntrinsicRatio(AspectRatio* aRatio)
 {
   nsresult rv = InnerImage()->GetIntrinsicRatio(aRatio);
 
   if (mOrientation.SwapsWidthAndHeight()) {
-    swap(aRatio->width, aRatio->height);
+    *aRatio = aRatio->Inverted();
   }
 
   return rv;

--- a/image/OrientedImage.h
+++ b/image/OrientedImage.h
@@ -31,7 +31,7 @@ public:
   NS_IMETHOD GetWidth(int32_t* aWidth) override;
   NS_IMETHOD GetHeight(int32_t* aHeight) override;
   NS_IMETHOD GetIntrinsicSize(nsSize* aSize) override;
-  NS_IMETHOD GetIntrinsicRatio(nsSize* aRatio) override;
+  NS_IMETHOD GetIntrinsicRatio(AspectRatio* aRatio) override;
   NS_IMETHOD_(already_AddRefed<SourceSurface>)
     GetFrame(uint32_t aWhichFrame, uint32_t aFlags) override;
   NS_IMETHOD_(already_AddRefed<SourceSurface>)

--- a/image/RasterImage.cpp
+++ b/image/RasterImage.cpp
@@ -240,13 +240,14 @@ RasterImage::GetIntrinsicSize(nsSize* aSize)
 
 //******************************************************************************
 NS_IMETHODIMP
-RasterImage::GetIntrinsicRatio(nsSize* aRatio)
+RasterImage::GetIntrinsicRatio(AspectRatio* aRatio)
 {
   if (mError) {
     return NS_ERROR_FAILURE;
   }
 
-  *aRatio = nsSize(mSize.width, mSize.height);
+  *aRatio = AspectRatio::FromSize(mSize);
+
   return NS_OK;
 }
 

--- a/image/VectorImage.cpp
+++ b/image/VectorImage.cpp
@@ -628,7 +628,7 @@ VectorImage::GetIntrinsicSize(nsSize* aSize)
 
 //******************************************************************************
 NS_IMETHODIMP
-VectorImage::GetIntrinsicRatio(nsSize* aRatio)
+VectorImage::GetIntrinsicRatio(AspectRatio* aRatio)
 {
   if (mError || !mIsFullyLoaded) {
     return NS_ERROR_FAILURE;

--- a/image/imgIContainer.idl
+++ b/image/imgIContainer.idl
@@ -12,6 +12,7 @@
 #include "gfxMatrix.h"
 #include "gfxRect.h"
 #include "mozilla/gfx/2D.h"
+#include "mozilla/AspectRatio.h"
 #include "mozilla/Maybe.h"
 #include "mozilla/RefPtr.h"
 #include "nsRect.h"
@@ -55,6 +56,7 @@ native SamplingFilter(mozilla::gfx::SamplingFilter);
 native nsIntRectByVal(nsIntRect);
 [ref] native nsIntSize(nsIntSize);
 native nsSize(nsSize);
+native AspectRatio(mozilla::AspectRatio);
 [ptr] native nsIFrame(nsIFrame);
 native TempRefImageContainer(already_AddRefed<mozilla::layers::ImageContainer>);
 [ref] native ImageRegion(mozilla::image::ImageRegion);
@@ -101,7 +103,7 @@ interface imgIContainer : nsISupports
    * The (dimensionless) intrinsic ratio of this image. In the case of any
    * error, an exception will be thrown.
    */
-  [noscript] readonly attribute nsSize intrinsicRatio;
+  [noscript] readonly attribute AspectRatio intrinsicRatio;
 
   /**
    * Given a size at which this image will be displayed, and the drawing

--- a/layout/base/nsCSSRendering.cpp
+++ b/layout/base/nsCSSRendering.cpp
@@ -3546,10 +3546,10 @@ ComputeDrawnSizeForBackground(const CSSSizeOrRatio& aIntrinsicSize,
     imageSize.width = ComputeRoundedSize(imageSize.width, aBgPositioningArea.width);
     if (!isRepeatRoundInBothDimensions &&
         aLayerSize.mHeightType == nsStyleImageLayers::Size::DimensionType::eAuto) {
-      // Restore intrinsic rato
-      if (aIntrinsicSize.mRatio.width) {
-        float scale = float(aIntrinsicSize.mRatio.height) / aIntrinsicSize.mRatio.width;
-        imageSize.height = NSCoordSaturatingNonnegativeMultiply(imageSize.width, scale);
+      // Restore intrinsic ratio
+      if (aIntrinsicSize.mRatio) {
+        imageSize.height =
+            aIntrinsicSize.mRatio.Inverted().ApplyTo(imageSize.width);
       }
     }
   }
@@ -3560,10 +3560,9 @@ ComputeDrawnSizeForBackground(const CSSSizeOrRatio& aIntrinsicSize,
     imageSize.height = ComputeRoundedSize(imageSize.height, aBgPositioningArea.height);
     if (!isRepeatRoundInBothDimensions &&
         aLayerSize.mWidthType == nsStyleImageLayers::Size::DimensionType::eAuto) {
-      // Restore intrinsic rato
-      if (aIntrinsicSize.mRatio.height) {
-        float scale = float(aIntrinsicSize.mRatio.width) / aIntrinsicSize.mRatio.height;
-        imageSize.width = NSCoordSaturatingNonnegativeMultiply(imageSize.height, scale);
+      // Restore intrinsic ratio
+      if (aIntrinsicSize.mRatio) {
+        imageSize.width = aIntrinsicSize.mRatio.ApplyTo(imageSize.height);
       }
     }
   }
@@ -5264,17 +5263,11 @@ CSSSizeOrRatio::ComputeConcreteSize() const
     return nsSize(mWidth, mHeight);
   }
   if (mHasWidth) {
-    nscoord height = NSCoordSaturatingNonnegativeMultiply(
-      mWidth,
-      double(mRatio.height) / mRatio.width);
-    return nsSize(mWidth, height);
+    return nsSize(mWidth, mRatio.Inverted().ApplyTo(mWidth));
   }
 
   MOZ_ASSERT(mHasHeight);
-  nscoord width = NSCoordSaturatingNonnegativeMultiply(
-    mHeight,
-    double(mRatio.width) / mRatio.height);
-  return nsSize(width, mHeight);
+  return nsSize(mRatio.ApplyTo(mHeight), mHeight);
 }
 
 CSSSizeOrRatio
@@ -5379,9 +5372,7 @@ nsImageRenderer::ComputeConcreteSize(const CSSSizeOrRatio& aSpecifiedSize,
   if (aSpecifiedSize.mHasWidth) {
     nscoord height;
     if (aIntrinsicSize.HasRatio()) {
-      height = NSCoordSaturatingNonnegativeMultiply(
-        aSpecifiedSize.mWidth,
-        double(aIntrinsicSize.mRatio.height) / aIntrinsicSize.mRatio.width);
+      height = aIntrinsicSize.mRatio.Inverted().ApplyTo(aSpecifiedSize.mWidth);
     } else if (aIntrinsicSize.mHasHeight) {
       height = aIntrinsicSize.mHeight;
     } else {
@@ -5393,9 +5384,7 @@ nsImageRenderer::ComputeConcreteSize(const CSSSizeOrRatio& aSpecifiedSize,
   MOZ_ASSERT(aSpecifiedSize.mHasHeight);
   nscoord width;
   if (aIntrinsicSize.HasRatio()) {
-    width = NSCoordSaturatingNonnegativeMultiply(
-      aSpecifiedSize.mHeight,
-      double(aIntrinsicSize.mRatio.width) / aIntrinsicSize.mRatio.height);
+    width = aIntrinsicSize.mRatio.ApplyTo(aSpecifiedSize.mHeight);
   } else if (aIntrinsicSize.mHasWidth) {
     width = aIntrinsicSize.mWidth;
   } else {
@@ -5406,32 +5395,57 @@ nsImageRenderer::ComputeConcreteSize(const CSSSizeOrRatio& aSpecifiedSize,
 
 /* static */ nsSize
 nsImageRenderer::ComputeConstrainedSize(const nsSize& aConstrainingSize,
-                                        const nsSize& aIntrinsicRatio,
+                                        const AspectRatio& aIntrinsicRatio,
                                         FitType aFitType)
 {
-  if (aIntrinsicRatio.width <= 0 && aIntrinsicRatio.height <= 0) {
+  if (!aIntrinsicRatio) {
     return aConstrainingSize;
   }
 
-  float scaleX = double(aConstrainingSize.width) / aIntrinsicRatio.width;
-  float scaleY = double(aConstrainingSize.height) / aIntrinsicRatio.height;
+  // Suppose we're doing a "contain" fit. If the image's aspect ratio has a
+  // "fatter" shape than the constraint area, then we need to use the
+  // constraint area's full width, and we need to use the aspect ratio to
+  // produce a height. ON the other hand, if the aspect ratio is "skinnier", we
+  // use the constraint area's full height, and we use the aspect ratio to
+  // produce a width. (If instead we're doing a "cover" fit, then it can easily
+  // be seen that we should do precisely the opposite.)
+  //
+  // This is equivalent to the more descriptive alternative:
+  //
+  //   AspectRatio::FromSize(aConstrainingSize) < aIntrinsicRatio
+  //
+  // But gracefully handling the case where one of the two dimensions from
+  // aConstrainingSize is zero. This is easy to prove since:
+  //
+  //   aConstrainingSize.width / aConstrainingSize.height < aIntrinsicRatio
+  //
+  // Is trivially equivalent to:
+  //
+  //   aIntrinsicRatio.width < aIntrinsicRatio * aConstrainingSize.height
+  //
+  // For the cases where height is not zero.
+  //
+  // We use float math here to avoid losing precision for very lareg backgrounds
+  // since we use saturating nscoord math otherwise.
+  const float constraintWidth = float(aConstrainingSize.width);
+  const float hypotheticalWidth =
+      aIntrinsicRatio.ApplyToFloat(aConstrainingSize.height);
+
   nsSize size;
-  if ((aFitType == CONTAIN) == (scaleX < scaleY)) {
+  if ((aFitType == CONTAIN) == (constraintWidth < hypotheticalWidth)) {
     size.width = aConstrainingSize.width;
-    size.height = NSCoordSaturatingNonnegativeMultiply(
-                    aIntrinsicRatio.height, scaleX);
+    size.height = aIntrinsicRatio.Inverted().ApplyTo(aConstrainingSize.width);
     // If we're reducing the size by less than one css pixel, then just use the
     // constraining size.
     if (aFitType == CONTAIN && aConstrainingSize.height - size.height < nsPresContext::AppUnitsPerCSSPixel()) {
       size.height = aConstrainingSize.height;
     }
   } else {
-    size.width = NSCoordSaturatingNonnegativeMultiply(
-                   aIntrinsicRatio.width, scaleY);
+    size.height = aConstrainingSize.height;
+    size.width = aIntrinsicRatio.ApplyTo(aConstrainingSize.height);
     if (aFitType == CONTAIN && aConstrainingSize.width - size.width < nsPresContext::AppUnitsPerCSSPixel()) {
       size.width = aConstrainingSize.width;
     }
-    size.height = aConstrainingSize.height;
   }
   return size;
 }

--- a/layout/base/nsCSSRendering.cpp
+++ b/layout/base/nsCSSRendering.cpp
@@ -5290,6 +5290,16 @@ nsImageRenderer::ComputeIntrinsicSize()
       if (haveHeight) {
         result.SetHeight(nsPresContext::CSSPixelsToAppUnits(imageIntSize.height));
       }
+
+      if (!haveHeight && haveWidth && result.mRatio) {
+        nscoord intrinsicHeight =
+            result.mRatio.Inverted().ApplyTo(imageIntSize.width);
+        result.SetHeight(nsPresContext::CSSPixelsToAppUnits(intrinsicHeight));
+      } else if (haveHeight && !haveWidth && result.mRatio) {
+        nscoord intrinsicWidth = result.mRatio.ApplyTo(imageIntSize.height);
+        result.SetWidth(nsPresContext::CSSPixelsToAppUnits(intrinsicWidth));
+      }
+
       break;
     }
     case eStyleImageType_Element:

--- a/layout/base/nsLayoutUtils.cpp
+++ b/layout/base/nsLayoutUtils.cpp
@@ -3966,7 +3966,7 @@ nsLayoutUtils::GetTextShadowRectsUnion(const nsRect& aTextAndDecorationsRect,
 enum ObjectDimensionType { eWidth, eHeight };
 static nscoord
 ComputeMissingDimension(const nsSize& aDefaultObjectSize,
-                        const nsSize& aIntrinsicRatio,
+                        const AspectRatio& aIntrinsicRatio,
                         const Maybe<nscoord>& aSpecifiedWidth,
                         const Maybe<nscoord>& aSpecifiedHeight,
                         ObjectDimensionType aDimensionToCompute)
@@ -3977,21 +3977,15 @@ ComputeMissingDimension(const nsSize& aDefaultObjectSize,
   // 1. "If the object has an intrinsic aspect ratio, the missing dimension of
   //     the concrete object size is calculated using the intrinsic aspect
   //     ratio and the present dimension."
-  if (aIntrinsicRatio.width > 0 && aIntrinsicRatio.height > 0) {
+  if (aIntrinsicRatio) {
     // Fill in the missing dimension using the intrinsic aspect ratio.
-    nscoord knownDimensionSize;
-    float ratio;
     if (aDimensionToCompute == eWidth) {
-      knownDimensionSize = *aSpecifiedHeight;
-      ratio = aIntrinsicRatio.width / aIntrinsicRatio.height;
-    } else {
-      knownDimensionSize = *aSpecifiedWidth;
-      ratio = aIntrinsicRatio.height / aIntrinsicRatio.width;
+      return aIntrinsicRatio.ApplyTo(*aSpecifiedHeight);
     }
-    return NSCoordSaturatingNonnegativeMultiply(knownDimensionSize, ratio);
+    return aIntrinsicRatio.Inverted().ApplyTo(*aSpecifiedWidth);
   }
 
-  // 2. "Otherwise, if the missing dimension is present in the object’s
+  // 2. "Otherwise, if the missing dimension is present in the object's
   //     intrinsic dimensions, [...]"
   // NOTE: *Skipping* this case, because we already know it's not true -- we're
   // in this function because the missing dimension is *not* present in
@@ -4029,7 +4023,7 @@ ComputeMissingDimension(const nsSize& aDefaultObjectSize,
 static Maybe<nsSize>
 MaybeComputeObjectFitNoneSize(const nsSize& aDefaultObjectSize,
                               const IntrinsicSize& aIntrinsicSize,
-                              const nsSize& aIntrinsicRatio)
+                              const AspectRatio& aIntrinsicRatio)
 {
   // "If the object has an intrinsic height or width, its size is resolved as
   // if its intrinsic dimensions were given as the specified size."
@@ -4076,15 +4070,13 @@ MaybeComputeObjectFitNoneSize(const nsSize& aDefaultObjectSize,
 static nsSize
 ComputeConcreteObjectSize(const nsSize& aConstraintSize,
                           const IntrinsicSize& aIntrinsicSize,
-                          const nsSize& aIntrinsicRatio,
+                          const AspectRatio& aIntrinsicRatio,
                           uint8_t aObjectFit)
 {
   // Handle default behavior (filling the container) w/ fast early return.
   // (Also: if there's no valid intrinsic ratio, then we have the "fill"
   // behavior & just use the constraint size.)
-  if (MOZ_LIKELY(aObjectFit == NS_STYLE_OBJECT_FIT_FILL) ||
-      aIntrinsicRatio.width == 0 ||
-      aIntrinsicRatio.height == 0) {
+  if (MOZ_LIKELY(aObjectFit == NS_STYLE_OBJECT_FIT_FILL) || !aIntrinsicRatio) {
     return aConstraintSize;
   }
 
@@ -4171,7 +4163,7 @@ HasInitialObjectFitAndPosition(const nsStylePosition* aStylePos)
 /* static */ nsRect
 nsLayoutUtils::ComputeObjectDestRect(const nsRect& aConstraintRect,
                                      const IntrinsicSize& aIntrinsicSize,
-                                     const nsSize& aIntrinsicRatio,
+                                     const AspectRatio& aIntrinsicRatio,
                                      const nsStylePosition* aStylePos,
                                      nsPoint* aAnchorPoint)
 {
@@ -5092,10 +5084,12 @@ nsLayoutUtils::IntrinsicForAxis(PhysicalAxis              aAxis,
            styleMinBSize.GetCoordValue() == 0)) ||
         styleMaxBSize.GetUnit() != eStyleUnit_None) {
 
-      nsSize ratio(aFrame->GetIntrinsicRatio());
-      nscoord ratioISize = (horizontalAxis ? ratio.width  : ratio.height);
-      nscoord ratioBSize = (horizontalAxis ? ratio.height : ratio.width);
-      if (ratioBSize != 0) {
+      AspectRatio ratio = aFrame->GetIntrinsicRatio();
+      if (ratio) {
+        // Convert 'ratio' if necessary, so that it's storing ISize/BSize:
+        if (!horizontalAxis) {
+          ratio = ratio.Inverted();
+        }
         AddStateBitToAncestors(aFrame,
             NS_FRAME_DESCENDANT_INTRINSIC_ISIZE_DEPENDS_ON_BSIZE);
 
@@ -5111,14 +5105,14 @@ nsLayoutUtils::IntrinsicForAxis(PhysicalAxis              aAxis,
             (aPercentageBasis.isNothing() &&
              GetPercentBSize(styleBSize, aFrame, horizontalAxis, h))) {
           h = std::max(0, h - bSizeTakenByBoxSizing);
-          result = NSCoordMulDiv(h, ratioISize, ratioBSize);
+          result = ratio.ApplyTo(h);
         }
 
         if (GetDefiniteSize(styleMaxBSize, aFrame, !isInlineAxis, aPercentageBasis, &h) ||
             (aPercentageBasis.isNothing() &&
              GetPercentBSize(styleMaxBSize, aFrame, horizontalAxis, h))) {
           h = std::max(0, h - bSizeTakenByBoxSizing);
-          nscoord maxISize = NSCoordMulDiv(h, ratioISize, ratioBSize);
+          nscoord maxISize = ratio.ApplyTo(h);
           if (maxISize < result) {
             result = maxISize;
           }
@@ -5131,7 +5125,7 @@ nsLayoutUtils::IntrinsicForAxis(PhysicalAxis              aAxis,
             (aPercentageBasis.isNothing() &&
              GetPercentBSize(styleMinBSize, aFrame, horizontalAxis, h))) {
           h = std::max(0, h - bSizeTakenByBoxSizing);
-          nscoord minISize = NSCoordMulDiv(h, ratioISize, ratioBSize);
+          nscoord minISize = ratio.ApplyTo(h);
           if (minISize > result) {
             result = minISize;
           }
@@ -6594,12 +6588,12 @@ nsLayoutUtils::DrawSingleImage(gfxContext&            aContext,
 /* static */ void
 nsLayoutUtils::ComputeSizeForDrawing(imgIContainer *aImage,
                                      CSSIntSize&    aImageSize, /*outparam*/
-                                     nsSize&        aIntrinsicRatio, /*outparam*/
+                                     AspectRatio&   aIntrinsicRatio, /*outparam*/
                                      bool&          aGotWidth,  /*outparam*/
                                      bool&          aGotHeight  /*outparam*/)
 {
   aGotWidth  = NS_SUCCEEDED(aImage->GetWidth(&aImageSize.width));
-  aGotHeight = NS_SUCCEEDED(aImage->GetHeight(&aImageSize.height));
+  aGotHeight = NS_SUCCEEDED(aImage->GetHeight(&aImageSize.height)); 
   bool gotRatio = NS_SUCCEEDED(aImage->GetIntrinsicRatio(&aIntrinsicRatio));
 
   if (!(aGotWidth && aGotHeight) && !gotRatio) {
@@ -6607,7 +6601,7 @@ nsLayoutUtils::ComputeSizeForDrawing(imgIContainer *aImage,
     // decoded) and should return zero size.
     aGotWidth = aGotHeight = true;
     aImageSize = CSSIntSize(0, 0);
-    aIntrinsicRatio = nsSize(0, 0);
+    aIntrinsicRatio = AspectRatio();
   }
 }
 
@@ -6616,7 +6610,7 @@ nsLayoutUtils::ComputeSizeForDrawingWithFallback(imgIContainer* aImage,
                                                  const nsSize&  aFallbackSize)
 {
   CSSIntSize imageSize;
-  nsSize imageRatio;
+  AspectRatio imageRatio;
   bool gotHeight, gotWidth;
   ComputeSizeForDrawing(aImage, imageSize, imageRatio, gotWidth, gotHeight);
 
@@ -6624,19 +6618,13 @@ nsLayoutUtils::ComputeSizeForDrawingWithFallback(imgIContainer* aImage,
   // intrinsic ratio of the image.
   if (gotWidth != gotHeight) {
     if (!gotWidth) {
-      if (imageRatio.height != 0) {
-        imageSize.width =
-          NSCoordSaturatingNonnegativeMultiply(imageSize.height,
-                                               float(imageRatio.width) /
-                                               float(imageRatio.height));
+      if (imageRatio) {
+        imageSize.width = imageRatio.ApplyTo(imageSize.height);
         gotWidth = true;
       }
     } else {
-      if (imageRatio.width != 0) {
-        imageSize.height =
-          NSCoordSaturatingNonnegativeMultiply(imageSize.width,
-                                               float(imageRatio.height) /
-                                               float(imageRatio.width));
+      if (imageRatio) {
+        imageSize.height = imageRatio.Inverted().ApplyTo(imageSize.width);
         gotHeight = true;
       }
     }

--- a/layout/base/nsLayoutUtils.h
+++ b/layout/base/nsLayoutUtils.h
@@ -65,6 +65,7 @@ struct nsStyleImageOrientation;
 struct nsOverflowAreas;
 
 namespace mozilla {
+struct aspectRatio;
 enum class CSSPseudoElementType : uint8_t;
 class EventListenerManager;
 class SVGImageContext;
@@ -126,6 +127,7 @@ enum class RelativeTo {
  */
 class nsLayoutUtils
 {
+  typedef mozilla::AspectRatio AspectRatio;
   typedef mozilla::dom::DOMRectList DOMRectList;
   typedef mozilla::layers::Layer Layer;
   typedef mozilla::ContainerLayerParameters ContainerLayerParameters;
@@ -1217,7 +1219,7 @@ public:
    */
   static nsRect ComputeObjectDestRect(const nsRect& aConstraintRect,
                                       const IntrinsicSize& aIntrinsicSize,
-                                      const nsSize& aIntrinsicRatio,
+                                      const AspectRatio& aIntrinsicRatio,
                                       const nsStylePosition* aStylePos,
                                       nsPoint* aAnchorPoint = nullptr);
 
@@ -1837,7 +1839,7 @@ public:
    */
   static void ComputeSizeForDrawing(imgIContainer* aImage,
                                     CSSIntSize&    aImageSize,
-                                    nsSize&        aIntrinsicRatio,
+                                    AspectRatio&        aIntrinsicRatio,
                                     bool&          aGotWidth,
                                     bool&          aGotHeight);
 

--- a/layout/generic/AspectRatio.h
+++ b/layout/generic/AspectRatio.h
@@ -1,0 +1,81 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_AspectRatio_h
+#define mozilla_AspectRatio_h
+
+/* The aspect ratio of a box, in a "width / height" format. */
+
+#include "mozilla/Attributes.h"
+#include "nsCoord.h"
+#include <algorithm>
+#include <limits>
+
+namespace mozilla {
+
+struct AspectRatio {
+  AspectRatio() : mRatio(0.0f) {}
+  explicit AspectRatio(float aRatio) : mRatio(std::max(aRatio, 0.0f)) {}
+
+  static AspectRatio FromSize(float aWidth, float aHeight) {
+    if (aWidth == 0.0f || aHeight == 0.0f) {
+      return AspectRatio();
+    }
+    return AspectRatio(aWidth / aHeight);
+  }
+
+  static AspectRatio FromSize(nsSize aSize) {
+    return FromSize(aSize.width, aSize.height);
+  }
+
+  static AspectRatio FromSize(nsIntSize aSize) {
+    return FromSize(aSize.width, aSize.height);
+  }
+
+  explicit operator bool() const { return mRatio != 0.0f; }
+
+  nscoord ApplyTo(nscoord aCoord) const {
+    MOZ_DIAGNOSTIC_ASSERT(*this);
+    return NSCoordSaturatingNonnegativeMultiply(aCoord, mRatio);
+  }
+
+  float ApplyToFloat(float aFloat) const {
+    MOZ_DIAGNOSTIC_ASSERT(*this);
+    return mRatio * aFloat;
+  }
+
+  // Inverts the ratio, in order to get the height / width ratio.
+  MOZ_MUST_USE AspectRatio Inverted() const {
+    if (!*this) {
+      return AspectRatio();
+    }
+    // Clamp to a small epsilon, in case mRatio is absurdly large & produces
+    // 0.0f in the division here (so that valid ratios always generate other
+    // valid ratios when inverted).
+    return AspectRatio(
+        std::max(std::numeric_limits<float>::epsilon(), 1.0f / mRatio));
+  }
+
+  bool operator==(const AspectRatio& aOther) const {
+    return mRatio == aOther.mRatio;
+  }
+
+  bool operator!=(const AspectRatio& aOther) const {
+    return !(*this == aOther);
+  }
+
+  bool operator<(const AspectRatio& aOther) const {
+    return mRatio < aOther.mRatio;
+  }
+
+ private:
+  // 0.0f represents no aspect ratio.
+  float mRatio;
+};
+
+}  // namespace mozilla
+
+#endif  // mozilla_AspectRatio_h

--- a/layout/generic/moz.build
+++ b/layout/generic/moz.build
@@ -109,6 +109,7 @@ EXPORTS += [
 ]
 
 EXPORTS.mozilla += [
+    'AspectRatio.h',
     'CSSAlignUtils.h',
     'ReflowInput.h',
     'ReflowOutput.h',

--- a/layout/generic/nsFlexContainerFrame.cpp
+++ b/layout/generic/nsFlexContainerFrame.cpp
@@ -1529,9 +1529,9 @@ MainSizeFromAspectRatio(nscoord aCrossSize,
 {
   MOZ_ASSERT(aIntrinsicRatio,
              "Invalid ratio; will divide by 0! Caller should've checked...");
-  AspectRatio ratio = aAxisTracker.IsMainAxisHorizontal()
-                          ? aIntrinsicRatio
-                          : aIntrinsicRatio.Inverted();
+  AspectRatio ratio = aAxisTracker.IsMainAxisHorizontal() ?
+                      aIntrinsicRatio :
+                      aIntrinsicRatio.Inverted();
 
   return ratio.ApplyTo(aCrossSize);
 }

--- a/layout/generic/nsFrame.cpp
+++ b/layout/generic/nsFrame.cpp
@@ -5197,26 +5197,6 @@ nsFrame::ComputeSizeWithIntrinsicDimensions(nsRenderingContext*  aRenderingConte
       if (hasIntrinsicISize) {
         tentISize = intrinsicISize;
       } else if (hasIntrinsicBSize && logicalRatio) {
-        // (dholbert) <https://phabricator.services.mozilla.com
-        //             /D29244#change-5faEkbsohV7O>
-        // This is wrong -- this ApplyTo call (and probably every ApplyTo call
-        // in this function) would only be valid if we're in a horizontal
-        // writing mode. It's not valid in a vertical writing mode. If this
-        // doesn't break tests, that's a bit concerning, and I think it means
-        // we're missing some test coverage. (That, or I'm misreading things.)
-        //
-        // aIntrinsicRatio is stored in terms of physical axes (width/height),
-        // either of which could be I vs. B axis. So any sort of
-        // aIntrinsicRatio.ApplyTo(someBSize) operation will be
-        // potentially-bogus.
-        //
-        // You probably want to bring back a logicalRatio variable
-        // (like the one we used to have here), but now with type AspectRatio.
-        // It would be equal to either aIntrinsicRatio or
-        // aIntrinsicRatio.Invert() depending on whether aWM is horizontal or
-        // vertical. (And hopefully having logical in its name would be a
-        // reminder that it's in terms of Inline/Block and can be used for
-        // these sorts of ApplyTo(intrinsicBSize) operations.
         tentISize = logicalRatio.ApplyTo(intrinsicBSize);
       } else if (logicalRatio) {
         tentISize = aCBSize.ISize(aWM) - boxSizingToMarginEdgeISize; // XXX scrollbar?

--- a/layout/generic/nsFrame.cpp
+++ b/layout/generic/nsFrame.cpp
@@ -4641,10 +4641,10 @@ nsFrame::GetIntrinsicSize()
   return IntrinsicSize(); // default is width/height set to eStyleUnit_None
 }
 
-/* virtual */ nsSize
+/* virtual */ AspectRatio
 nsFrame::GetIntrinsicRatio()
 {
-  return nsSize(0, 0);
+  return AspectRatio();
 }
 
 /* virtual */
@@ -4658,7 +4658,7 @@ nsFrame::ComputeSize(nsRenderingContext* aRenderingContext,
                      const LogicalSize&  aPadding,
                      ComputeSizeFlags    aFlags)
 {
-  MOZ_ASSERT(GetIntrinsicRatio() == nsSize(0,0),
+  MOZ_ASSERT(!GetIntrinsicRatio(),
              "Please override this method and call "
              "nsFrame::ComputeSizeWithIntrinsicDimensions instead.");
   LogicalSize result = ComputeAutoSize(aRenderingContext, aWM,
@@ -4914,13 +4914,15 @@ LogicalSize
 nsFrame::ComputeSizeWithIntrinsicDimensions(nsRenderingContext*  aRenderingContext,
                                             WritingMode          aWM,
                                             const IntrinsicSize& aIntrinsicSize,
-                                            nsSize               aIntrinsicRatio,
+                                            const AspectRatio&   aIntrinsicRatio,
                                             const LogicalSize&   aCBSize,
                                             const LogicalSize&   aMargin,
                                             const LogicalSize&   aBorder,
                                             const LogicalSize&   aPadding,
                                             ComputeSizeFlags     aFlags)
 {
+  auto logicalRatio =
+      aWM.IsVertical() ? aIntrinsicRatio.Inverted() : aIntrinsicRatio;
   const nsStylePosition* stylePos = StylePosition();
   const nsStyleCoord* inlineStyleCoord = &stylePos->ISize(aWM);
   const nsStyleCoord* blockStyleCoord = &stylePos->BSize(aWM);
@@ -5181,10 +5183,6 @@ nsFrame::ComputeSizeWithIntrinsicDimensions(nsRenderingContext*  aRenderingConte
     intrinsicBSize = 0;
   }
 
-  NS_ASSERTION(aIntrinsicRatio.width >= 0 && aIntrinsicRatio.height >= 0,
-               "Intrinsic ratio has a negative component!");
-  LogicalSize logicalRatio(aWM, aIntrinsicRatio);
-
   // Now calculate the used values for iSize and bSize:
 
   if (isAutoISize) {
@@ -5198,9 +5196,29 @@ nsFrame::ComputeSizeWithIntrinsicDimensions(nsRenderingContext*  aRenderingConte
 
       if (hasIntrinsicISize) {
         tentISize = intrinsicISize;
-      } else if (hasIntrinsicBSize && logicalRatio.BSize(aWM) > 0) {
-        tentISize = NSCoordMulDiv(intrinsicBSize, logicalRatio.ISize(aWM), logicalRatio.BSize(aWM));
-      } else if (logicalRatio.ISize(aWM) > 0) {
+      } else if (hasIntrinsicBSize && logicalRatio) {
+        // (dholbert) <https://phabricator.services.mozilla.com
+        //             /D29244#change-5faEkbsohV7O>
+        // This is wrong -- this ApplyTo call (and probably every ApplyTo call
+        // in this function) would only be valid if we're in a horizontal
+        // writing mode. It's not valid in a vertical writing mode. If this
+        // doesn't break tests, that's a bit concerning, and I think it means
+        // we're missing some test coverage. (That, or I'm misreading things.)
+        //
+        // aIntrinsicRatio is stored in terms of physical axes (width/height),
+        // either of which could be I vs. B axis. So any sort of
+        // aIntrinsicRatio.ApplyTo(someBSize) operation will be
+        // potentially-bogus.
+        //
+        // You probably want to bring back a logicalRatio variable
+        // (like the one we used to have here), but now with type AspectRatio.
+        // It would be equal to either aIntrinsicRatio or
+        // aIntrinsicRatio.Invert() depending on whether aWM is horizontal or
+        // vertical. (And hopefully having logical in its name would be a
+        // reminder that it's in terms of Inline/Block and can be used for
+        // these sorts of ApplyTo(intrinsicBSize) operations.
+        tentISize = logicalRatio.ApplyTo(intrinsicBSize);
+      } else if (logicalRatio) {
         tentISize = aCBSize.ISize(aWM) - boxSizingToMarginEdgeISize; // XXX scrollbar?
         if (tentISize < 0) tentISize = 0;
       } else {
@@ -5217,8 +5235,8 @@ nsFrame::ComputeSizeWithIntrinsicDimensions(nsRenderingContext*  aRenderingConte
 
       if (hasIntrinsicBSize) {
         tentBSize = intrinsicBSize;
-      } else if (logicalRatio.ISize(aWM) > 0) {
-        tentBSize = NSCoordMulDiv(tentISize, logicalRatio.BSize(aWM), logicalRatio.ISize(aWM));
+      } else if (logicalRatio) {
+        tentBSize = logicalRatio.Inverted().ApplyTo(tentISize);
       } else {
         tentBSize = nsPresContext::CSSPixelsToAppUnits(150);
       }
@@ -5229,46 +5247,39 @@ nsFrame::ComputeSizeWithIntrinsicDimensions(nsRenderingContext*  aRenderingConte
         stretchB = (stretchI == eStretch ? eStretch : eStretchPreservingRatio);
       }
 
-      if (aIntrinsicRatio != nsSize(0, 0)) {
+      if (logicalRatio) {
         if (stretchI == eStretch) {
           tentISize = iSize;  // * / 'stretch'
           if (stretchB == eStretch) {
             tentBSize = bSize;  // 'stretch' / 'stretch'
-          } else if (stretchB == eStretchPreservingRatio && logicalRatio.ISize(aWM) > 0) {
+          } else if (stretchB == eStretchPreservingRatio) {
             // 'normal' / 'stretch'
-            tentBSize = NSCoordMulDiv(iSize, logicalRatio.BSize(aWM), logicalRatio.ISize(aWM));
+            tentBSize = logicalRatio.Inverted().ApplyTo(iSize);
           }
         } else if (stretchB == eStretch) {
           tentBSize = bSize;  // 'stretch' / * (except 'stretch')
-          if (stretchI == eStretchPreservingRatio && logicalRatio.BSize(aWM) > 0) {
+          if (stretchI == eStretchPreservingRatio) {
             // 'stretch' / 'normal'
-            tentISize = NSCoordMulDiv(bSize, logicalRatio.ISize(aWM), logicalRatio.BSize(aWM));
+            tentISize = logicalRatio.ApplyTo(bSize);
           }
         } else if (stretchI == eStretchPreservingRatio) {
           tentISize = iSize;  // * (except 'stretch') / 'normal'
-          if (logicalRatio.ISize(aWM) > 0) {
-            tentBSize = NSCoordMulDiv(iSize, logicalRatio.BSize(aWM), logicalRatio.ISize(aWM));
-          }
+          tentBSize = logicalRatio.Inverted().ApplyTo(iSize);
           if (stretchB == eStretchPreservingRatio && tentBSize > bSize) {
             // Stretch within the CB size with preserved intrinsic ratio.
             tentBSize = bSize;  // 'normal' / 'normal'
-            if (logicalRatio.BSize(aWM) > 0) {
-              tentISize = NSCoordMulDiv(bSize, logicalRatio.ISize(aWM), logicalRatio.BSize(aWM));
-            }
+            tentISize = logicalRatio.ApplyTo(bSize);
           }
         } else if (stretchB == eStretchPreservingRatio) {
           tentBSize = bSize;  // 'normal' / * (except 'normal' and 'stretch')
-          if (logicalRatio.BSize(aWM) > 0) {
-            tentISize = NSCoordMulDiv(bSize, logicalRatio.ISize(aWM), logicalRatio.BSize(aWM));
-          }
+          tentISize = logicalRatio.ApplyTo(bSize);
         }
       }
 
       // ComputeAutoSizeWithIntrinsicDimensions preserves the ratio when applying
       // the min/max-size.  We don't want that when we have 'stretch' in either
       // axis because tentISize/tentBSize is likely not according to ratio now.
-      if (aIntrinsicRatio != nsSize(0, 0) &&
-          stretchI != eStretch && stretchB != eStretch) {
+      if (logicalRatio && stretchI != eStretch && stretchB != eStretch) {
         nsSize autoSize = nsLayoutUtils::
           ComputeAutoSizeWithIntrinsicDimensions(minISize, minBSize,
                                                  maxISize, maxBSize,
@@ -5289,8 +5300,8 @@ nsFrame::ComputeSizeWithIntrinsicDimensions(nsRenderingContext*  aRenderingConte
       // 'auto' iSize, non-'auto' bSize
       bSize = NS_CSS_MINMAX(bSize, minBSize, maxBSize);
       if (stretchI != eStretch) {
-        if (logicalRatio.BSize(aWM) > 0) {
-          iSize = NSCoordMulDiv(bSize, logicalRatio.ISize(aWM), logicalRatio.BSize(aWM));
+        if (logicalRatio) {
+          iSize = logicalRatio.ApplyTo(bSize);
         } else if (hasIntrinsicISize) {
           if (!((aFlags & ComputeSizeFlags::eIClampMarginBoxMinSize) &&
                 intrinsicISize > iSize)) {
@@ -5309,8 +5320,8 @@ nsFrame::ComputeSizeWithIntrinsicDimensions(nsRenderingContext*  aRenderingConte
       // non-'auto' iSize, 'auto' bSize
       iSize = NS_CSS_MINMAX(iSize, minISize, maxISize);
       if (stretchB != eStretch) {
-        if (logicalRatio.ISize(aWM) > 0) {
-          bSize = NSCoordMulDiv(iSize, logicalRatio.BSize(aWM), logicalRatio.ISize(aWM));
+        if (logicalRatio) {
+          bSize = logicalRatio.Inverted().ApplyTo(iSize);
         } else if (hasIntrinsicBSize) {
           if (!((aFlags & ComputeSizeFlags::eBClampMarginBoxMinSize) &&
                 intrinsicBSize > bSize)) {

--- a/layout/generic/nsFrame.h
+++ b/layout/generic/nsFrame.h
@@ -264,7 +264,7 @@ public:
   IntrinsicISizeOffsetData
   IntrinsicISizeOffsets(nscoord aPercentageBasis = NS_UNCONSTRAINEDSIZE) override;
   virtual mozilla::IntrinsicSize GetIntrinsicSize() override;
-  virtual nsSize GetIntrinsicRatio() override;
+  virtual mozilla::AspectRatio GetIntrinsicRatio() override;
 
   virtual mozilla::LogicalSize
   ComputeSize(nsRenderingContext*         aRenderingContext,
@@ -285,7 +285,7 @@ public:
               nsRenderingContext*           aRenderingContext,
               mozilla::WritingMode          aWM,
               const mozilla::IntrinsicSize& aIntrinsicSize,
-              nsSize                        aIntrinsicRatio,
+              const mozilla::AspectRatio&   aIntrinsicRatio,
               const mozilla::LogicalSize&   aCBSize,
               const mozilla::LogicalSize&   aMargin,
               const mozilla::LogicalSize&   aBorder,

--- a/layout/generic/nsHTMLCanvasFrame.cpp
+++ b/layout/generic/nsHTMLCanvasFrame.cpp
@@ -199,6 +199,7 @@ nsHTMLCanvasFrame::GetIntrinsicSize()
 /* virtual */ AspectRatio
 nsHTMLCanvasFrame::GetIntrinsicRatio()
 {
+ // When 'contain: size' is implemented, make sure to check for it.
 /*
   if (StyleDisplay()->IsContainSize()) {
     return AspectRatio();

--- a/layout/generic/nsHTMLCanvasFrame.h
+++ b/layout/generic/nsHTMLCanvasFrame.h
@@ -58,7 +58,7 @@ public:
   virtual nscoord GetMinISize(nsRenderingContext *aRenderingContext) override;
   virtual nscoord GetPrefISize(nsRenderingContext *aRenderingContext) override;
   virtual mozilla::IntrinsicSize GetIntrinsicSize() override;
-  virtual nsSize GetIntrinsicRatio() override;
+  virtual mozilla::AspectRatio GetIntrinsicRatio() override;
 
   virtual mozilla::LogicalSize
   ComputeSize(nsRenderingContext *aRenderingContext,

--- a/layout/generic/nsIFrame.h
+++ b/layout/generic/nsIFrame.h
@@ -27,6 +27,7 @@
 #include "FrameProperties.h"
 #include "LayoutConstants.h"
 #include "mozilla/layout/FrameChildList.h"
+#include "mozilla/AspectRatio.h"
 #include "mozilla/Maybe.h"
 #include "mozilla/WritingModes.h"
 #include "nsDirection.h"
@@ -2063,15 +2064,14 @@ public:
   virtual mozilla::IntrinsicSize GetIntrinsicSize() = 0;
 
   /**
-   * Get the intrinsic ratio of this element, or nsSize(0,0) if it has
-   * no intrinsic ratio.  The intrinsic ratio is the ratio of the
-   * height/width of a box with an intrinsic size or the intrinsic
-   * aspect ratio of a scalable vector image without an intrinsic size.
+   * Get the intrinsic ratio of this element, or a default-constructed
+   * AspectRatio if it has no intrinsic ratio.
    *
-   * Either one of the sides may be zero, indicating a zero or infinite
-   * ratio.
+   * The intrinsic ratio is the ratio of the width/height of a box with an
+   * intrinsic size or the intrinsic aspect ratio of a scalable vector image
+   * without an intrinsic size.
    */
-  virtual nsSize GetIntrinsicRatio() = 0;
+  virtual mozilla::AspectRatio GetIntrinsicRatio() = 0;
 
   /**
    * Bit-flags to pass to ComputeSize in |aFlags| parameter.

--- a/layout/generic/nsImageFrame.cpp
+++ b/layout/generic/nsImageFrame.cpp
@@ -138,7 +138,6 @@ NS_IMPL_FRAMEARENA_HELPERS(nsImageFrame)
 nsImageFrame::nsImageFrame(nsStyleContext* aContext) :
   nsAtomicContainerFrame(aContext),
   mComputedSize(0, 0),
-  mIntrinsicRatio(0, 0),
   mDisplayingIcon(false),
   mFirstFrameComplete(false),
   mReflowCallbackPosted(false),
@@ -325,11 +324,11 @@ nsImageFrame::UpdateIntrinsicRatio(imgIContainer* aImage)
   if (!aImage)
     return false;
 
-  nsSize oldIntrinsicRatio = mIntrinsicRatio;
+  AspectRatio oldIntrinsicRatio = mIntrinsicRatio;
 
   // Set intrinsic ratio to match aImage's reported intrinsic ratio.
   if (NS_FAILED(aImage->GetIntrinsicRatio(&mIntrinsicRatio)))
-    mIntrinsicRatio.SizeTo(0, 0);
+    mIntrinsicRatio = AspectRatio();
 
   return mIntrinsicRatio != oldIntrinsicRatio;
 }
@@ -557,7 +556,7 @@ nsImageFrame::OnSizeAvailable(imgIRequest* aRequest, imgIContainer* aImage)
     // Have to size to 0,0 so that GetDesiredSize recalculates the size.
     mIntrinsicSize.width.SetCoordValue(0);
     mIntrinsicSize.height.SetCoordValue(0);
-    mIntrinsicRatio.SizeTo(0, 0);
+    mIntrinsicRatio = AspectRatio();
     intrinsicSizeChanged = true;
   }
 
@@ -672,7 +671,7 @@ nsImageFrame::NotifyNewCurrentRequest(imgIRequest *aRequest,
     // Have to size to 0,0 so that GetDesiredSize recalculates the size
     mIntrinsicSize.width.SetCoordValue(0);
     mIntrinsicSize.height.SetCoordValue(0);
-    mIntrinsicRatio.SizeTo(0, 0);
+    mIntrinsicRatio = AspectRatio();
   }
 
   if (mState & IMAGE_GOTINITIALREFLOW) { // do nothing if we haven't gotten the initial reflow yet
@@ -808,7 +807,7 @@ nsImageFrame::EnsureIntrinsicSizeAndRatio()
               ICON_SIZE + (2 * (ICON_PADDING + ALT_BORDER_WIDTH)));
           mIntrinsicSize.width.SetCoordValue(edgeLengthToUse);
           mIntrinsicSize.height.SetCoordValue(edgeLengthToUse);
-          mIntrinsicRatio.SizeTo(1, 1);
+          mIntrinsicRatio = AspectRatio(1.0f);
         }
       }
     }
@@ -932,7 +931,7 @@ nsImageFrame::GetIntrinsicSize()
   return mIntrinsicSize;
 }
 
-/* virtual */ nsSize
+/* virtual */ AspectRatio
 nsImageFrame::GetIntrinsicRatio()
 {
   return mIntrinsicRatio;

--- a/layout/generic/nsImageFrame.h
+++ b/layout/generic/nsImageFrame.h
@@ -86,7 +86,7 @@ public:
   virtual nscoord GetMinISize(nsRenderingContext *aRenderingContext) override;
   virtual nscoord GetPrefISize(nsRenderingContext *aRenderingContext) override;
   virtual mozilla::IntrinsicSize GetIntrinsicSize() override;
-  virtual nsSize GetIntrinsicRatio() override;
+  virtual mozilla::AspectRatio GetIntrinsicRatio() override;
   virtual void Reflow(nsPresContext*           aPresContext,
                       ReflowOutput&     aDesiredSize,
                       const ReflowInput& aReflowInput,
@@ -333,7 +333,7 @@ private:
   nsCOMPtr<imgIContainer> mPrevImage;
   nsSize mComputedSize;
   mozilla::IntrinsicSize mIntrinsicSize;
-  nsSize mIntrinsicRatio;
+  mozilla::AspectRatio mIntrinsicRatio;
 
   bool mDisplayingIcon;
   bool mFirstFrameComplete;

--- a/layout/generic/nsLineLayout.cpp
+++ b/layout/generic/nsLineLayout.cpp
@@ -784,7 +784,7 @@ IsPercentageAware(const nsIFrame* aFrame)
     //   is calculated from the constraint equation used for
     //   block-level, non-replaced elements in normal flow. 
     nsIFrame *f = const_cast<nsIFrame*>(aFrame);
-    if (f->GetIntrinsicRatio() != nsSize(0, 0) &&
+    if (f->GetIntrinsicRatio() &&
         // Some percents are treated like 'auto', so check != coord
         pos->mHeight.GetUnit() != eStyleUnit_Coord) {
       const IntrinsicSize &intrinsicSize = f->GetIntrinsicSize();

--- a/layout/generic/nsSubDocumentFrame.cpp
+++ b/layout/generic/nsSubDocumentFrame.cpp
@@ -671,7 +671,7 @@ nsSubDocumentFrame::GetIntrinsicSize()
   return nsAtomicContainerFrame::GetIntrinsicSize();
 }
 
-/* virtual */ nsSize
+/* virtual */ AspectRatio
 nsSubDocumentFrame::GetIntrinsicRatio()
 {
   nsIFrame* subDocRoot = ObtainIntrinsicSizeFrame();
@@ -771,7 +771,7 @@ nsSubDocumentFrame::Reflow(nsPresContext*           aPresContext,
     // Size & position the view according to 'object-fit' & 'object-position'.
     nsIFrame* subDocRoot = ObtainIntrinsicSizeFrame();
     IntrinsicSize intrinsSize;
-    nsSize intrinsRatio;
+    AspectRatio intrinsRatio;
     if (subDocRoot) {
       intrinsSize = subDocRoot->GetIntrinsicSize();
       intrinsRatio = subDocRoot->GetIntrinsicRatio();

--- a/layout/generic/nsSubDocumentFrame.h
+++ b/layout/generic/nsSubDocumentFrame.h
@@ -51,7 +51,7 @@ public:
   virtual nscoord GetPrefISize(nsRenderingContext *aRenderingContext) override;
 
   virtual mozilla::IntrinsicSize GetIntrinsicSize() override;
-  virtual nsSize  GetIntrinsicRatio() override;
+  virtual mozilla::AspectRatio GetIntrinsicRatio() override;
 
   virtual mozilla::LogicalSize
   ComputeAutoSize(nsRenderingContext*         aRenderingContext,

--- a/layout/generic/nsVideoFrame.cpp
+++ b/layout/generic/nsVideoFrame.cpp
@@ -217,12 +217,10 @@ nsVideoFrame::BuildLayer(nsDisplayListBuilder* aBuilder,
   // Convert video size from pixel units into app units, to get an aspect-ratio
   // (which has to be represented as a nsSize) and an IntrinsicSize that we
   // can pass to ComputeObjectRenderRect.
-  nsSize aspectRatio(nsPresContext::CSSPixelsToAppUnits(videoSizeInPx.width),
-                     nsPresContext::CSSPixelsToAppUnits(videoSizeInPx.height));
+  auto aspectRatio = AspectRatio::FromSize(videoSizeInPx);
   IntrinsicSize intrinsicSize;
-  intrinsicSize.width.SetCoordValue(aspectRatio.width);
-  intrinsicSize.height.SetCoordValue(aspectRatio.height);
-
+  intrinsicSize.width.SetCoordValue(nsPresContext::CSSPixelsToAppUnits(videoSizeInPx.width));
+  intrinsicSize.height.SetCoordValue(nsPresContext::CSSPixelsToAppUnits(videoSizeInPx.height));
   nsRect dest = nsLayoutUtils::ComputeObjectDestRect(area,
                                                      intrinsicSize,
                                                      aspectRatio,
@@ -533,7 +531,9 @@ nsVideoFrame::ComputeSize(nsRenderingContext *aRenderingContext,
   intrinsicSize.height.SetCoordValue(size.height);
 
   // Only video elements have an intrinsic ratio.
-  nsSize intrinsicRatio = HasVideoElement() ? size : nsSize(0, 0);
+  auto intrinsicRatio = HasVideoElement()
+                            ? AspectRatio::FromSize(size)
+                            : AspectRatio();
 
   return ComputeSizeWithIntrinsicDimensions(aRenderingContext, aWM,
                                             intrinsicSize, intrinsicRatio,
@@ -557,14 +557,14 @@ nscoord nsVideoFrame::GetPrefISize(nsRenderingContext *aRenderingContext)
   return result;
 }
 
-nsSize nsVideoFrame::GetIntrinsicRatio()
+AspectRatio nsVideoFrame::GetIntrinsicRatio()
 {
   if (!HasVideoElement()) {
     // Audio elements have no intrinsic ratio.
-    return nsSize(0, 0);
+    return AspectRatio();
   }
 
-  return GetVideoIntrinsicSize(nullptr);
+  return AspectRatio::FromSize(GetVideoIntrinsicSize(nullptr));
 }
 
 bool nsVideoFrame::ShouldDisplayPoster()

--- a/layout/generic/nsVideoFrame.cpp
+++ b/layout/generic/nsVideoFrame.cpp
@@ -531,9 +531,9 @@ nsVideoFrame::ComputeSize(nsRenderingContext *aRenderingContext,
   intrinsicSize.height.SetCoordValue(size.height);
 
   // Only video elements have an intrinsic ratio.
-  auto intrinsicRatio = HasVideoElement()
-                            ? AspectRatio::FromSize(size)
-                            : AspectRatio();
+  auto intrinsicRatio = HasVideoElement() ?
+                        AspectRatio::FromSize(size) :
+                        AspectRatio();
 
   return ComputeSizeWithIntrinsicDimensions(aRenderingContext, aWM,
                                             intrinsicSize, intrinsicRatio,

--- a/layout/generic/nsVideoFrame.h
+++ b/layout/generic/nsVideoFrame.h
@@ -56,7 +56,7 @@ public:
 
   /* get the size of the video's display */
   nsSize GetVideoIntrinsicSize(nsRenderingContext *aRenderingContext);
-  virtual nsSize GetIntrinsicRatio() override;
+  virtual mozilla::AspectRatio GetIntrinsicRatio() override;
   virtual mozilla::LogicalSize
   ComputeSize(nsRenderingContext *aRenderingContext,
               mozilla::WritingMode aWritingMode,

--- a/layout/style/nsStyleStruct.cpp
+++ b/layout/style/nsStyleStruct.cpp
@@ -2731,7 +2731,7 @@ nsStyleImageLayers::Size::DependsOnPositioningAreaSize(const nsStyleImage& aImag
     }
     if (imgContainer) {
       CSSIntSize imageSize;
-      nsSize imageRatio;
+      AspectRatio imageRatio;
       bool hasWidth, hasHeight;
       nsLayoutUtils::ComputeSizeForDrawing(imgContainer, imageSize, imageRatio,
                                            hasWidth, hasHeight);
@@ -2744,7 +2744,7 @@ nsStyleImageLayers::Size::DependsOnPositioningAreaSize(const nsStyleImage& aImag
 
       // If the image has an intrinsic ratio, rendering will depend on frame
       // size when background-size is all auto.
-      if (imageRatio != nsSize(0, 0)) {
+      if (imageRatio) {
         return mWidthType == mHeightType;
       }
 

--- a/layout/svg/nsSVGOuterSVGFrame.h
+++ b/layout/svg/nsSVGOuterSVGFrame.h
@@ -42,7 +42,7 @@ public:
   virtual nscoord GetPrefISize(nsRenderingContext *aRenderingContext) override;
 
   virtual mozilla::IntrinsicSize GetIntrinsicSize() override;
-  virtual nsSize  GetIntrinsicRatio() override;
+  virtual mozilla::AspectRatio GetIntrinsicRatio() override;
 
   virtual mozilla::LogicalSize
   ComputeSize(nsRenderingContext *aRenderingContext,

--- a/layout/xul/nsImageBoxFrame.cpp
+++ b/layout/xul/nsImageBoxFrame.cpp
@@ -407,8 +407,7 @@ nsImageBoxFrame::PaintImage(nsRenderingContext& aRenderingContext,
       // Image has a valid size; use it as intrinsic size & ratio.
       intrinsicSize.width.SetCoordValue(mIntrinsicSize.width);
       intrinsicSize.height.SetCoordValue(mIntrinsicSize.height);
-      intrinsicRatio =
-          AspectRatio::FromSize(mIntrinsicSize);
+      intrinsicRatio = AspectRatio::FromSize(mIntrinsicSize);
     } else {
       // Image doesn't have a (valid) intrinsic size.
       // Try to look up intrinsic ratio and use that at least.

--- a/layout/xul/nsImageBoxFrame.cpp
+++ b/layout/xul/nsImageBoxFrame.cpp
@@ -402,12 +402,13 @@ nsImageBoxFrame::PaintImage(nsRenderingContext& aRenderingContext,
     // Determine dest rect based on intrinsic size & ratio, along with
     // 'object-fit' & 'object-position' properties:
     IntrinsicSize intrinsicSize;
-    nsSize intrinsicRatio;
+    AspectRatio intrinsicRatio;
     if (mIntrinsicSize.width > 0 && mIntrinsicSize.height > 0) {
       // Image has a valid size; use it as intrinsic size & ratio.
       intrinsicSize.width.SetCoordValue(mIntrinsicSize.width);
       intrinsicSize.height.SetCoordValue(mIntrinsicSize.height);
-      intrinsicRatio = mIntrinsicSize;
+      intrinsicRatio =
+          AspectRatio::FromSize(mIntrinsicSize);
     } else {
       // Image doesn't have a (valid) intrinsic size.
       // Try to look up intrinsic ratio and use that at least.

--- a/testing/web-platform/tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/object_intrinsic_size_vertical.html
+++ b/testing/web-platform/tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/object_intrinsic_size_vertical.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<title>Frame width and height attributes as they apply in a vertical writing mode</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+ #horiz
+ {
+  writing-mode: horizontal-tb;
+  display: inline-block;
+ }
+ #vert
+ {
+  writing-mode: vertical-rl;
+  display: inline-block;
+ }
+ object
+ {
+  border: 1px solid red;
+  margin: 5px;
+ }
+</style>
+<div id="horiz">
+<object data="/images/green.png" width=300></object>
+<object data="/images/green.png" height=50></object>
+</div>
+<div id="vert">
+<object data="/images/green.png" width=300></object>
+<object data="/images/green.png" height=50></object>
+</div>
+<script>
+let t = async_test("Frame width and height attributes as they apply in a vertical writing mode");
+function assert_dimensions(obj, expectedX, expectedY) {
+  assert_equals(getComputedStyle(obj).width, expectedX);
+  assert_equals(getComputedStyle(obj).height, expectedY);
+}
+t.step(function() {
+  var obj = document.createElement('object');
+  obj.width = 133;
+  obj.data = '/images/blue.png';
+  document.getElementById('horiz').appendChild(obj);
+
+  obj = document.createElement('object');
+  obj.width = 133;
+  obj.data = '/images/blue.png';
+  document.getElementById('vert').appendChild(obj);
+});
+
+onload = t.step_func_done(function() {
+  let objects = document.querySelectorAll("object");
+  assert_dimensions(objects[0], '300px', '150px');
+  assert_dimensions(objects[1], '100px', '50px');
+  assert_dimensions(objects[2], '133px', '106px');
+  assert_dimensions(objects[3], '300px', '150px');
+  assert_dimensions(objects[4], '100px', '50px');
+  assert_dimensions(objects[5], '133px', '106px');
+});
+</script>


### PR DESCRIPTION
First of two-phase implementation of Intrinsic Aspect Ratios from `width=` and `height=` HTML values:

Any use of `nsSize` for Aspect Ratio values now uses a `float` value. Some special helper functions simplify basic aspect ratio tasks, both in current use and in phase two of Intrinsic Aspect Ratio support.

This code should cause no real functional changes as of yet. Resolves issue #1619.