### PR TITLE
Remove excessive VARIANT_OPACITY statements.

### DIFF
--- a/layout/inspector/inDOMUtils.cpp
+++ b/layout/inspector/inDOMUtils.cpp
@@ -842,7 +842,7 @@ PropertySupportsVariant(nsCSSPropertyID aPropertyID, uint32_t aVariant)
       case eCSSProperty_grid_row_end:
       case eCSSProperty_font_weight:
       case eCSSProperty_initial_letter:
-        supported = VARIANT_NUMBER | VARIANT_OPACITY;
+        supported = VARIANT_NUMBER;
         break;
 
       default:

--- a/layout/style/nsCSSParser.cpp
+++ b/layout/style/nsCSSParser.cpp
@@ -1299,7 +1299,7 @@ protected:
   }
   bool ParseNonNegativeNumber(nsCSSValue& aValue)
   {
-    return ParseSingleTokenNonNegativeVariant(aValue, VARIANT_NUMBER | VARIANT_OPACITY, nullptr);
+    return ParseSingleTokenNonNegativeVariant(aValue, VARIANT_NUMBER, nullptr);
   }
 
   // Helpers for some common ParseSingleTokenOneOrLargerVariant calls.
@@ -1309,7 +1309,7 @@ protected:
   }
   bool ParseOneOrLargerNumber(nsCSSValue& aValue)
   {
-    return ParseSingleTokenOneOrLargerVariant(aValue, VARIANT_NUMBER | VARIANT_OPACITY, nullptr);
+    return ParseSingleTokenOneOrLargerVariant(aValue, VARIANT_NUMBER, nullptr);
   }
 
   // http://dev.w3.org/csswg/css-values/#custom-idents
@@ -8483,7 +8483,7 @@ CSSParserImpl::ParseImageRect(nsCSSValue& aImage)
       break;
     }
 
-    static const int32_t VARIANT_SIDE = VARIANT_NUMBER | VARIANT_PERCENT | VARIANT_OPACITY;
+    static const int32_t VARIANT_SIDE = VARIANT_NUMBER | VARIANT_PERCENT;
     if (!ParseSingleTokenNonNegativeVariant(top, VARIANT_SIDE, nullptr) ||
         !ExpectSymbol(',', true) ||
         !ParseSingleTokenNonNegativeVariant(right, VARIANT_SIDE, nullptr) ||
@@ -10892,7 +10892,7 @@ CSSParserImpl::ParseWebkitGradientColorStop(nsCSSValueGradient* aGradient)
   if (mToken.mIdent.LowerCaseEqualsLiteral("color-stop")) {
     // Parse stop location, followed by comma.
     if (!ParseSingleTokenVariant(stop->mLocation,
-                                 VARIANT_NUMBER | VARIANT_PERCENT | VARIANT_OPACITY,
+                                 VARIANT_NUMBER | VARIANT_PERCENT,
                                  nullptr) ||
         !ExpectSymbol(',', true)) {
       SkipUntil(')'); // Skip to end of color-stop(...) expression.
@@ -16055,7 +16055,7 @@ static bool GetFunctionParseInformation(nsCSSKeyword aToken,
     {VARIANT_LBCALC, VARIANT_LBCALC, VARIANT_LBCALC},
     {VARIANT_ANGLE_OR_ZERO},
     {VARIANT_ANGLE_OR_ZERO, VARIANT_ANGLE_OR_ZERO},
-    {VARIANT_NUMBER|VARIANT_OPACITY},
+    {VARIANT_NUMBER},
     {VARIANT_LENGTH|VARIANT_NONNEGATIVE_DIMENSION},
     {VARIANT_LB|VARIANT_NONNEGATIVE_DIMENSION},
     {VARIANT_NUMBER, VARIANT_NUMBER},
@@ -17637,7 +17637,7 @@ CSSParserImpl::ParseScrollSnapPoints(nsCSSValue& aValue, nsCSSPropertyID aPropID
       nsCSSKeywords::LookupKeyword(mToken.mIdent) == eCSSKeyword_repeat) {
     nsCSSValue lengthValue;
     if (ParseNonNegativeVariant(lengthValue,
-                                VARIANT_LENGTH | VARIANT_PERCENT | VARIANT_OPACITY | VARIANT_CALC,
+                                VARIANT_LENGTH | VARIANT_PERCENT | VARIANT_CALC,
                                 nullptr) != CSSParseResult::Ok) {
       REPORT_UNEXPECTED(PEExpectedNonnegativeNP);
       SkipUntil(')');


### PR DESCRIPTION
I included VARIANT_OPACITY in too many places because I wanted it to be treated exactly like VARIANT_NUMBER for most purposes. This had some unintended consequences, but I've addressed it now.

Tag #1647