### PR TITLE
Clear the module map - Debug Followup

### DIFF
--- a/xpcom/glue/nsBaseHashtable.h
+++ b/xpcom/glue/nsBaseHashtable.h
@@ -59,6 +59,7 @@ public:
   typedef nsBaseHashtableET<KeyClass, DataType> EntryType;
 
   using nsTHashtable<EntryType>::Contains;
+  using nsTHashtable<EntryType>::IsEmpty;
 
   nsBaseHashtable() {}
   explicit nsBaseHashtable(uint32_t aInitLength)


### PR DESCRIPTION
An assertion was added to dom/script/ScriptLoader.cpp but fails to compile on debug builds due it not being included in the namespace. This adds the missing namespace so that debug builds work again.