### PR TITLE
Intrinsic Aspect Ratio: Debug Follow up.

### DIFF
--- a/layout/style/nsCSSPropList.h
+++ b/layout/style/nsCSSPropList.h
@@ -470,6 +470,7 @@ CSS_PROP_DISPLAY(
     kAppearanceKTable,
     CSS_PROP_NO_OFFSET,
     eStyleAnimType_Discrete)
+#ifndef CSS_PROP_LIST_EXCLUDE_INTERNAL
 CSS_PROP_POSITION(
     aspect-ratio,
     aspect_ratio,
@@ -481,6 +482,7 @@ CSS_PROP_POSITION(
     nullptr,
     offsetof(nsStylePosition, mAspectRatio),
     eStyleAnimType_None)
+#endif // CSS_PROP_LIST_EXCLUDE_INTERNAL
 CSS_PROP_DISPLAY(
     backface-visibility,
     backface_visibility,


### PR DESCRIPTION
Newly introduced aspect-ratio property did not have CSS_PROP_LIST_EXCLUDE_INTERNAL defines. 

Causing the following assertion:

`!nsCSSProps::PropHasFlags(p, (1<<28)) (properties defined outside of #ifndef CSS_PROP_LIST_EXCLUDE_INTERNAL sections must not have the CSS_PROPERTY_INTERNAL flag), at ...layout/style/nsCSSProps.cpp:289`

This patch resolves the assertion by adding #ifndef around the aspect-ratio property.