### PR TITLE
Fix usage of a macro in a cocoa widget

### DIFF
--- a/widget/cocoa/nsDragService.mm
+++ b/widget/cocoa/nsDragService.mm
@@ -222,7 +222,7 @@ nsDragService::ConstructDragImage(nsIDOMNode* aDOMNode,
 bool
 nsDragService::IsValidType(NSString* availableType, bool allowFileURL)
 {
-  NS_OBJC_BEGIN_TRY_ABORT_BLOCK;
+  NS_OBJC_BEGIN_TRY_ABORT_BLOCK_RETURN;
 
   // Prevent exposing fileURL for non-fileURL type.
   // We need URL provided by dropped webloc file, but don't need file's URL.
@@ -234,7 +234,7 @@ nsDragService::IsValidType(NSString* availableType, bool allowFileURL)
 
   return true;
 
-  NS_OBJC_END_TRY_ABORT_BLOCK;
+  NS_OBJC_END_TRY_ABORT_BLOCK_RETURN(false);
 }
 
 NSString*

--- a/widget/cocoa/nsDragService.mm
+++ b/widget/cocoa/nsDragService.mm
@@ -234,7 +234,7 @@ nsDragService::IsValidType(NSString* availableType, bool allowFileURL)
 
   return true;
 
-  NS_OBJC_END_TRY_ABORT_BLOCK(false);
+  NS_OBJC_END_TRY_ABORT_BLOCK;
 }
 
 NSString*


### PR DESCRIPTION
The unintended usage doesn't seem to affect anything, but results in a compiler warning.